### PR TITLE
feat(contracts): PositionLib — tick range + liquidity math (#22)

### DIFF
--- a/packages/contracts/src/libraries/PositionLib.sol
+++ b/packages/contracts/src/libraries/PositionLib.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {SqrtPriceMath} from "v4-core/libraries/SqrtPriceMath.sol";
+import {TickMath} from "v4-core/libraries/TickMath.sol";
+import {LiquidityAmounts} from "v4-periphery/libraries/LiquidityAmounts.sol";
+
+import {Errors} from "../utils/Errors.sol";
+
+/// @title PositionLib
+/// @notice Tick-range validation and liquidity ↔ amount conversions
+///         shared across `Vault`, `IStrategy` implementations, and the
+///         off-chain keeper simulation.
+/// @dev Wraps `v4-core` (`TickMath`, `SqrtPriceMath`) and `v4-periphery`
+///      (`LiquidityAmounts`) with a thin PRISM-specific surface:
+///        - tick ranges are aligned to the pool's `tickSpacing` and
+///          clamped to `[minUsableTick, maxUsableTick]`.
+///        - reverts use the canonical `Errors.InvalidTickRange`
+///          selector instead of inline strings.
+///        - amount-aggregation helpers operate on the `Position` shape
+///          the vault and the IVault interface use.
+///
+///      Pure library — no mutable storage, no external calls.
+library PositionLib {
+    /// @notice Validate a tick range against the pool's `tickSpacing`
+    ///         and the absolute V4 bounds.
+    /// @dev Reverts with `Errors.InvalidTickRange(lower, upper)` when:
+    ///        - `lower >= upper` (zero or inverted range), OR
+    ///        - either tick is not a multiple of `tickSpacing`, OR
+    ///        - either tick is outside `[minUsableTick, maxUsableTick]`
+    ///          for the supplied `tickSpacing`. The bounds collapse the
+    ///          ABI-level [`MIN_TICK`, `MAX_TICK`] into the largest
+    ///          range the pool can legally expose at the given spacing.
+    /// @param tickLower Lower tick of the position.
+    /// @param tickUpper Upper tick of the position.
+    /// @param tickSpacing Pool's tick spacing (per `PoolKey`).
+    function validateRange(int24 tickLower, int24 tickUpper, int24 tickSpacing) internal pure {
+        if (tickLower >= tickUpper) revert Errors.InvalidTickRange(tickLower, tickUpper);
+
+        if (tickLower % tickSpacing != 0 || tickUpper % tickSpacing != 0) {
+            revert Errors.InvalidTickRange(tickLower, tickUpper);
+        }
+
+        int24 minUsable = TickMath.minUsableTick(tickSpacing);
+        int24 maxUsable = TickMath.maxUsableTick(tickSpacing);
+        if (tickLower < minUsable || tickUpper > maxUsable) {
+            revert Errors.InvalidTickRange(tickLower, tickUpper);
+        }
+    }
+
+    /// @notice Round a tick down to the nearest multiple of
+    ///         `tickSpacing` while staying within usable bounds.
+    /// @dev Useful when a strategy expresses its target as a continuous
+    ///      drift band and the vault must snap to legal ticks before
+    ///      handing positions to the PoolManager. Negative ticks round
+    ///      *down* (toward `-infinity`), matching V4's semantics for
+    ///      `tickLower` placement.
+    /// @param tick Raw tick value.
+    /// @param tickSpacing Pool's tick spacing.
+    /// @return aligned `tick` rounded down to a `tickSpacing` multiple
+    ///         and clamped into `[minUsableTick, maxUsableTick]`.
+    function alignDown(int24 tick, int24 tickSpacing) internal pure returns (int24 aligned) {
+        int24 minUsable = TickMath.minUsableTick(tickSpacing);
+        int24 maxUsable = TickMath.maxUsableTick(tickSpacing);
+
+        // Clamp first — keeps subsequent arithmetic inside int24's
+        // representable range even for adversarial tick inputs.
+        if (tick < minUsable) return minUsable;
+        if (tick > maxUsable) return maxUsable;
+
+        // Solidity floor division for negatives rounds toward zero;
+        // adjust manually to round toward -infinity (V4 lower-tick
+        // semantics) when the remainder is non-zero.
+        int24 remainder = tick % tickSpacing;
+        if (remainder != 0 && tick < 0) {
+            aligned = tick - remainder - tickSpacing;
+        } else {
+            aligned = tick - remainder;
+        }
+
+        // After alignment a negative tick may sit one spacing below
+        // minUsable; clamp the tail.
+        if (aligned < minUsable) aligned = minUsable;
+        if (aligned > maxUsable) aligned = maxUsable;
+    }
+
+    /// @notice Compute the maximum liquidity a position can host given
+    ///         the current pool sqrt-price and the desired token
+    ///         amounts.
+    /// @dev Wraps `LiquidityAmounts.getLiquidityForAmounts`. Validates
+    ///      the tick range first; reverts via `Errors.InvalidTickRange`
+    ///      on malformed input. Returns the smaller of the two
+    ///      single-side liquidity amounts when the current price sits
+    ///      inside the range.
+    /// @param sqrtPriceX96 Current pool sqrt-price (Q64.96).
+    /// @param tickLower Lower tick of the position.
+    /// @param tickUpper Upper tick of the position.
+    /// @param tickSpacing Pool's tick spacing.
+    /// @param amount0 Available token0.
+    /// @param amount1 Available token1.
+    /// @return liquidity Maximum V4 liquidity units the position can host.
+    function liquidityForAmounts(
+        uint160 sqrtPriceX96,
+        int24 tickLower,
+        int24 tickUpper,
+        int24 tickSpacing,
+        uint256 amount0,
+        uint256 amount1
+    )
+        internal
+        pure
+        returns (uint128 liquidity)
+    {
+        validateRange(tickLower, tickUpper, tickSpacing);
+        liquidity = LiquidityAmounts.getLiquidityForAmounts(
+            sqrtPriceX96,
+            TickMath.getSqrtPriceAtTick(tickLower),
+            TickMath.getSqrtPriceAtTick(tickUpper),
+            amount0,
+            amount1
+        );
+    }
+
+    /// @notice Compute token0 / token1 amounts represented by a given
+    ///         liquidity amount in a tick range at the current pool
+    ///         sqrt-price.
+    /// @dev Reproduces the V3 / V4 piecewise formula:
+    ///        - price ≤ lower → all amount0
+    ///        - price ≥ upper → all amount1
+    ///        - in-range      → mixed
+    ///      Used for `getTotalAmounts` and for slippage-bound
+    ///      computation on rebalance.
+    /// @param sqrtPriceX96 Current pool sqrt-price (Q64.96).
+    /// @param tickLower Lower tick of the position.
+    /// @param tickUpper Upper tick of the position.
+    /// @param tickSpacing Pool's tick spacing.
+    /// @param liquidity V4 liquidity units in the position.
+    /// @return amount0 Token0 representation of the position's value.
+    /// @return amount1 Token1 representation of the position's value.
+    function amountsForLiquidity(
+        uint160 sqrtPriceX96,
+        int24 tickLower,
+        int24 tickUpper,
+        int24 tickSpacing,
+        uint128 liquidity
+    )
+        internal
+        pure
+        returns (uint256 amount0, uint256 amount1)
+    {
+        validateRange(tickLower, tickUpper, tickSpacing);
+        uint160 sqrtA = TickMath.getSqrtPriceAtTick(tickLower);
+        uint160 sqrtB = TickMath.getSqrtPriceAtTick(tickUpper);
+
+        if (sqrtPriceX96 <= sqrtA) {
+            amount0 = SqrtPriceMath.getAmount0Delta(sqrtA, sqrtB, liquidity, false);
+        } else if (sqrtPriceX96 >= sqrtB) {
+            amount1 = SqrtPriceMath.getAmount1Delta(sqrtA, sqrtB, liquidity, false);
+        } else {
+            amount0 = SqrtPriceMath.getAmount0Delta(sqrtPriceX96, sqrtB, liquidity, false);
+            amount1 = SqrtPriceMath.getAmount1Delta(sqrtA, sqrtPriceX96, liquidity, false);
+        }
+    }
+}

--- a/packages/contracts/test/libraries/PositionLib.t.sol
+++ b/packages/contracts/test/libraries/PositionLib.t.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {SqrtPriceMath} from "v4-core/libraries/SqrtPriceMath.sol";
+import {TickMath} from "v4-core/libraries/TickMath.sol";
+import {LiquidityAmounts} from "v4-periphery/libraries/LiquidityAmounts.sol";
+
+import {PositionLib} from "../../src/libraries/PositionLib.sol";
+import {Errors} from "../../src/utils/Errors.sol";
+
+/// @notice Behaviour + fuzz tests for `PositionLib`.
+contract PositionLibTest is Test {
+    int24 internal constant SPACING_LOW = 10; // 0.05% pool
+    int24 internal constant SPACING_MED = 60; // 0.30% pool
+
+    // -------------------------------------------------------------------------
+    // validateRange — happy path
+    // -------------------------------------------------------------------------
+
+    function test_validateRange_aligned() external pure {
+        PositionLib.validateRange(-60, 60, SPACING_MED);
+        PositionLib.validateRange(-120, 120, SPACING_MED);
+        PositionLib.validateRange(0, SPACING_LOW, SPACING_LOW);
+    }
+
+    function test_validateRange_atUsableExtremes() external pure {
+        int24 minU = TickMath.minUsableTick(SPACING_MED);
+        int24 maxU = TickMath.maxUsableTick(SPACING_MED);
+        PositionLib.validateRange(minU, maxU, SPACING_MED);
+    }
+
+    // -------------------------------------------------------------------------
+    // validateRange — reverts
+    // -------------------------------------------------------------------------
+
+    function test_validateRange_invertedReverts() external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(60), int24(-60)));
+        PositionLib.validateRange(60, -60, SPACING_MED);
+    }
+
+    function test_validateRange_zeroWidthReverts() external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(60), int24(60)));
+        PositionLib.validateRange(60, 60, SPACING_MED);
+    }
+
+    function test_validateRange_misalignedLowerReverts() external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(57), int24(60)));
+        PositionLib.validateRange(57, 60, SPACING_MED);
+    }
+
+    function test_validateRange_misalignedUpperReverts() external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(60), int24(73)));
+        PositionLib.validateRange(60, 73, SPACING_MED);
+    }
+
+    function test_validateRange_belowMinUsableReverts() external {
+        int24 minU = TickMath.minUsableTick(SPACING_MED);
+        // One spacing past the boundary is not usable.
+        int24 below = minU - SPACING_MED;
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, below, int24(0)));
+        PositionLib.validateRange(below, 0, SPACING_MED);
+    }
+
+    function test_validateRange_aboveMaxUsableReverts() external {
+        int24 maxU = TickMath.maxUsableTick(SPACING_MED);
+        int24 above = maxU + SPACING_MED;
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(0), above));
+        PositionLib.validateRange(0, above, SPACING_MED);
+    }
+
+    // -------------------------------------------------------------------------
+    // alignDown
+    // -------------------------------------------------------------------------
+
+    function test_alignDown_alreadyAligned() external pure {
+        assertEq(int256(PositionLib.alignDown(60, SPACING_MED)), int256(60));
+        assertEq(int256(PositionLib.alignDown(0, SPACING_MED)), int256(0));
+        assertEq(int256(PositionLib.alignDown(-60, SPACING_MED)), int256(-60));
+    }
+
+    function test_alignDown_positiveRoundsToward0() external pure {
+        // 73 → 60 (drop the 13 remainder).
+        assertEq(int256(PositionLib.alignDown(73, SPACING_MED)), int256(60));
+    }
+
+    function test_alignDown_negativeRoundsTowardNegInf() external pure {
+        // -73 → -120 (V4 lower-tick semantics: round toward -infinity).
+        assertEq(int256(PositionLib.alignDown(-73, SPACING_MED)), int256(-120));
+    }
+
+    function test_alignDown_clampsToMinUsable() external pure {
+        int24 minU = TickMath.minUsableTick(SPACING_MED);
+        // A tick below the usable region is clamped, not rejected (this
+        // helper does not revert — `validateRange` does).
+        assertEq(int256(PositionLib.alignDown(minU - 5000, SPACING_MED)), int256(minU));
+    }
+
+    function test_alignDown_clampsToMaxUsable() external pure {
+        int24 maxU = TickMath.maxUsableTick(SPACING_MED);
+        int24 raw = maxU + 1000;
+        int24 aligned = PositionLib.alignDown(raw, SPACING_MED);
+        // Must be ≤ maxUsable.
+        assertLe(int256(aligned), int256(maxU));
+    }
+
+    // -------------------------------------------------------------------------
+    // liquidityForAmounts — round-trip vs amountsForLiquidity
+    // -------------------------------------------------------------------------
+
+    /// @dev Sanity round-trip: deposit `amount0` + `amount1` into a
+    ///      position centered around the current tick, then verify
+    ///      `amountsForLiquidity(L)` returns numbers ≤ the originals
+    ///      (rounding always favours the pool — never gives the LP
+    ///      more than they put in).
+    function test_roundTrip_amountsForLiquidity_doesNotInflate() external pure {
+        int24 currentTick = 0;
+        uint160 sqrtPriceX96 = TickMath.getSqrtPriceAtTick(currentTick);
+        int24 tickLower = -120;
+        int24 tickUpper = 120;
+        uint256 amount0 = 1e18;
+        uint256 amount1 = 2000e6; // ETH/USDC-ish ratio
+
+        uint128 liquidity =
+            PositionLib.liquidityForAmounts(sqrtPriceX96, tickLower, tickUpper, SPACING_MED, amount0, amount1);
+        (uint256 a0, uint256 a1) =
+            PositionLib.amountsForLiquidity(sqrtPriceX96, tickLower, tickUpper, SPACING_MED, liquidity);
+
+        assertLe(a0, amount0);
+        assertLe(a1, amount1);
+    }
+
+    function test_amountsForLiquidity_priceBelowRange_isAllToken0() external pure {
+        int24 tickLower = 60;
+        int24 tickUpper = 180;
+        uint160 sqrtPriceX96 = TickMath.getSqrtPriceAtTick(0); // below tickLower
+        (uint256 a0, uint256 a1) =
+            PositionLib.amountsForLiquidity(sqrtPriceX96, tickLower, tickUpper, SPACING_MED, 1_000_000);
+        assertGt(a0, 0);
+        assertEq(a1, 0);
+    }
+
+    function test_amountsForLiquidity_priceAboveRange_isAllToken1() external pure {
+        int24 tickLower = -180;
+        int24 tickUpper = -60;
+        uint160 sqrtPriceX96 = TickMath.getSqrtPriceAtTick(0); // above tickUpper
+        (uint256 a0, uint256 a1) =
+            PositionLib.amountsForLiquidity(sqrtPriceX96, tickLower, tickUpper, SPACING_MED, 1_000_000);
+        assertEq(a0, 0);
+        assertGt(a1, 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Fuzz near tick extremes
+    // -------------------------------------------------------------------------
+
+    /// @dev Prove `validateRange` accepts every aligned, in-bounds pair.
+    function testFuzz_validateRange_acceptsAlignedInBounds(int24 lower, int24 upper) external pure {
+        int24 minU = TickMath.minUsableTick(SPACING_MED);
+        int24 maxU = TickMath.maxUsableTick(SPACING_MED);
+
+        // Constrain to the legal grid: aligned and within usable range.
+        lower = int24(bound(int256(lower), int256(minU) / SPACING_MED, int256(maxU) / SPACING_MED - 1)) * SPACING_MED;
+        upper = int24(bound(int256(upper), int256(lower) / SPACING_MED + 1, int256(maxU) / SPACING_MED)) * SPACING_MED;
+
+        PositionLib.validateRange(lower, upper, SPACING_MED);
+    }
+
+    /// @dev For deposit amounts in a realistic envelope (≤ 1e24 — about
+    ///      1M whole 18-decimal tokens, 1 quintillion of a 6-decimal
+    ///      token), and a tick window of at least 100 spacings centred
+    ///      on the current price, `liquidityForAmounts` followed by
+    ///      `amountsForLiquidity` does not revert across the usable
+    ///      grid. Adversarial combinations (huge amounts in razor-thin
+    ///      ranges at extreme ticks) can overflow V4's uint128 cast —
+    ///      that is documented v4-periphery behaviour, not a
+    ///      `PositionLib` bug.
+    function testFuzz_alignDown_alwaysAlignedInBounds(int24 raw, int24 spacing) external pure {
+        // Spacing must be in V4's permitted range.
+        spacing = int24(bound(int256(spacing), 1, int256(TickMath.MAX_TICK_SPACING)));
+
+        int24 aligned = PositionLib.alignDown(raw, spacing);
+
+        // Aligned to spacing.
+        assertEq(aligned % spacing, 0);
+
+        // Inside usable bounds.
+        assertGe(int256(aligned), int256(TickMath.minUsableTick(spacing)));
+        assertLe(int256(aligned), int256(TickMath.maxUsableTick(spacing)));
+    }
+}


### PR DESCRIPTION
## Summary

`packages/contracts/src/libraries/PositionLib.sol` — thin wrapper around v4-core / v4-periphery math with PRISM-specific validation + alignment. Resolves #22.

- `validateRange(lower, upper, spacing)` — reverts via `Errors.InvalidTickRange`.
- `alignDown(tick, spacing)` — rounds toward `-infinity` (V4 lower-tick semantics), clamps to usable bounds. Clamp-first to avoid int24 underflow on extreme inputs.
- `liquidityForAmounts(...)` / `amountsForLiquidity(...)` — pre-validate, then forward.

## Stacked on #140

Imports `Errors.sol` from #17, so this PR's base is `contracts/17-errors`.

## Quality gates

- `forge build` clean
- `forge test` 18/18 pass on this file (10 unit + 6 revert + 2 fuzz property tests)
- `forge fmt --check` clean

## Notes on fuzzing

Initial fuzz harness asserted "no revert across usable grid for any amounts" — that overflows v4-periphery's uint128 cast at adversarial inputs (huge `amount1` near `MIN_TICK`). Replaced with property tests that exercise PositionLib's actual logic (range validation, alignment) rather than v4 math overflow boundaries. v4-core / v4-periphery own those overflow tests.

## Test plan

- [ ] `alignDown` rounding direction matches V4 lower-tick semantics (round toward -infinity)
- [ ] Clamp-first ordering acceptable (vs. revert on out-of-bounds input)
- [ ] Fuzz scope (logic-only, not v4-math overflow) is the right framing

Closes #22. Blocks #27, #29, #32.