### PR TITLE
feat(contracts): IVault interface (#19)

### DIFF
--- a/packages/contracts/remappings.txt
+++ b/packages/contracts/remappings.txt
@@ -1,3 +1,5 @@
 v4-core/=lib/v4-core/src/
 v4-periphery/=lib/v4-periphery/src/
 permit2/=lib/permit2/src/
+@openzeppelin/=lib/v4-core/lib/openzeppelin-contracts/
+solmate/=lib/v4-core/lib/solmate/

--- a/packages/contracts/src/core/Vault.sol
+++ b/packages/contracts/src/core/Vault.sol
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {Currency} from "v4-core/types/Currency.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+
+import {IProtocolHook} from "../interfaces/IProtocolHook.sol";
+import {IStrategy} from "../interfaces/IStrategy.sol";
+import {IVault} from "../interfaces/IVault.sol";
+import {Errors} from "../utils/Errors.sol";
+
+/// @title PRISM Vault — multi-position LP aggregator on Uniswap V4
+/// @notice This PR (#26) wires storage layout, ERC-20 share accounting,
+///         and the constructor. The hot-path methods land in follow-ups:
+///           - deposit  → #27
+///           - withdraw → #28
+///           - rebalance → #29
+///           - views    → #30
+///         Until those land the methods revert UnknownOp; the contract
+///         compiles, tests can verify the storage shape, and downstream
+///         integrators (factory, deployer scripts) can wire against the
+///         real ABI.
+///
+/// @dev Storage layout is part of the immutable surface — moving slots
+///      after launch is a redeploy, not an upgrade (ADR-006). Slot
+///      ordering is therefore fixed:
+///        slot 0..N-1 → ERC20 base (name, symbol, _balances, _allowances, _totalSupply)
+///        slot 1     ↓ owner (mutable)
+///        slot ↓     → depositsPaused (mutable)
+///        slot ↓     → tvlCap (mutable, owner-bounded)
+///        slot ↓     → positions (Position[] mutable)
+///      The immutables (poolManager, poolKey hashed, strategy, hook,
+///      token0, token1, MIN_SHARES, MAX_POSITIONS) live in code, not
+///      storage — gas and rotation hygiene.
+///
+///      ERC-20 transfer hooks: this vault deliberately does NOT
+///      override _update / _beforeTokenTransfer. Shares are freely
+///      transferable, no transfer fees, no blocklists — composability
+///      is non-negotiable per the PRD anti-goals.
+///
+///      MIN_SHARES = 1000 burned to address(0) on first deposit
+///      mitigates the first-depositor inflation attack (PRD §13).
+contract Vault is IVault, ERC20 {
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    /// @notice First-deposit shares burned to dead address. Inflation guard.
+    uint256 public constant MIN_SHARES = 1000;
+
+    /// @notice Hard cap on positions per vault (PRD invariant 3).
+    uint256 public constant MAX_POSITIONS = 7;
+
+    /// @notice Address that receives the MIN_SHARES burn.
+    address public constant DEAD = 0x000000000000000000000000000000000000dEaD;
+
+    // -------------------------------------------------------------------------
+    // Immutables — set at construction, never updatable
+    // -------------------------------------------------------------------------
+
+    /// @notice Canonical V4 PoolManager.
+    IPoolManager public immutable poolManager;
+
+    /// @notice Strategy that computes target positions + the rebalance gate.
+    ///         Per ADR-005 implementations are pure / stateless.
+    IStrategy public immutable strategy;
+
+    /// @notice Singleton hook that handles dynamic fees + MEV observation.
+    IProtocolHook public immutable hook;
+
+    /// @notice Pool tokens, snapshot from `PoolKey` for hot-path use.
+    IERC20 public immutable token0;
+    IERC20 public immutable token1;
+
+    /// @notice Pool tickSpacing, snapshot for tick-alignment math.
+    int24 public immutable tickSpacing;
+
+    /// @notice Fee tier of the underlying pool. For PRISM this is the
+    ///         dynamic-fee sentinel `0x800000`; immutable on the vault.
+    uint24 public immutable poolFee;
+
+    // -------------------------------------------------------------------------
+    // Mutable storage
+    // -------------------------------------------------------------------------
+
+    /// @notice Multisig-controlled admin. Holds the two mutable levers
+    ///         (depositsPaused, tvlCap) per ADR-006.
+    address public owner;
+
+    /// @notice Pause flag for deposits only. Withdrawals are NEVER pausable.
+    bool public depositsPaused;
+
+    /// @notice TVL cap in token0 notional units. Enforced by deposit().
+    uint256 public tvlCap;
+
+    /// @notice Active positions. Set by `rebalance` (#29). Indexed
+    ///         in the order the strategy emits them.
+    Position[] internal _positions;
+
+    /// @notice Currency0 / currency1 slots from the pool key — kept as
+    ///         storage (not immutable) only because PoolKey is a struct
+    ///         and Solidity doesn't allow struct immutables. The values
+    ///         match `token0` / `token1` and never change post-construction.
+    PoolKey internal _poolKey;
+
+    // -------------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------------
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event DepositsPausedSet(bool paused);
+    event TVLCapSet(uint256 newCap);
+
+    // -------------------------------------------------------------------------
+    // Modifiers
+    // -------------------------------------------------------------------------
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert Errors.OnlyOwner();
+        _;
+    }
+
+    // -------------------------------------------------------------------------
+    // Construction
+    // -------------------------------------------------------------------------
+
+    constructor(
+        IPoolManager poolManager_,
+        PoolKey memory poolKey_,
+        IStrategy strategy_,
+        IProtocolHook hook_,
+        address owner_,
+        uint256 tvlCap_,
+        string memory name_,
+        string memory symbol_
+    )
+        ERC20(name_, symbol_)
+    {
+        if (address(poolManager_) == address(0)) revert Errors.ZeroAddress();
+        if (address(strategy_) == address(0)) revert Errors.ZeroAddress();
+        if (address(hook_) == address(0)) revert Errors.ZeroAddress();
+        if (owner_ == address(0)) revert Errors.ZeroAddress();
+        if (tvlCap_ == 0) revert Errors.ValueOutOfBounds(tvlCap_, type(uint256).max);
+        if (poolKey_.tickSpacing <= 0) revert Errors.InvalidTickRange(0, 0);
+
+        poolManager = poolManager_;
+        strategy = strategy_;
+        hook = hook_;
+
+        // Snapshot pool tokens. PoolKey enforces currency0 < currency1
+        // at the V4 layer; we mirror that ordering for hot-path use.
+        token0 = IERC20(_unwrap(poolKey_.currency0));
+        token1 = IERC20(_unwrap(poolKey_.currency1));
+        tickSpacing = poolKey_.tickSpacing;
+        poolFee = poolKey_.fee;
+
+        _poolKey = poolKey_;
+
+        owner = owner_;
+        tvlCap = tvlCap_;
+
+        emit OwnershipTransferred(address(0), owner_);
+        emit TVLCapSet(tvlCap_);
+    }
+
+    // -------------------------------------------------------------------------
+    // IERC20Metadata override — already provided by OZ ERC20 base
+    // -------------------------------------------------------------------------
+
+    function decimals() public pure override returns (uint8) {
+        // Vault shares are 18 decimals regardless of underlying token
+        // decimals. Keeps frontend formatting deterministic and matches
+        // the convention from ERC-4626.
+        return 18;
+    }
+
+    // -------------------------------------------------------------------------
+    // Admin (ADR-006 two-lever model)
+    // -------------------------------------------------------------------------
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert Errors.ZeroAddress();
+        emit OwnershipTransferred(owner, newOwner);
+        owner = newOwner;
+    }
+
+    function setDepositsPaused(bool paused) external onlyOwner {
+        depositsPaused = paused;
+        emit DepositsPausedSet(paused);
+    }
+
+    function setTVLCap(uint256 newCap) external onlyOwner {
+        if (newCap == 0) revert Errors.ValueOutOfBounds(newCap, type(uint256).max);
+        tvlCap = newCap;
+        emit TVLCapSet(newCap);
+    }
+
+    // -------------------------------------------------------------------------
+    // IVault method stubs — filled by #27/#28/#29/#30
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IVault
+    function deposit(
+        uint256,
+        uint256,
+        uint256,
+        uint256,
+        address
+    )
+        external
+        pure
+        override
+        returns (uint256, uint256, uint256)
+    {
+        // #27 implements deposit via PoolManager.unlock + multi-position
+        // deploy + MIN_SHARES burn on first deposit.
+        revert Errors.UnknownOp();
+    }
+
+    /// @inheritdoc IVault
+    function withdraw(uint256, uint256, uint256, address) external pure override returns (uint256, uint256) {
+        // #28 implements withdraw with proportional removal across all
+        // positions; never pausable per invariant 6.
+        revert Errors.UnknownOp();
+    }
+
+    /// @inheritdoc IVault
+    function rebalance() external pure override {
+        // #29 implements remove-all → bounded swap → redeploy.
+        revert Errors.UnknownOp();
+    }
+
+    /// @inheritdoc IVault
+    function getPositions() external view override returns (Position[] memory) {
+        return _positions;
+    }
+
+    /// @inheritdoc IVault
+    function getTotalAmounts() external pure override returns (uint256, uint256) {
+        // #30 wires the per-position amount aggregation against PoolManager
+        // state.
+        return (0, 0);
+    }
+
+    /// @inheritdoc IVault
+    function poolKey() external view override returns (PoolKey memory) {
+        return _poolKey;
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /// @dev Currency is `type Currency is address;` in v4-core.
+    function _unwrap(Currency c) private pure returns (address) {
+        return Currency.unwrap(c);
+    }
+}

--- a/packages/contracts/src/interfaces/IProtocolHook.sol
+++ b/packages/contracts/src/interfaces/IProtocolHook.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {Hooks} from "v4-core/libraries/Hooks.sol";
+
+/// @title IProtocolHook
+/// @notice PRISM's V4 hook surface — dynamic fees in `beforeSwap`, MEV
+///         observation in `afterSwap`, lightweight position-state
+///         cleanup in `afterAddLiquidity` / `afterRemoveLiquidity`, and
+///         the per-pool / per-vault read accessors used by the dApp
+///         and keeper.
+/// @dev Inherits `v4-core/IHooks` so all four V4 callbacks PRISM uses
+///      keep their canonical selectors and ABI shape — implementations
+///      override the `IHooks` methods directly. The four callbacks
+///      PRISM ENABLES are bits 6, 7, 8, 10 (`afterSwap`, `beforeSwap`,
+///      `afterRemoveLiquidity`, `afterAddLiquidity`); the deployed hook
+///      address satisfies `address & 0x3FFF == 0x05C0` per ADR-002.
+///
+///      A bug in `afterAddLiquidity` or `afterRemoveLiquidity` MUST NOT
+///      revert (ADR-002 §hard rule). Those callbacks sit on the
+///      withdraw hot path; reverting them violates invariant 6.
+///      Implementations are emit-only or pure state cleanup.
+///
+///      The hook is a singleton (ADR-002): a single deployed instance
+///      services every PRISM vault. State is sharded by `PoolId` and
+///      vault address inside the implementation.
+interface IProtocolHook is IHooks {
+    // -------------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------------
+
+    /// @notice Emitted when `beforeSwap` recomputes the dynamic fee for
+    ///         a pool.
+    /// @param poolId Indexed `PoolId` (cast to bytes32 for indexer
+    ///        ergonomics — V4's `PoolId` is `bytes32` underneath).
+    /// @param newFee Fee in pip (1e-6); written as the V4
+    ///        `OVERRIDE_FEE_FLAG`-tagged return value.
+    /// @param volatility Snapshot of the short-window EWMA used to
+    ///        compute the new fee; for dApp / analytics consumers.
+    event FeeUpdated(bytes32 indexed poolId, uint24 newFee, uint256 volatility);
+
+    /// @notice Emitted on every swap through the hook — the v1.0 MEV
+    ///         capture surface is observation-only.
+    /// @param poolId Indexed `PoolId`.
+    /// @param tick Pool tick *after* the swap.
+    /// @param sqrtPriceX96 Pool sqrt-price after the swap (Q64.96).
+    event SwapObserved(bytes32 indexed poolId, int24 tick, uint160 sqrtPriceX96);
+
+    /// @notice Emitted when v1.1 backrun execution captures MEV and
+    ///         credits the captured profit to a vault. v1.0 emits no
+    ///         MEVCaptured events (observation only); the event lives
+    ///         on the interface so v1.1 can ship without a hook
+    ///         redeploy of the EVENT topic.
+    /// @param vault Indexed vault that received the credit.
+    /// @param amount Amount captured, denominated in `isToken0 ? token0 : token1`.
+    /// @param isToken0 Which token the captured amount is denominated in.
+    event MEVCaptured(address indexed vault, uint256 amount, bool isToken0);
+
+    // -------------------------------------------------------------------------
+    // Mutators
+    // -------------------------------------------------------------------------
+
+    /// @notice Register a `Vault` against this hook so the hook can
+    ///         attribute MEV captures and per-pool state to the right
+    ///         vault.
+    /// @dev Called by `VaultFactory` immediately after vault deployment
+    ///      so the hook learns the `PoolId → vault` mapping. Reverts
+    ///      via `Errors.OnlyOwner` (or the access-controlled equivalent
+    ///      chosen by the implementation) for non-factory callers.
+    /// @param vault The vault address to register against this hook.
+    function registerVault(address vault) external;
+
+    // -------------------------------------------------------------------------
+    // Views
+    // -------------------------------------------------------------------------
+
+    /// @notice The current dynamic fee the hook will return from
+    ///         `beforeSwap` for this pool, in pip (1e-6 units; e.g.
+    ///         3_000 = 0.30%). Used by the dApp for fee display and by
+    ///         the keeper for simulation.
+    /// @param poolId The `PoolId` (V4 hash of the `PoolKey`) cast to
+    ///        bytes32.
+    /// @return fee Current dynamic fee in pip.
+    function currentFee(bytes32 poolId) external view returns (uint24 fee);
+
+    /// @notice Per-vault MEV profit ledger. v1.0 always returns
+    ///         `(0, 0)` because v1.0 only observes; v1.1 populates as
+    ///         backruns execute.
+    /// @dev Returning two amounts (token0 + token1) lets v1.1 capture
+    ///      profits in either currency depending on the backrun
+    ///      direction without changing the interface surface.
+    /// @param vault The vault to read.
+    /// @return amount0 MEV profits in token0 awaiting distribution.
+    /// @return amount1 MEV profits in token1 awaiting distribution.
+    function mevProfits(address vault) external view returns (uint256 amount0, uint256 amount1);
+
+    /// @notice The exact permissions matrix this hook implements.
+    /// @dev MUST match the bits encoded in the deployed hook address —
+    ///      `PoolManager.initialize` reverts via
+    ///      `Hooks.HookAddressNotValid` otherwise (invariant #7,
+    ///      ADR-002). PRISM hooks return:
+    ///        beforeSwap = true (bit 7)
+    ///        afterSwap = true (bit 6)
+    ///        afterAddLiquidity = true (bit 10)
+    ///        afterRemoveLiquidity = true (bit 8)
+    ///      All other flags false. Combined: `0x05C0`.
+    /// @return permissions The struct of all 14 V4 hook permission flags.
+    function getHookPermissions() external pure returns (Hooks.Permissions memory permissions);
+}

--- a/packages/contracts/src/interfaces/IStrategy.sol
+++ b/packages/contracts/src/interfaces/IStrategy.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+/// @title IStrategy
+/// @notice Pluggable rebalance-shape API. A strategy decides
+///         (a) the tick-range positions a vault should hold given the
+///         current pool tick and the vault's available assets, and
+///         (b) when the vault should rebalance into a new shape.
+/// @dev Implementations MUST satisfy the purity contract codified in
+///      ADR-005: deterministic, stateless, vault-agnostic. Concretely:
+///        - `computePositions` and `shouldRebalance` are `view` and
+///          MUST NOT read mutable storage on the strategy or any other
+///          contract.
+///        - Repeated calls with identical inputs MUST return identical
+///          outputs. No `block.*`, `tx.origin`, oracle reads, or vault
+///          storage reads.
+///        - `block.timestamp` is permitted only inside `shouldRebalance`
+///          and only as an input to the 24h liveness fallback.
+///        - The strategy contract MUST NOT contain SSTORE in its
+///          runtime bytecode (immutables and constants only). Enforced
+///          by CI bytecode scan.
+///
+///      The vault is the trust boundary. After every call to
+///      `computePositions`, the vault re-checks invariants (#2 weight
+///      sum == 10_000, #3 length <= MAX_POSITIONS) and reverts via
+///      `Errors.WeightsDoNotSum` / `Errors.MaxPositionsExceeded` if the
+///      strategy returns malformed output.
+interface IStrategy {
+    /// @notice One target position the strategy wants the vault to hold.
+    /// @param tickLower Lower tick — MUST be aligned to the pool's
+    ///        `tickSpacing` and strictly less than `tickUpper`.
+    /// @param tickUpper Upper tick — MUST be aligned and strictly greater
+    ///        than `tickLower`.
+    /// @param weight Share of total vault liquidity assigned to this
+    ///        position, in basis points. Σ `weight` over all returned
+    ///        positions MUST equal exactly 10_000 (invariant #2). Any
+    ///        rounding remainder must be absorbed by the strategy
+    ///        before returning.
+    struct TargetPosition {
+        int24 tickLower;
+        int24 tickUpper;
+        uint256 weight;
+    }
+
+    /// @notice Compute the target liquidity shape given the current pool
+    ///         tick, the pool's tick spacing, and the vault's available
+    ///         token0 / token1.
+    /// @dev Pure function: deterministic, reads no mutable state. The
+    ///      vault calls this from inside its `unlockCallback` (per
+    ///      ADR-004) so the function MUST be cheap — `BellStrategy`
+    ///      sits at ~50k gas for N=7.
+    ///
+    ///      Returns no more than `MAX_POSITIONS` (= 30) positions; the
+    ///      vault enforces the cap independently. Returning more is
+    ///      not undefined — it is rejected with
+    ///      `Errors.MaxPositionsExceeded`.
+    ///
+    ///      `currentTick` and `tickSpacing` come from
+    ///      `IPoolManager.getSlot0` / `PoolKey.tickSpacing`. `amount0`
+    ///      and `amount1` are the vault's totals at the moment of the
+    ///      call. The strategy treats these as opaque numbers; provenance
+    ///      is the vault's concern (ADR-005 §vault-agnosticism).
+    /// @param currentTick The pool's current tick.
+    /// @param tickSpacing The pool's tick spacing.
+    /// @param amount0 Vault's total token0 (idle + position-equivalent).
+    /// @param amount1 Vault's total token1 (idle + position-equivalent).
+    /// @return positions The target tick-range positions and their weights.
+    function computePositions(
+        int24 currentTick,
+        int24 tickSpacing,
+        uint256 amount0,
+        uint256 amount1
+    )
+        external
+        view
+        returns (TargetPosition[] memory positions);
+
+    /// @notice Decide whether the vault should rebalance now.
+    /// @dev `view`; called by the vault and off-chain by the keeper as a
+    ///      simulation gate before submission. Implementations typically
+    ///      return true when:
+    ///        - tick has drifted by more than the strategy's threshold,
+    ///          OR
+    ///        - more than the strategy's `timeFallback` seconds have
+    ///          elapsed since the last rebalance (24h liveness floor).
+    ///
+    ///      `block.timestamp` MAY be read here, and ONLY here within the
+    ///      strategy, exclusively for the time-fallback comparison.
+    ///      No other implicit input (oracle, vault state, etc.).
+    /// @param currentTick Pool's current tick from `getSlot0`.
+    /// @param lastRebalanceTick Tick at the most recent rebalance (vault
+    ///        bookkeeping).
+    /// @param lastRebalanceTimestamp `block.timestamp` of the most recent
+    ///        rebalance (vault bookkeeping).
+    /// @return rebalance Whether the vault should rebalance.
+    function shouldRebalance(
+        int24 currentTick,
+        int24 lastRebalanceTick,
+        uint256 lastRebalanceTimestamp
+    )
+        external
+        view
+        returns (bool rebalance);
+}

--- a/packages/contracts/src/interfaces/IVault.sol
+++ b/packages/contracts/src/interfaces/IVault.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+
+/// @title IVault
+/// @notice The PRISM vault interface — a multi-position LP aggregator on top
+///         of a single Uniswap V4 pool. Users deposit a pair of tokens, the
+///         vault refracts that liquidity into N tick-range positions chosen
+///         by an `IStrategy`, and ERC-20 shares track each user's claim.
+/// @dev Defined ahead of `Vault.sol` (#26) so mocks, tests, and frontend
+///      ABIs compile against a single signature surface. Implementations
+///      MUST reuse the function and event signatures verbatim — third
+///      parties (indexers, the keeper, the dApp) bind to selectors and
+///      topic hashes derived here.
+///
+///      Behavioural contracts (enforced by implementation, not by the
+///      interface):
+///        - `deposit` reverts via `Errors.DepositsPaused` when paused;
+///          `withdraw` is **never** pausable (PRD invariant 6 + ADR-006).
+///        - `rebalance` is permissionless and reverts via
+///          `Errors.RebalanceNotNeeded` when the strategy's gate is false.
+///        - All state-mutating entry points are `nonReentrantTransient`
+///          (ADR-004) and run inside one `PoolManager.unlock`.
+///        - `getTotalAmounts` and `getPositions` are `view` and may be
+///          called freely by frontends and the keeper.
+///
+///      Slippage: callers MUST pass non-zero `amount0Min` / `amount1Min`
+///      on deposit and withdraw. Implementations revert with
+///      `Errors.SlippageExceeded` on violation.
+interface IVault is IERC20 {
+    // -------------------------------------------------------------------------
+    // Types
+    // -------------------------------------------------------------------------
+
+    /// @notice One tick-range position held by the vault.
+    /// @dev Position liquidity is owned by the vault inside the
+    ///      PoolManager singleton — `liquidity` here is a snapshot for
+    ///      view consumers. Authoritative liquidity lives in
+    ///      PoolManager state.
+    /// @param tickLower Lower tick (must be aligned to pool tickSpacing).
+    /// @param tickUpper Upper tick (strictly greater than `tickLower`).
+    /// @param liquidity V4 liquidity units assigned to this position.
+    struct Position {
+        int24 tickLower;
+        int24 tickUpper;
+        uint128 liquidity;
+    }
+
+    // -------------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------------
+
+    /// @notice Emitted on every successful `deposit` after settlement.
+    /// @param user Recipient of the minted shares (`to` arg).
+    /// @param amount0 Token0 actually consumed (≤ `amount0Desired`).
+    /// @param amount1 Token1 actually consumed (≤ `amount1Desired`).
+    /// @param shares Shares minted to `user`.
+    event Deposit(address indexed user, uint256 amount0, uint256 amount1, uint256 shares);
+
+    /// @notice Emitted on every successful `withdraw` after settlement.
+    /// @param user Recipient of the withdrawn tokens (`to` arg).
+    /// @param amount0 Token0 transferred to `to`.
+    /// @param amount1 Token1 transferred to `to`.
+    /// @param shares Shares burned from the caller.
+    event Withdraw(address indexed user, uint256 amount0, uint256 amount1, uint256 shares);
+
+    /// @notice Emitted when the vault completes a rebalance.
+    /// @param tick Current pool tick at the moment positions were redeployed.
+    /// @param nPositions Number of `TargetPosition`s deployed by the strategy.
+    /// @param gasUsed Approximate gas consumed by the rebalance call body
+    ///        (recorded for the keeper to size its gas-price ceiling).
+    event Rebalanced(int24 tick, uint256 nPositions, uint256 gasUsed);
+
+    /// @notice Emitted when the vault collects accrued LP fees during
+    ///         deposit / withdraw / rebalance.
+    /// @param fees0 Token0 fees collected this op.
+    /// @param fees1 Token1 fees collected this op.
+    event FeesCollected(uint256 fees0, uint256 fees1);
+
+    // -------------------------------------------------------------------------
+    // Mutators
+    // -------------------------------------------------------------------------
+
+    /// @notice Deposit `amount0Desired` token0 + `amount1Desired` token1 in
+    ///         exchange for ERC-20 shares of the vault.
+    /// @dev Reverts with:
+    ///        - `Errors.DepositsPaused` when paused (per ADR-006).
+    ///        - `Errors.SlippageExceeded` when realised amounts fall
+    ///          below the user-supplied minimums.
+    ///        - `Errors.TVLCapExceeded` when the deposit would push
+    ///          notional above the per-vault cap.
+    ///        - `Errors.ZeroShares` when this is the first deposit and
+    ///          the share count would land below `MIN_SHARES`.
+    ///      Token transfers happen inside one `PoolManager.unlock`
+    ///      callback per ADR-004 — the caller MUST `approve` both
+    ///      tokens to the vault prior to calling.
+    /// @param amount0Desired Maximum token0 the caller is willing to spend.
+    /// @param amount1Desired Maximum token1 the caller is willing to spend.
+    /// @param amount0Min Lower bound on token0 actually consumed.
+    /// @param amount1Min Lower bound on token1 actually consumed.
+    /// @param to Recipient of the minted shares.
+    /// @return shares Shares minted to `to`.
+    /// @return amount0 Token0 consumed (= idle deposit + flash-accounted spend).
+    /// @return amount1 Token1 consumed.
+    function deposit(
+        uint256 amount0Desired,
+        uint256 amount1Desired,
+        uint256 amount0Min,
+        uint256 amount1Min,
+        address to
+    )
+        external
+        returns (uint256 shares, uint256 amount0, uint256 amount1);
+
+    /// @notice Burn `shares` and receive a proportional slice of every
+    ///         position the vault holds, plus a proportional slice of
+    ///         any idle balances.
+    /// @dev Always callable while the caller holds shares — invariant 6
+    ///      (withdrawals never pausable). Reverts with:
+    ///        - `Errors.InvalidShareAmount` for zero or > balance.
+    ///        - `Errors.SlippageExceeded` when realised amounts fall
+    ///          below the user-supplied minimums.
+    /// @param shares Share count to burn (must be > 0 and ≤ caller's balance).
+    /// @param amount0Min Lower bound on token0 transferred out.
+    /// @param amount1Min Lower bound on token1 transferred out.
+    /// @param to Recipient of the underlying token transfers.
+    /// @return amount0 Token0 transferred to `to`.
+    /// @return amount1 Token1 transferred to `to`.
+    function withdraw(
+        uint256 shares,
+        uint256 amount0Min,
+        uint256 amount1Min,
+        address to
+    )
+        external
+        returns (uint256 amount0, uint256 amount1);
+
+    /// @notice Permissionless rebalance trigger.
+    /// @dev Reverts with `Errors.RebalanceNotNeeded` when
+    ///      `IStrategy.shouldRebalance` returns false. On success the
+    ///      vault removes all current positions, performs an optional
+    ///      internal swap (slippage-bounded; per ADR-004), and deploys
+    ///      the new `TargetPosition[]` returned by
+    ///      `IStrategy.computePositions`, all inside one
+    ///      `PoolManager.unlock`. Emits `Rebalanced`.
+    function rebalance() external;
+
+    // -------------------------------------------------------------------------
+    // Views
+    // -------------------------------------------------------------------------
+
+    /// @notice Snapshot of the vault's currently deployed positions.
+    /// @dev Order matches `IStrategy.computePositions` output from the
+    ///      most recent rebalance. Empty array between deployment and
+    ///      first deposit.
+    /// @return positions Vault-held tick-range positions.
+    function getPositions() external view returns (Position[] memory positions);
+
+    /// @notice Total underlying assets the vault represents — idle
+    ///         balances plus the token-equivalent of every position's
+    ///         in-range liquidity at the current pool sqrt-price.
+    /// @dev Used for share-price computation and for the TVL cap check.
+    ///      Returns the same numbers the next deposit / withdraw would
+    ///      use as denominators.
+    /// @return total0 Token0-equivalent of all vault assets.
+    /// @return total1 Token1-equivalent of all vault assets.
+    function getTotalAmounts() external view returns (uint256 total0, uint256 total1);
+
+    /// @notice Pool this vault provides liquidity to.
+    /// @dev Returned by value — `PoolKey` is a struct, not a hash. The
+    ///      hook field is the singleton `ProtocolHook` address per
+    ///      ADR-002.
+    /// @return key The pool key (currency0, currency1, fee=DYNAMIC,
+    ///         tickSpacing, hooks=PROTOCOL_HOOK).
+    function poolKey() external view returns (PoolKey memory key);
+}

--- a/packages/contracts/src/utils/Errors.sol
+++ b/packages/contracts/src/utils/Errors.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+/// @title PRISM error library
+/// @notice Centralised custom errors for every PRISM contract.
+/// @dev Custom errors emit a 4-byte selector + ABI-encoded args (~200 gas)
+///      versus 2,000+ gas for revert strings. All state-mutating PRISM
+///      contracts revert through this library and never with strings.
+///
+///      Errors are grouped by domain (access control, vault, strategy,
+///      hook, oracle, callback, generic). Adding a new error requires
+///      updating this library; downstream contracts import the library
+///      and call e.g. `revert Errors.SlippageExceeded(...);`.
+///
+///      Selector stability matters — third parties index reverts by
+///      selector. The selector regression test in
+///      `test/utils/Errors.t.sol` snapshots every selector. Changing an
+///      error's signature is a breaking change.
+library Errors {
+    // -------------------------------------------------------------------------
+    // Access control
+    // -------------------------------------------------------------------------
+
+    /// @notice Caller is not the contract owner.
+    error OnlyOwner();
+
+    /// @notice Caller is not the configured keeper.
+    error OnlyKeeper();
+
+    /// @notice Caller is not the canonical Uniswap V4 PoolManager.
+    /// @dev Guards every IHooks callback and every IUnlockCallback entry.
+    error OnlyPoolManager();
+
+    /// @notice Constructor or setter received the zero address where a
+    ///         non-zero address is required.
+    error ZeroAddress();
+
+    // -------------------------------------------------------------------------
+    // Vault — deposit / withdraw / shares
+    // -------------------------------------------------------------------------
+
+    /// @notice Realised output of a deposit or withdraw violated the
+    ///         user-supplied minimum.
+    /// @param actual The smaller of the two amounts that fell below its floor.
+    /// @param min The corresponding floor that was violated.
+    error SlippageExceeded(uint256 actual, uint256 min);
+
+    /// @notice Deposit would push vault TVL above the configured cap.
+    /// @param proposed Total vault notional (in token0 units) after the deposit.
+    /// @param cap Current TVL cap.
+    error TVLCapExceeded(uint256 proposed, uint256 cap);
+
+    /// @notice `deposit` invoked while deposits are paused by the multisig.
+    /// @dev Withdraws and rebalances are unaffected — invariant 6.
+    error DepositsPaused();
+
+    /// @notice First-depositor inflation guard: the deposit would mint
+    ///         fewer than `MIN_SHARES` shares, which would let the
+    ///         depositor capture `MIN_SHARES`-worth of donations from
+    ///         later depositors. See ADR-006 / PRD §13.
+    error ZeroShares();
+
+    /// @notice Withdraw asked for an invalid (zero or > balance) share count.
+    error InvalidShareAmount();
+
+    // -------------------------------------------------------------------------
+    // Strategy
+    // -------------------------------------------------------------------------
+
+    /// @notice `IStrategy.computePositions` returned weights whose sum is
+    ///         not exactly 10_000 basis points (invariant #2).
+    /// @param actual The actual weight sum returned by the strategy.
+    error WeightsDoNotSum(uint256 actual);
+
+    /// @notice Strategy returned more positions than the vault's
+    ///         `MAX_POSITIONS` cap allows (invariant #3).
+    /// @param requested The number of positions returned by the strategy.
+    error MaxPositionsExceeded(uint256 requested);
+
+    /// @notice Strategy or caller supplied a tick range with `lower >= upper`
+    ///         or a tick that is not aligned to `tickSpacing`.
+    error InvalidTickRange(int24 lower, int24 upper);
+
+    /// @notice `Vault.rebalance` invoked when `IStrategy.shouldRebalance`
+    ///         returns false. Permissionless callers must wait for the
+    ///         drift threshold or 24h fallback.
+    error RebalanceNotNeeded();
+
+    // -------------------------------------------------------------------------
+    // Hook — V4 permission + lifecycle
+    // -------------------------------------------------------------------------
+
+    /// @notice Deployed hook address bits do not match
+    ///         `getHookPermissions()`. Caught at deploy / pool-init time.
+    /// @param expected The permission bits required by the hook bytecode.
+    /// @param actual The bits actually encoded in the deployed address.
+    error HookNotPermissioned(uint160 expected, uint160 actual);
+
+    // -------------------------------------------------------------------------
+    // Oracle
+    // -------------------------------------------------------------------------
+
+    /// @notice Oracle round is older than `STALENESS` (1h on mainnet).
+    ///         Hook treats this as `healthy = false` rather than
+    ///         reverting on the swap path (ADR-003).
+    /// @param updatedAt The `updatedAt` timestamp of the stale round.
+    error OracleStale(uint256 updatedAt);
+
+    /// @notice Pool sqrt-price has drifted further from the oracle
+    ///         reference than the configured deviation threshold.
+    ///         v1.0 hook pauses MEV capture; v1.1 may revert backruns
+    ///         that would execute outside the threshold.
+    /// @param deviation Absolute deviation in basis points (10_000 = 100%).
+    error OracleDeviation(uint256 deviation);
+
+    // -------------------------------------------------------------------------
+    // Flash-accounting callback (ADR-004)
+    // -------------------------------------------------------------------------
+
+    /// @notice `unlockCallback` was invoked with a `CallbackData.op` value
+    ///         outside the supported `Op` enum.
+    error UnknownOp();
+
+    /// @notice Currency delta did not settle to zero before
+    ///         `unlockCallback` returned (invariant #4). Bug, not user
+    ///         error — surfaces a missing `take` / `settle` pair.
+    error DeltaUnsettled();
+
+    /// @notice Transient reentrancy guard tripped: a second nested
+    ///         entry into a `nonReentrantTransient` function was
+    ///         attempted in the same transaction.
+    error Reentrancy();
+
+    // -------------------------------------------------------------------------
+    // Generic
+    // -------------------------------------------------------------------------
+
+    /// @notice An arithmetic computation produced a value outside the
+    ///         caller's accepted range. Reserved for math helpers that
+    ///         do not have a more specific error already.
+    error MathOverflow();
+
+    /// @notice A value parameter (typically a basis-point or fee value)
+    ///         exceeded the contract's allowed bound.
+    /// @param value The offending value.
+    /// @param max The contract's documented maximum.
+    error ValueOutOfBounds(uint256 value, uint256 max);
+}

--- a/packages/contracts/test/core/Vault.t.sol
+++ b/packages/contracts/test/core/Vault.t.sol
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {Currency} from "v4-core/types/Currency.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+
+import {Vault} from "../../src/core/Vault.sol";
+import {IProtocolHook} from "../../src/interfaces/IProtocolHook.sol";
+import {IStrategy} from "../../src/interfaces/IStrategy.sol";
+import {Errors} from "../../src/utils/Errors.sol";
+
+contract VaultStorageTest is Test {
+    address constant POOL_MANAGER = address(0xCa11);
+    address constant STRATEGY = address(0x5747);
+    address constant HOOK = address(0xB00C);
+    address constant TOKEN0 = address(0x0001);
+    address constant TOKEN1 = address(0x0002);
+    address constant OWNER = address(0xACE);
+
+    uint256 constant TVL_CAP = 1_000_000e18;
+
+    Vault vault;
+
+    function setUp() public {
+        PoolKey memory key = _key();
+        vault = new Vault(
+            IPoolManager(POOL_MANAGER),
+            key,
+            IStrategy(STRATEGY),
+            IProtocolHook(HOOK),
+            OWNER,
+            TVL_CAP,
+            "PRISM Vault WETH/USDC",
+            "pWETHUSDC"
+        );
+    }
+
+    function _key() internal pure returns (PoolKey memory) {
+        return PoolKey({
+            currency0: Currency.wrap(TOKEN0),
+            currency1: Currency.wrap(TOKEN1),
+            fee: 0x800000, // dynamic-fee sentinel
+            tickSpacing: 60,
+            hooks: IHooks(HOOK)
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Construction
+    // -------------------------------------------------------------------------
+
+    function test_immutables_pinnedAtConstruction() public view {
+        assertEq(address(vault.poolManager()), POOL_MANAGER);
+        assertEq(address(vault.strategy()), STRATEGY);
+        assertEq(address(vault.hook()), HOOK);
+        assertEq(address(vault.token0()), TOKEN0);
+        assertEq(address(vault.token1()), TOKEN1);
+        assertEq(vault.tickSpacing(), 60);
+        assertEq(vault.poolFee(), 0x800000);
+    }
+
+    function test_storage_initialState() public view {
+        assertEq(vault.owner(), OWNER);
+        assertEq(vault.depositsPaused(), false);
+        assertEq(vault.tvlCap(), TVL_CAP);
+        assertEq(vault.totalSupply(), 0);
+    }
+
+    function test_metadata() public view {
+        assertEq(vault.name(), "PRISM Vault WETH/USDC");
+        assertEq(vault.symbol(), "pWETHUSDC");
+        assertEq(vault.decimals(), 18);
+    }
+
+    function test_constants() public view {
+        assertEq(vault.MIN_SHARES(), 1000);
+        assertEq(vault.MAX_POSITIONS(), 7);
+        assertEq(vault.DEAD(), 0x000000000000000000000000000000000000dEaD);
+    }
+
+    function test_poolKey_returnsConstructedKey() public view {
+        PoolKey memory k = vault.poolKey();
+        assertEq(Currency.unwrap(k.currency0), TOKEN0);
+        assertEq(Currency.unwrap(k.currency1), TOKEN1);
+        assertEq(k.fee, 0x800000);
+        assertEq(k.tickSpacing, 60);
+        assertEq(address(k.hooks), HOOK);
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor reverts
+    // -------------------------------------------------------------------------
+
+    function test_constructor_revertsOnZeroPoolManager() public {
+        PoolKey memory key = _key();
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new Vault(IPoolManager(address(0)), key, IStrategy(STRATEGY), IProtocolHook(HOOK), OWNER, TVL_CAP, "n", "s");
+    }
+
+    function test_constructor_revertsOnZeroStrategy() public {
+        PoolKey memory key = _key();
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new Vault(IPoolManager(POOL_MANAGER), key, IStrategy(address(0)), IProtocolHook(HOOK), OWNER, TVL_CAP, "n", "s");
+    }
+
+    function test_constructor_revertsOnZeroHook() public {
+        PoolKey memory key = _key();
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new Vault(
+            IPoolManager(POOL_MANAGER), key, IStrategy(STRATEGY), IProtocolHook(address(0)), OWNER, TVL_CAP, "n", "s"
+        );
+    }
+
+    function test_constructor_revertsOnZeroOwner() public {
+        PoolKey memory key = _key();
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new Vault(
+            IPoolManager(POOL_MANAGER), key, IStrategy(STRATEGY), IProtocolHook(HOOK), address(0), TVL_CAP, "n", "s"
+        );
+    }
+
+    function test_constructor_revertsOnZeroTvlCap() public {
+        PoolKey memory key = _key();
+        vm.expectRevert();
+        new Vault(IPoolManager(POOL_MANAGER), key, IStrategy(STRATEGY), IProtocolHook(HOOK), OWNER, 0, "n", "s");
+    }
+
+    // -------------------------------------------------------------------------
+    // Admin levers
+    // -------------------------------------------------------------------------
+
+    function test_setDepositsPaused_onlyOwner() public {
+        vm.prank(address(0x1234));
+        vm.expectRevert(Errors.OnlyOwner.selector);
+        vault.setDepositsPaused(true);
+    }
+
+    function test_setDepositsPaused_owner() public {
+        vm.prank(OWNER);
+        vault.setDepositsPaused(true);
+        assertTrue(vault.depositsPaused());
+
+        vm.prank(OWNER);
+        vault.setDepositsPaused(false);
+        assertFalse(vault.depositsPaused());
+    }
+
+    function test_setTVLCap_onlyOwner() public {
+        vm.prank(address(0x1234));
+        vm.expectRevert(Errors.OnlyOwner.selector);
+        vault.setTVLCap(2_000_000e18);
+    }
+
+    function test_setTVLCap_owner() public {
+        vm.prank(OWNER);
+        vault.setTVLCap(2_000_000e18);
+        assertEq(vault.tvlCap(), 2_000_000e18);
+    }
+
+    function test_setTVLCap_revertsOnZero() public {
+        vm.prank(OWNER);
+        vm.expectRevert();
+        vault.setTVLCap(0);
+    }
+
+    function test_transferOwnership_onlyOwner() public {
+        vm.prank(address(0x1234));
+        vm.expectRevert(Errors.OnlyOwner.selector);
+        vault.transferOwnership(address(0x5678));
+    }
+
+    function test_transferOwnership_owner() public {
+        vm.prank(OWNER);
+        vault.transferOwnership(address(0x5678));
+        assertEq(vault.owner(), address(0x5678));
+    }
+
+    function test_transferOwnership_revertsOnZero() public {
+        vm.prank(OWNER);
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        vault.transferOwnership(address(0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Stub method reverts (replaced by #27/#28/#29)
+    // -------------------------------------------------------------------------
+
+    function test_deposit_stubReverts() public {
+        vm.expectRevert(Errors.UnknownOp.selector);
+        vault.deposit(1e18, 1e18, 0, 0, address(this));
+    }
+
+    function test_withdraw_stubReverts() public {
+        vm.expectRevert(Errors.UnknownOp.selector);
+        vault.withdraw(1, 0, 0, address(this));
+    }
+
+    function test_rebalance_stubReverts() public {
+        vm.expectRevert(Errors.UnknownOp.selector);
+        vault.rebalance();
+    }
+
+    function test_views_stubsAreSafe() public view {
+        // getPositions returns empty array on a fresh vault.
+        Vault.Position[] memory ps = vault.getPositions();
+        assertEq(ps.length, 0);
+
+        // getTotalAmounts returns 0/0 stub.
+        (uint256 a, uint256 b) = vault.getTotalAmounts();
+        assertEq(a, 0);
+        assertEq(b, 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // ERC-20 base behaviour (transfers, allowances)
+    // -------------------------------------------------------------------------
+
+    function test_erc20_initialBalances() public view {
+        assertEq(vault.balanceOf(OWNER), 0);
+        assertEq(vault.balanceOf(address(this)), 0);
+    }
+
+    function test_erc20_transfer_zeroBalance() public {
+        vm.expectRevert();
+        vault.transfer(address(0x9999), 1);
+    }
+}

--- a/packages/contracts/test/interfaces/IProtocolHook.t.sol
+++ b/packages/contracts/test/interfaces/IProtocolHook.t.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {Hooks} from "v4-core/libraries/Hooks.sol";
+
+import {IProtocolHook} from "../../src/interfaces/IProtocolHook.sol";
+
+/// @notice Compile-time + selector-stability tests for `IProtocolHook`.
+///
+/// The behavioural tests on the hook implementation (#34, #35, #36) cover
+/// real callback semantics — this file only verifies the interface
+/// surface: signatures match V4's IHooks, the additional read accessors
+/// have stable selectors, and the events have stable topics.
+contract IProtocolHookTest is Test {
+    // -------------------------------------------------------------------------
+    // V4 IHooks inheritance
+    //
+    // Solidity does not expose inherited interface members through
+    // `IProtocolHook.<member>.selector` — the inheritance is enforced
+    // at the ABI level only. The compile-time `IHooks h = IProtocolHook(...)`
+    // assignment proves the IS-A relationship; v4-core owns the
+    // selector-stability tests for IHooks itself.
+    // -------------------------------------------------------------------------
+
+    function test_inherits_IHooks_isa() external pure {
+        IProtocolHook ph = IProtocolHook(address(0));
+        IHooks h = IHooks(ph);
+        assertEq(address(h), address(ph));
+    }
+
+    function test_v4_IHooks_callback_selectors_stable() external pure {
+        // Pin the four selectors PRISM relies on. If v4-core ever changes
+        // its IHooks shape, this test trips before users hit the bug.
+        assertEq(
+            IHooks.beforeSwap.selector,
+            bytes4(keccak256("beforeSwap(address,(address,address,uint24,int24,address),(bool,int256,uint160),bytes)"))
+        );
+        assertEq(
+            IHooks.afterSwap.selector,
+            bytes4(
+                keccak256(
+                    "afterSwap(address,(address,address,uint24,int24,address),(bool,int256,uint160),int256,bytes)"
+                )
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // PRISM-specific surface
+    // -------------------------------------------------------------------------
+
+    function test_selector_registerVault() external pure {
+        assertEq(IProtocolHook.registerVault.selector, bytes4(keccak256("registerVault(address)")));
+    }
+
+    function test_selector_currentFee() external pure {
+        assertEq(IProtocolHook.currentFee.selector, bytes4(keccak256("currentFee(bytes32)")));
+    }
+
+    function test_selector_mevProfits() external pure {
+        assertEq(IProtocolHook.mevProfits.selector, bytes4(keccak256("mevProfits(address)")));
+    }
+
+    function test_selector_getHookPermissions() external pure {
+        assertEq(IProtocolHook.getHookPermissions.selector, bytes4(keccak256("getHookPermissions()")));
+    }
+
+    // -------------------------------------------------------------------------
+    // Event topics
+    // -------------------------------------------------------------------------
+
+    function test_event_FeeUpdated_topic() external pure {
+        assertEq(IProtocolHook.FeeUpdated.selector, keccak256("FeeUpdated(bytes32,uint24,uint256)"));
+    }
+
+    function test_event_SwapObserved_topic() external pure {
+        assertEq(IProtocolHook.SwapObserved.selector, keccak256("SwapObserved(bytes32,int24,uint160)"));
+    }
+
+    function test_event_MEVCaptured_topic() external pure {
+        assertEq(IProtocolHook.MEVCaptured.selector, keccak256("MEVCaptured(address,uint256,bool)"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Permissions matrix — PRISM enables exactly bits 6, 7, 8, 10 (= 0x05C0)
+    //
+    // The permission *value* is ultimately produced by an implementation,
+    // but the interface guarantees the return type is `Hooks.Permissions`
+    // so call sites can construct the canonical PRISM permission set.
+    // -------------------------------------------------------------------------
+
+    function test_canonicalPRISMPermissions_compileGate() external pure {
+        Hooks.Permissions memory p = Hooks.Permissions({
+            beforeInitialize: false,
+            afterInitialize: false,
+            beforeAddLiquidity: false,
+            afterAddLiquidity: true, // bit 10 — 0x0400
+            beforeRemoveLiquidity: false,
+            afterRemoveLiquidity: true, // bit 8 — 0x0100
+            beforeSwap: true, // bit 7 — 0x0080
+            afterSwap: true, // bit 6 — 0x0040
+            beforeDonate: false,
+            afterDonate: false,
+            beforeSwapReturnDelta: false,
+            afterSwapReturnDelta: false,
+            afterAddLiquidityReturnDelta: false,
+            afterRemoveLiquidityReturnDelta: false
+        });
+        // Combined bits: 0x0400 + 0x0100 + 0x0080 + 0x0040 = 0x05C0.
+        assertTrue(p.beforeSwap && p.afterSwap && p.afterAddLiquidity && p.afterRemoveLiquidity);
+        assertFalse(p.beforeInitialize || p.afterInitialize);
+    }
+}

--- a/packages/contracts/test/interfaces/IStrategy.t.sol
+++ b/packages/contracts/test/interfaces/IStrategy.t.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IStrategy} from "../../src/interfaces/IStrategy.sol";
+
+/// @notice Compile-time + selector-stability tests for `IStrategy`.
+contract IStrategyMock is IStrategy {
+    /// @dev Returns one whole-pool position to exercise the round-trip.
+    function computePositions(
+        int24, /* currentTick */
+        int24, /* tickSpacing */
+        uint256, /* amount0 */
+        uint256 /* amount1 */
+    )
+        external
+        pure
+        returns (TargetPosition[] memory positions)
+    {
+        positions = new TargetPosition[](1);
+        positions[0] = TargetPosition({tickLower: -887_220, tickUpper: 887_220, weight: 10_000});
+    }
+
+    function shouldRebalance(
+        int24, /* currentTick */
+        int24, /* lastRebalanceTick */
+        uint256 /* lastRebalanceTimestamp */
+    )
+        external
+        pure
+        returns (bool)
+    {
+        return false;
+    }
+}
+
+contract IStrategyTest is Test {
+    // -------------------------------------------------------------------------
+    // Mock — implementable end-to-end
+    // -------------------------------------------------------------------------
+
+    function test_mock_returnsValidPosition() external {
+        IStrategyMock m = new IStrategyMock();
+        IStrategy.TargetPosition[] memory ps = m.computePositions(0, 60, 1 ether, 1 ether);
+
+        assertEq(ps.length, 1);
+        assertEq(int256(ps[0].tickLower), int256(-887_220));
+        assertEq(int256(ps[0].tickUpper), int256(887_220));
+        assertEq(ps[0].weight, 10_000);
+
+        assertEq(m.shouldRebalance(0, 0, block.timestamp), false);
+    }
+
+    // -------------------------------------------------------------------------
+    // Selector snapshots
+    // -------------------------------------------------------------------------
+
+    function test_selector_computePositions() external pure {
+        assertEq(
+            IStrategy.computePositions.selector, bytes4(keccak256("computePositions(int24,int24,uint256,uint256)"))
+        );
+    }
+
+    function test_selector_shouldRebalance() external pure {
+        assertEq(IStrategy.shouldRebalance.selector, bytes4(keccak256("shouldRebalance(int24,int24,uint256)")));
+    }
+
+    // -------------------------------------------------------------------------
+    // Invariant #2 — strategies that follow the contract sum to 10_000.
+    //                Verified here against the mock; production strategies
+    //                (BellStrategy, etc.) get their own invariant fuzz.
+    // -------------------------------------------------------------------------
+
+    function test_invariant_weightSum_mock(int24 tick, int24 spacing, uint256 a0, uint256 a1) external {
+        // Mock returns a single full-range position with weight 10_000;
+        // any inputs should preserve the sum.
+        IStrategyMock m = new IStrategyMock();
+        IStrategy.TargetPosition[] memory ps = m.computePositions(tick, spacing, a0, a1);
+        uint256 sum;
+        for (uint256 i; i < ps.length; ++i) {
+            sum += ps[i].weight;
+        }
+        assertEq(sum, 10_000);
+    }
+}

--- a/packages/contracts/test/interfaces/IVault.t.sol
+++ b/packages/contracts/test/interfaces/IVault.t.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {Currency} from "v4-core/types/Currency.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+
+import {IVault} from "../../src/interfaces/IVault.sol";
+
+/// @notice Compile-time + selector-stability tests for `IVault`.
+/// @dev Interfaces have no runtime behaviour to exercise. The tests:
+///      1. Force the interface to compile under the Foundry pipeline by
+///         instantiating a mock that fully implements it.
+///      2. Snapshot every external function selector and event topic so
+///         downstream consumers (frontend ABI exporter, keeper, indexer)
+///         catch accidental signature drift in CI.
+contract IVaultMock is IVault {
+    PoolKey internal _poolKey;
+
+    function setPoolKey(PoolKey memory k) external {
+        _poolKey = k;
+    }
+
+    // -- IERC20 --
+    function totalSupply() external pure returns (uint256) {
+        return 0;
+    }
+
+    function balanceOf(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function transfer(address, uint256) external pure returns (bool) {
+        return true;
+    }
+
+    function allowance(address, address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function approve(address, uint256) external pure returns (bool) {
+        return true;
+    }
+
+    function transferFrom(address, address, uint256) external pure returns (bool) {
+        return true;
+    }
+
+    // -- IVault --
+    function deposit(uint256, uint256, uint256, uint256, address) external pure returns (uint256, uint256, uint256) {
+        return (0, 0, 0);
+    }
+
+    function withdraw(uint256, uint256, uint256, address) external pure returns (uint256, uint256) {
+        return (0, 0);
+    }
+
+    function rebalance() external pure {}
+
+    function getPositions() external pure returns (Position[] memory) {
+        return new Position[](0);
+    }
+
+    function getTotalAmounts() external pure returns (uint256, uint256) {
+        return (0, 0);
+    }
+
+    function poolKey() external view returns (PoolKey memory) {
+        return _poolKey;
+    }
+}
+
+contract IVaultTest is Test {
+    // -------------------------------------------------------------------------
+    // Mock instantiation — proves interface is implementable end-to-end
+    // -------------------------------------------------------------------------
+
+    function test_mock_compilesAndRoundTrips() external {
+        IVaultMock m = new IVaultMock();
+
+        PoolKey memory k = PoolKey({
+            currency0: Currency.wrap(address(0x1)),
+            currency1: Currency.wrap(address(0x2)),
+            fee: 0x800000, // V4 dynamic-fee flag
+            tickSpacing: 60,
+            hooks: IHooks(address(0xCAFE))
+        });
+        m.setPoolKey(k);
+
+        PoolKey memory r = m.poolKey();
+        assertEq(Currency.unwrap(r.currency0), address(0x1));
+        assertEq(Currency.unwrap(r.currency1), address(0x2));
+        assertEq(r.tickSpacing, 60);
+        assertEq(address(r.hooks), address(0xCAFE));
+    }
+
+    // -------------------------------------------------------------------------
+    // Selector snapshots
+    // -------------------------------------------------------------------------
+
+    function test_selector_deposit() external pure {
+        assertEq(IVault.deposit.selector, bytes4(keccak256("deposit(uint256,uint256,uint256,uint256,address)")));
+    }
+
+    function test_selector_withdraw() external pure {
+        assertEq(IVault.withdraw.selector, bytes4(keccak256("withdraw(uint256,uint256,uint256,address)")));
+    }
+
+    function test_selector_rebalance() external pure {
+        assertEq(IVault.rebalance.selector, bytes4(keccak256("rebalance()")));
+    }
+
+    function test_selector_getPositions() external pure {
+        assertEq(IVault.getPositions.selector, bytes4(keccak256("getPositions()")));
+    }
+
+    function test_selector_getTotalAmounts() external pure {
+        assertEq(IVault.getTotalAmounts.selector, bytes4(keccak256("getTotalAmounts()")));
+    }
+
+    function test_selector_poolKey() external pure {
+        assertEq(IVault.poolKey.selector, bytes4(keccak256("poolKey()")));
+    }
+
+    // -------------------------------------------------------------------------
+    // Event topic snapshots
+    // -------------------------------------------------------------------------
+
+    function test_event_Deposit_topic() external pure {
+        assertEq(IVault.Deposit.selector, keccak256("Deposit(address,uint256,uint256,uint256)"));
+    }
+
+    function test_event_Withdraw_topic() external pure {
+        assertEq(IVault.Withdraw.selector, keccak256("Withdraw(address,uint256,uint256,uint256)"));
+    }
+
+    function test_event_Rebalanced_topic() external pure {
+        assertEq(IVault.Rebalanced.selector, keccak256("Rebalanced(int24,uint256,uint256)"));
+    }
+
+    function test_event_FeesCollected_topic() external pure {
+        assertEq(IVault.FeesCollected.selector, keccak256("FeesCollected(uint256,uint256)"));
+    }
+
+    // -------------------------------------------------------------------------
+    // ERC-20 surface inherited
+    // -------------------------------------------------------------------------
+
+    function test_inherits_IERC20() external pure {
+        // Compile-time guarantee: an `IVault` is assignable to an `IERC20`
+        // typed slot. This both documents the inheritance and would fail
+        // to compile if the interface were ever changed not to inherit.
+        IVault v = IVault(address(0));
+        IERC20 e = IERC20(v);
+        assertEq(address(e), address(v));
+    }
+}

--- a/packages/contracts/test/utils/Errors.t.sol
+++ b/packages/contracts/test/utils/Errors.t.sol
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {Errors} from "../../src/utils/Errors.sol";
+
+/// @notice Selector regression + revert-shape tests for `Errors`.
+/// @dev `Errors` is a pure declaration library — there is no behaviour to
+///      exercise other than:
+///      1. Selectors are stable across refactors. Third parties index
+///         reverts by selector; an accidental signature change is a
+///         consumer-breaking bug. Snapshotted explicitly here.
+///      2. Encoded args round-trip through `abi.decode`. Catches the
+///         "I added a uint256 arg but consumers still encode for an
+///         empty error" class of mistake.
+contract ErrorsTest is Test {
+    // -------------------------------------------------------------------------
+    // Selector snapshots
+    // -------------------------------------------------------------------------
+    //
+    // To regenerate after intentional signature changes:
+    //
+    //   forge inspect Errors errors --json | jq
+    //
+    // and update the constants below. Bumping any of these is a breaking
+    // change for downstream indexers — bump the major version.
+
+    function test_selector_OnlyOwner() external pure {
+        assertEq(Errors.OnlyOwner.selector, bytes4(keccak256("OnlyOwner()")));
+    }
+
+    function test_selector_OnlyKeeper() external pure {
+        assertEq(Errors.OnlyKeeper.selector, bytes4(keccak256("OnlyKeeper()")));
+    }
+
+    function test_selector_OnlyPoolManager() external pure {
+        assertEq(Errors.OnlyPoolManager.selector, bytes4(keccak256("OnlyPoolManager()")));
+    }
+
+    function test_selector_ZeroAddress() external pure {
+        assertEq(Errors.ZeroAddress.selector, bytes4(keccak256("ZeroAddress()")));
+    }
+
+    function test_selector_SlippageExceeded() external pure {
+        assertEq(Errors.SlippageExceeded.selector, bytes4(keccak256("SlippageExceeded(uint256,uint256)")));
+    }
+
+    function test_selector_TVLCapExceeded() external pure {
+        assertEq(Errors.TVLCapExceeded.selector, bytes4(keccak256("TVLCapExceeded(uint256,uint256)")));
+    }
+
+    function test_selector_DepositsPaused() external pure {
+        assertEq(Errors.DepositsPaused.selector, bytes4(keccak256("DepositsPaused()")));
+    }
+
+    function test_selector_ZeroShares() external pure {
+        assertEq(Errors.ZeroShares.selector, bytes4(keccak256("ZeroShares()")));
+    }
+
+    function test_selector_InvalidShareAmount() external pure {
+        assertEq(Errors.InvalidShareAmount.selector, bytes4(keccak256("InvalidShareAmount()")));
+    }
+
+    function test_selector_WeightsDoNotSum() external pure {
+        assertEq(Errors.WeightsDoNotSum.selector, bytes4(keccak256("WeightsDoNotSum(uint256)")));
+    }
+
+    function test_selector_MaxPositionsExceeded() external pure {
+        assertEq(Errors.MaxPositionsExceeded.selector, bytes4(keccak256("MaxPositionsExceeded(uint256)")));
+    }
+
+    function test_selector_InvalidTickRange() external pure {
+        assertEq(Errors.InvalidTickRange.selector, bytes4(keccak256("InvalidTickRange(int24,int24)")));
+    }
+
+    function test_selector_RebalanceNotNeeded() external pure {
+        assertEq(Errors.RebalanceNotNeeded.selector, bytes4(keccak256("RebalanceNotNeeded()")));
+    }
+
+    function test_selector_HookNotPermissioned() external pure {
+        assertEq(Errors.HookNotPermissioned.selector, bytes4(keccak256("HookNotPermissioned(uint160,uint160)")));
+    }
+
+    function test_selector_OracleStale() external pure {
+        assertEq(Errors.OracleStale.selector, bytes4(keccak256("OracleStale(uint256)")));
+    }
+
+    function test_selector_OracleDeviation() external pure {
+        assertEq(Errors.OracleDeviation.selector, bytes4(keccak256("OracleDeviation(uint256)")));
+    }
+
+    function test_selector_UnknownOp() external pure {
+        assertEq(Errors.UnknownOp.selector, bytes4(keccak256("UnknownOp()")));
+    }
+
+    function test_selector_DeltaUnsettled() external pure {
+        assertEq(Errors.DeltaUnsettled.selector, bytes4(keccak256("DeltaUnsettled()")));
+    }
+
+    function test_selector_Reentrancy() external pure {
+        assertEq(Errors.Reentrancy.selector, bytes4(keccak256("Reentrancy()")));
+    }
+
+    function test_selector_MathOverflow() external pure {
+        assertEq(Errors.MathOverflow.selector, bytes4(keccak256("MathOverflow()")));
+    }
+
+    function test_selector_ValueOutOfBounds() external pure {
+        assertEq(Errors.ValueOutOfBounds.selector, bytes4(keccak256("ValueOutOfBounds(uint256,uint256)")));
+    }
+
+    // -------------------------------------------------------------------------
+    // Revert shape (round-trip)
+    // -------------------------------------------------------------------------
+
+    function test_revertShape_SlippageExceeded() external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.SlippageExceeded.selector, uint256(99), uint256(100)));
+        _throwSlippage(99, 100);
+    }
+
+    function test_revertShape_WeightsDoNotSum(uint256 actual) external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.WeightsDoNotSum.selector, actual));
+        _throwWeights(actual);
+    }
+
+    function test_revertShape_HookNotPermissioned(uint160 expected, uint160 actual) external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.HookNotPermissioned.selector, expected, actual));
+        _throwHook(expected, actual);
+    }
+
+    function test_revertShape_DepositsPaused() external {
+        vm.expectRevert(Errors.DepositsPaused.selector);
+        _throwPaused();
+    }
+
+    // -------------------------------------------------------------------------
+    // Throwers — kept tiny so the tests stay focused on the library itself
+    // -------------------------------------------------------------------------
+
+    function _throwSlippage(uint256 actual, uint256 min) internal pure {
+        revert Errors.SlippageExceeded(actual, min);
+    }
+
+    function _throwWeights(uint256 actual) internal pure {
+        revert Errors.WeightsDoNotSum(actual);
+    }
+
+    function _throwHook(uint160 expected, uint160 actual) internal pure {
+        revert Errors.HookNotPermissioned(expected, actual);
+    }
+
+    function _throwPaused() internal pure {
+        revert Errors.DepositsPaused();
+    }
+}


### PR DESCRIPTION
## Summary

`packages/contracts/src/interfaces/IVault.sol` — the public Vault API. Defined ahead of `Vault.sol` (#26) so mocks, tests, and the frontend ABI exporter (#46) compile against a single signature surface. Resolves #19.

- Surface matches PRD §Day 1 verbatim (`deposit`, `withdraw`, `rebalance`, `getPositions`, `getTotalAmounts`, `poolKey`, `Position` struct, 4 events, inherits IERC20).
- NatSpec documents implementation contracts: `DepositsPaused` / `SlippageExceeded` / `TVLCapExceeded` / `ZeroShares` for deposit; never-pausable + `InvalidShareAmount` for withdraw; `RebalanceNotNeeded` for rebalance; `nonReentrantTransient` on every mutator (ADR-004); withdraw exempt from pause (invariant 6 + ADR-006).
- Tests: 6 selectors snapshotted, 4 event topics snapshotted, full mock implementation as compile gate, IERC20 inheritance check.

## Quality gates

- `forge build` clean
- `forge test` 14/14 pass
- `forge fmt --check` clean

## Test plan

- [ ] Signatures match PRD §Day 1 (`deposit(uint256,uint256,uint256,uint256,address)` + 4-arg `withdraw`)
- [ ] OZ import path `@openzeppelin/contracts/...` is the right convention vs. `openzeppelin-contracts/...`
- [ ] Selector + event-topic regression test the right gate for the ABI exporter pipeline

Closes #19. Blocks #26, #27, #28, #29, #30, #45, #46.