### PR TITLE
feat(contracts): EIP-1153 transient reentrancy guard (#18)

### DIFF
--- a/packages/contracts/src/utils/ReentrancyGuardTransient.sol
+++ b/packages/contracts/src/utils/ReentrancyGuardTransient.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Errors} from "./Errors.sol";
+
+/// @title Reentrancy guard backed by EIP-1153 transient storage
+/// @notice `nonReentrantTransient` modifier costing ~100 gas per call.
+/// @dev Compared to the storage-slot guard (e.g. OpenZeppelin's
+///      `ReentrancyGuard`):
+///        - storage version: ~2,100 gas per entry (warm SSTORE) plus a
+///          5,000-gas slot init cost on first use.
+///        - transient version: ~100 gas (TSTORE + TLOAD), no slot init,
+///          and the slot clears automatically at end-of-transaction so
+///          there is no "reset to zero on exit" SSTORE either.
+///
+///      EIP-1153 requires the Cancun fork, which Base supports and
+///      `foundry.toml` pins via `evm_version = "cancun"`.
+///
+///      Solidity 0.8.26 does not yet expose the `transient` storage
+///      keyword for state variables (added in 0.8.28); we drop to inline
+///      assembly using the canonical `_REENTRANCY_GUARD_SLOT`.
+///
+///      Slot derivation: `keccak256("PRISM.ReentrancyGuard")`. Using a
+///      named-derived slot rather than slot 0 avoids accidental aliasing
+///      with future transient state in derived contracts. The slot is a
+///      constant; transient storage is per-contract and per-transaction,
+///      so different contracts using the same constant do not collide.
+///
+///      Lifetime: the slot is scoped to the *transaction*, not the call.
+///      A nested call inside the same tx sees the busy flag set,
+///      regardless of intermediate contracts.
+///
+///      Inheritance: contracts inherit and apply the modifier on every
+///      external state-mutating entry point that could be re-entered
+///      via a PoolManager callback, hook, or token transfer hook. Pure
+///      / view functions do not need it.
+///
+///      Failure mode: a nested entry reverts with `Errors.Reentrancy()`.
+abstract contract ReentrancyGuardTransient {
+    /// @dev Transient slot identifier. `keccak256("PRISM.ReentrancyGuard")`
+    ///      computed at compile time so the slot is a pure constant.
+    bytes32 private constant _REENTRANCY_GUARD_SLOT = keccak256("PRISM.ReentrancyGuard");
+
+    /// @notice Reverts with `Errors.Reentrancy()` if a function marked
+    ///         `nonReentrantTransient` is already on the call stack
+    ///         within this transaction.
+    modifier nonReentrantTransient() {
+        bytes32 slot = _REENTRANCY_GUARD_SLOT;
+        uint256 entered;
+        assembly ("memory-safe") {
+            entered := tload(slot)
+        }
+        if (entered != 0) revert Errors.Reentrancy();
+        assembly ("memory-safe") {
+            tstore(slot, 1)
+        }
+        _;
+        assembly ("memory-safe") {
+            tstore(slot, 0)
+        }
+    }
+}

--- a/packages/contracts/test/utils/ReentrancyGuardTransient.t.sol
+++ b/packages/contracts/test/utils/ReentrancyGuardTransient.t.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {Errors} from "../../src/utils/Errors.sol";
+import {ReentrancyGuardTransient} from "../../src/utils/ReentrancyGuardTransient.sol";
+
+/// @notice Test fixture exposing two protected entry points that can
+///         optionally call back into themselves via the same external
+///         interface — exercising both single-function and cross-function
+///         reentrancy attempts.
+contract Guarded is ReentrancyGuardTransient {
+    /// @dev Reentrancy attempts route through this address; we set it
+    ///      to `address(this)` so the contract can call itself.
+    address public callback;
+
+    /// @notice Tracks whether the protected body executed at least once.
+    bool public touched;
+
+    function setCallback(address c) external {
+        callback = c;
+    }
+
+    function protectedA() external nonReentrantTransient {
+        touched = true;
+        if (callback != address(0)) {
+            // Solidity returns bubbled revert data on failure, which is
+            // what `vm.expectRevert(selector)` matches against.
+            Guarded(callback).protectedA();
+        }
+    }
+
+    function protectedB() external nonReentrantTransient {
+        if (callback != address(0)) {
+            Guarded(callback).protectedA();
+        }
+    }
+}
+
+/// @notice Behaviour tests for the EIP-1153 reentrancy guard.
+contract ReentrancyGuardTransientTest is Test {
+    Guarded internal g;
+
+    function setUp() public {
+        g = new Guarded();
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------------------
+
+    function test_nonReentrant_singleCall_succeeds() external {
+        g.protectedA();
+        assertTrue(g.touched(), "body did not execute");
+    }
+
+    function test_nonReentrant_sequentialCalls_succeed() external {
+        // Across two separate top-level calls, the transient flag has
+        // cleared between them, so the guard does not trip.
+        g.protectedA();
+        g.protectedA();
+        assertTrue(g.touched());
+    }
+
+    // -------------------------------------------------------------------------
+    // Reentrancy reverts
+    // -------------------------------------------------------------------------
+
+    function test_nonReentrant_directReentry_reverts() external {
+        g.setCallback(address(g));
+        vm.expectRevert(Errors.Reentrancy.selector);
+        g.protectedA();
+    }
+
+    /// @dev Cross-function reentrancy: `protectedB` calls into
+    ///      `protectedA`. Both are guarded by the same modifier and
+    ///      share `_entered`, so the second guard MUST trip.
+    function test_nonReentrant_crossFunctionReentry_reverts() external {
+        g.setCallback(address(g));
+        vm.expectRevert(Errors.Reentrancy.selector);
+        g.protectedB();
+    }
+
+    // -------------------------------------------------------------------------
+    // Transient slot lifecycle
+    // -------------------------------------------------------------------------
+
+    /// @dev After a successful protected call returns, `_entered` must
+    ///      be cleared so the next call in the same transaction can
+    ///      enter freely. We exercise that by chaining two top-level
+    ///      calls inside one test (= one transaction) without
+    ///      reentering, then a third that DOES reenter.
+    function test_transient_clearsBetweenSiblingCalls() external {
+        g.protectedA();
+        g.protectedA();
+        g.setCallback(address(g));
+        vm.expectRevert(Errors.Reentrancy.selector);
+        g.protectedA();
+    }
+
+    /// @dev After a reverted reentrant call, the next top-level call
+    ///      from a fresh entry must succeed: `_entered` was set to
+    ///      true mid-call, the revert unwound the storage write, and
+    ///      the transient slot resets at transaction end. Foundry
+    ///      treats every test invocation as a separate transaction
+    ///      via `vm.expectRevert` semantics, so we verify by calling
+    ///      again inside the SAME test after clearing the callback.
+    function test_transient_recoverable_afterRevert() external {
+        g.setCallback(address(g));
+        try g.protectedA() {
+            revert("expected reentrancy revert");
+        } catch (bytes memory data) {
+            // Confirm the revert was the reentrancy selector.
+            assertEq(bytes4(data), Errors.Reentrancy.selector);
+        }
+
+        // Clear the callback and try again — the guard should not
+        // remember the previous failed attempt.
+        g.setCallback(address(0));
+        g.protectedA();
+        assertTrue(g.touched());
+    }
+
+    // -------------------------------------------------------------------------
+    // Gas snapshot
+    // -------------------------------------------------------------------------
+
+    /// @dev Sanity-bound on the per-call gas cost of the modifier. The
+    ///      protected body here is a single SSTORE + a zero-address
+    ///      branch, so almost the entire cost is the modifier itself
+    ///      plus call overhead. Ceiling is generous — the goal is to
+    ///      catch a regression that swaps in a storage-slot guard.
+    function test_gas_belowStorageGuardThreshold() external {
+        uint256 before = gasleft();
+        g.protectedA();
+        uint256 used = before - gasleft();
+        // Storage-slot guards burn ~2,100 gas/call once warm; transient
+        // sits at ~100. Add a generous body + call-overhead buffer.
+        // If this trips, almost certainly the modifier was reverted to
+        // a `bool` storage slot.
+        assertLt(used, 30_000, "modifier consumed unexpectedly large gas");
+    }
+}


### PR DESCRIPTION
## Summary

`ReentrancyGuardTransient` — abstract contract exposing `nonReentrantTransient`, ~100 gas per call (vs ~2,100 for OZ's storage version). Resolves #18.

- EIP-1153 `tload` / `tstore` via inline assembly (`transient` state-variable keyword landed in solc 0.8.28; we are on 0.8.26 per ADR-001).
- Slot derived from `keccak256("PRISM.ReentrancyGuard")` to avoid aliasing with future transient state in derived contracts.
- 7 tests: single call, sequential calls, direct reentry, cross-function reentry, transient-slot clearing, recovery after reverted reentry, gas ceiling that catches a regression to a storage guard.

## Stacked on #140

This PR stacks on `contracts/17-errors` (#140) because the guard `revert`s with `Errors.Reentrancy()`. Merge #140 first, then this rebases onto `main` cleanly.

## Quality gates

- `forge build` clean
- `forge test` 7/7 pass on the new file (full suite continues to pass with #140 included)
- `forge fmt --check` clean

## Test plan

- [ ] Inline-assembly + named-derived slot acceptable for v1.0 (vs. waiting for 0.8.28's `transient` keyword)
- [ ] Slot name `keccak256("PRISM.ReentrancyGuard")` OK
- [ ] Cross-function reentry test covers a realistic V4-hook callback shape
- [ ] Gas ceiling test (30k) is the right regression net

Closes #18. Blocks #26, #27, #28, #29.