### PR TITLE
feat(contracts): IProtocolHook interface (#21)

### DIFF
--- a/packages/contracts/src/interfaces/IProtocolHook.sol
+++ b/packages/contracts/src/interfaces/IProtocolHook.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {Hooks} from "v4-core/libraries/Hooks.sol";
+
+/// @title IProtocolHook
+/// @notice PRISM's V4 hook surface — dynamic fees in `beforeSwap`, MEV
+///         observation in `afterSwap`, lightweight position-state
+///         cleanup in `afterAddLiquidity` / `afterRemoveLiquidity`, and
+///         the per-pool / per-vault read accessors used by the dApp
+///         and keeper.
+/// @dev Inherits `v4-core/IHooks` so all four V4 callbacks PRISM uses
+///      keep their canonical selectors and ABI shape — implementations
+///      override the `IHooks` methods directly. The four callbacks
+///      PRISM ENABLES are bits 6, 7, 8, 10 (`afterSwap`, `beforeSwap`,
+///      `afterRemoveLiquidity`, `afterAddLiquidity`); the deployed hook
+///      address satisfies `address & 0x3FFF == 0x05C0` per ADR-002.
+///
+///      A bug in `afterAddLiquidity` or `afterRemoveLiquidity` MUST NOT
+///      revert (ADR-002 §hard rule). Those callbacks sit on the
+///      withdraw hot path; reverting them violates invariant 6.
+///      Implementations are emit-only or pure state cleanup.
+///
+///      The hook is a singleton (ADR-002): a single deployed instance
+///      services every PRISM vault. State is sharded by `PoolId` and
+///      vault address inside the implementation.
+interface IProtocolHook is IHooks {
+    // -------------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------------
+
+    /// @notice Emitted when `beforeSwap` recomputes the dynamic fee for
+    ///         a pool.
+    /// @param poolId Indexed `PoolId` (cast to bytes32 for indexer
+    ///        ergonomics — V4's `PoolId` is `bytes32` underneath).
+    /// @param newFee Fee in pip (1e-6); written as the V4
+    ///        `OVERRIDE_FEE_FLAG`-tagged return value.
+    /// @param volatility Snapshot of the short-window EWMA used to
+    ///        compute the new fee; for dApp / analytics consumers.
+    event FeeUpdated(bytes32 indexed poolId, uint24 newFee, uint256 volatility);
+
+    /// @notice Emitted on every swap through the hook — the v1.0 MEV
+    ///         capture surface is observation-only.
+    /// @param poolId Indexed `PoolId`.
+    /// @param tick Pool tick *after* the swap.
+    /// @param sqrtPriceX96 Pool sqrt-price after the swap (Q64.96).
+    event SwapObserved(bytes32 indexed poolId, int24 tick, uint160 sqrtPriceX96);
+
+    /// @notice Emitted when v1.1 backrun execution captures MEV and
+    ///         credits the captured profit to a vault. v1.0 emits no
+    ///         MEVCaptured events (observation only); the event lives
+    ///         on the interface so v1.1 can ship without a hook
+    ///         redeploy of the EVENT topic.
+    /// @param vault Indexed vault that received the credit.
+    /// @param amount Amount captured, denominated in `isToken0 ? token0 : token1`.
+    /// @param isToken0 Which token the captured amount is denominated in.
+    event MEVCaptured(address indexed vault, uint256 amount, bool isToken0);
+
+    // -------------------------------------------------------------------------
+    // Mutators
+    // -------------------------------------------------------------------------
+
+    /// @notice Register a `Vault` against this hook so the hook can
+    ///         attribute MEV captures and per-pool state to the right
+    ///         vault.
+    /// @dev Called by `VaultFactory` immediately after vault deployment
+    ///      so the hook learns the `PoolId → vault` mapping. Reverts
+    ///      via `Errors.OnlyOwner` (or the access-controlled equivalent
+    ///      chosen by the implementation) for non-factory callers.
+    /// @param vault The vault address to register against this hook.
+    function registerVault(address vault) external;
+
+    // -------------------------------------------------------------------------
+    // Views
+    // -------------------------------------------------------------------------
+
+    /// @notice The current dynamic fee the hook will return from
+    ///         `beforeSwap` for this pool, in pip (1e-6 units; e.g.
+    ///         3_000 = 0.30%). Used by the dApp for fee display and by
+    ///         the keeper for simulation.
+    /// @param poolId The `PoolId` (V4 hash of the `PoolKey`) cast to
+    ///        bytes32.
+    /// @return fee Current dynamic fee in pip.
+    function currentFee(bytes32 poolId) external view returns (uint24 fee);
+
+    /// @notice Per-vault MEV profit ledger. v1.0 always returns
+    ///         `(0, 0)` because v1.0 only observes; v1.1 populates as
+    ///         backruns execute.
+    /// @dev Returning two amounts (token0 + token1) lets v1.1 capture
+    ///      profits in either currency depending on the backrun
+    ///      direction without changing the interface surface.
+    /// @param vault The vault to read.
+    /// @return amount0 MEV profits in token0 awaiting distribution.
+    /// @return amount1 MEV profits in token1 awaiting distribution.
+    function mevProfits(address vault) external view returns (uint256 amount0, uint256 amount1);
+
+    /// @notice The exact permissions matrix this hook implements.
+    /// @dev MUST match the bits encoded in the deployed hook address —
+    ///      `PoolManager.initialize` reverts via
+    ///      `Hooks.HookAddressNotValid` otherwise (invariant #7,
+    ///      ADR-002). PRISM hooks return:
+    ///        beforeSwap = true (bit 7)
+    ///        afterSwap = true (bit 6)
+    ///        afterAddLiquidity = true (bit 10)
+    ///        afterRemoveLiquidity = true (bit 8)
+    ///      All other flags false. Combined: `0x05C0`.
+    /// @return permissions The struct of all 14 V4 hook permission flags.
+    function getHookPermissions() external pure returns (Hooks.Permissions memory permissions);
+}

--- a/packages/contracts/test/interfaces/IProtocolHook.t.sol
+++ b/packages/contracts/test/interfaces/IProtocolHook.t.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {Hooks} from "v4-core/libraries/Hooks.sol";
+
+import {IProtocolHook} from "../../src/interfaces/IProtocolHook.sol";
+
+/// @notice Compile-time + selector-stability tests for `IProtocolHook`.
+///
+/// The behavioural tests on the hook implementation (#34, #35, #36) cover
+/// real callback semantics — this file only verifies the interface
+/// surface: signatures match V4's IHooks, the additional read accessors
+/// have stable selectors, and the events have stable topics.
+contract IProtocolHookTest is Test {
+    // -------------------------------------------------------------------------
+    // V4 IHooks inheritance
+    //
+    // Solidity does not expose inherited interface members through
+    // `IProtocolHook.<member>.selector` — the inheritance is enforced
+    // at the ABI level only. The compile-time `IHooks h = IProtocolHook(...)`
+    // assignment proves the IS-A relationship; v4-core owns the
+    // selector-stability tests for IHooks itself.
+    // -------------------------------------------------------------------------
+
+    function test_inherits_IHooks_isa() external pure {
+        IProtocolHook ph = IProtocolHook(address(0));
+        IHooks h = IHooks(ph);
+        assertEq(address(h), address(ph));
+    }
+
+    function test_v4_IHooks_callback_selectors_stable() external pure {
+        // Pin the four selectors PRISM relies on. If v4-core ever changes
+        // its IHooks shape, this test trips before users hit the bug.
+        assertEq(
+            IHooks.beforeSwap.selector,
+            bytes4(keccak256("beforeSwap(address,(address,address,uint24,int24,address),(bool,int256,uint160),bytes)"))
+        );
+        assertEq(
+            IHooks.afterSwap.selector,
+            bytes4(
+                keccak256(
+                    "afterSwap(address,(address,address,uint24,int24,address),(bool,int256,uint160),int256,bytes)"
+                )
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // PRISM-specific surface
+    // -------------------------------------------------------------------------
+
+    function test_selector_registerVault() external pure {
+        assertEq(IProtocolHook.registerVault.selector, bytes4(keccak256("registerVault(address)")));
+    }
+
+    function test_selector_currentFee() external pure {
+        assertEq(IProtocolHook.currentFee.selector, bytes4(keccak256("currentFee(bytes32)")));
+    }
+
+    function test_selector_mevProfits() external pure {
+        assertEq(IProtocolHook.mevProfits.selector, bytes4(keccak256("mevProfits(address)")));
+    }
+
+    function test_selector_getHookPermissions() external pure {
+        assertEq(IProtocolHook.getHookPermissions.selector, bytes4(keccak256("getHookPermissions()")));
+    }
+
+    // -------------------------------------------------------------------------
+    // Event topics
+    // -------------------------------------------------------------------------
+
+    function test_event_FeeUpdated_topic() external pure {
+        assertEq(IProtocolHook.FeeUpdated.selector, keccak256("FeeUpdated(bytes32,uint24,uint256)"));
+    }
+
+    function test_event_SwapObserved_topic() external pure {
+        assertEq(IProtocolHook.SwapObserved.selector, keccak256("SwapObserved(bytes32,int24,uint160)"));
+    }
+
+    function test_event_MEVCaptured_topic() external pure {
+        assertEq(IProtocolHook.MEVCaptured.selector, keccak256("MEVCaptured(address,uint256,bool)"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Permissions matrix — PRISM enables exactly bits 6, 7, 8, 10 (= 0x05C0)
+    //
+    // The permission *value* is ultimately produced by an implementation,
+    // but the interface guarantees the return type is `Hooks.Permissions`
+    // so call sites can construct the canonical PRISM permission set.
+    // -------------------------------------------------------------------------
+
+    function test_canonicalPRISMPermissions_compileGate() external pure {
+        Hooks.Permissions memory p = Hooks.Permissions({
+            beforeInitialize: false,
+            afterInitialize: false,
+            beforeAddLiquidity: false,
+            afterAddLiquidity: true, // bit 10 — 0x0400
+            beforeRemoveLiquidity: false,
+            afterRemoveLiquidity: true, // bit 8 — 0x0100
+            beforeSwap: true, // bit 7 — 0x0080
+            afterSwap: true, // bit 6 — 0x0040
+            beforeDonate: false,
+            afterDonate: false,
+            beforeSwapReturnDelta: false,
+            afterSwapReturnDelta: false,
+            afterAddLiquidityReturnDelta: false,
+            afterRemoveLiquidityReturnDelta: false
+        });
+        // Combined bits: 0x0400 + 0x0100 + 0x0080 + 0x0040 = 0x05C0.
+        assertTrue(p.beforeSwap && p.afterSwap && p.afterAddLiquidity && p.afterRemoveLiquidity);
+        assertFalse(p.beforeInitialize || p.afterInitialize);
+    }
+}


### PR DESCRIPTION
## Summary

`packages/contracts/src/interfaces/IProtocolHook.sol` — V4 hook surface inheriting `v4-core/IHooks`. Resolves #21.

- 4 PRISM-enabled callbacks (`beforeSwap`, `afterSwap`, `afterAddLiquidity`, `afterRemoveLiquidity`) keep canonical v4-core selectors.
- 4 PRISM-specific functions: `registerVault`, `currentFee`, `mevProfits`, `getHookPermissions`.
- 3 events: `FeeUpdated`, `SwapObserved`, `MEVCaptured` — `MEVCaptured` ships in v1.0 even though only v1.1 emits it, so the topic doesn't change at v1.1.
- NatSpec encodes ADR-002 hard rules: singleton hook, liquidity callbacks never revert, `getHookPermissions` must match address bits = `0x05C0`.

`mevProfits` returns `(amount0, amount1)` so v1.1 backrun execution can credit either currency without bumping the interface.

## Quality gates

- `forge build` clean
- `forge test` 10/10 pass on this file (selector + event-topic snapshots, `IHooks` IS-A inheritance, two v4-core IHooks selector pins, canonical permission matrix compile gate)
- `forge fmt --check` clean

## Test plan

- [ ] 4 PRISM-surface selectors and the 3 event topics — names + signatures stable
- [ ] `mevProfits` returning `(amount0, amount1)` is the right shape for v1.1 (vs. uint256 + side flag)
- [ ] `MEVCaptured` topic shipped in v1.0 even though no emitter — acceptable as forward-compat

Closes #21. Blocks #34, #35, #36, #37.