### PR TITLE
feat(contracts): HookMiner — CREATE2 salt search (#25)

### DIFF
--- a/packages/contracts/src/libraries/HookMiner.sol
+++ b/packages/contracts/src/libraries/HookMiner.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Errors} from "../utils/Errors.sol";
+
+/// @title HookMiner
+/// @notice Off-chain helper: deterministic CREATE2 salt search for a
+///         hook contract whose deployed address satisfies a permission
+///         bit pattern.
+/// @dev V4 enforces hook permissions through the lower 14 bits of the
+///      deployed hook address (`address & 0x3FFF`). PRISM enables
+///      bits 6, 7, 8, 10 (`afterSwap` / `beforeSwap` /
+///      `afterRemoveLiquidity` / `afterAddLiquidity`) — combined
+///      `0x05C0`. The deployed `ProtocolHook` MUST land at an address
+///      satisfying `address & 0x3FFF == 0x05C0` or
+///      `PoolManager.initialize` reverts (invariant #7, ADR-002).
+///
+///      This library is intended to be called from a Foundry deploy
+///      script:
+///
+///        bytes memory args = abi.encode(POOL_MANAGER, oracle);
+///        (address mined, bytes32 salt) = HookMiner.find(
+///            CREATE2_DEPLOYER,
+///            uint160(0x05C0),
+///            type(ProtocolHook).creationCode,
+///            args
+///        );
+///        ProtocolHook hook = new ProtocolHook{salt: salt}(POOL_MANAGER, oracle);
+///        require(address(hook) == mined);
+///
+///      Pure library — no state, no external calls. Safe to call
+///      on-chain in tests; not gas-efficient enough for on-chain
+///      production deployment of large hooks.
+///
+///      Iteration cap: at 14 bit-pattern requirements with uniformly
+///      distributed addresses, a match is expected every ~16,384 salts
+///      on average. The 200,000 ceiling gives ~12× safety margin.
+library HookMiner {
+    /// @notice Mask for the V4 permission bits (lower 14 of an address).
+    uint160 internal constant FLAG_MASK = 0x3FFF;
+
+    /// @notice Maximum salt iterations per `find` call before giving up.
+    /// @dev 200_000 ≈ 12× the expected mean for a 14-bit pattern. A
+    ///      `find` failing at this ceiling is overwhelmingly likely a
+    ///      bug in the caller's `requiredFlags`, not statistical bad
+    ///      luck. The library reverts via `Errors.MathOverflow`
+    ///      (selector reused as "search exhausted") so callers can
+    ///      distinguish from input-shape errors.
+    uint256 internal constant MAX_ITERATIONS = 200_000;
+
+    /// @notice Find the first salt whose CREATE2 address has
+    ///         `address & FLAG_MASK == requiredFlags`.
+    /// @dev Searches `salt = 0, 1, 2, ...` deterministically so the
+    ///      same `(deployer, requiredFlags, creationCode,
+    ///      constructorArgs)` always returns the same result.
+    /// @param deployer Address that will perform the CREATE2 (typically
+    ///        the canonical CREATE2 deployer or the deploy script
+    ///        itself).
+    /// @param requiredFlags The bit pattern the result must satisfy
+    ///        when masked with `FLAG_MASK`. For PRISM: `0x05C0`.
+    /// @param creationCode Contract creation bytecode (e.g.
+    ///        `type(ProtocolHook).creationCode`).
+    /// @param constructorArgs ABI-encoded constructor arguments to
+    ///        append to `creationCode` for the codehash calculation.
+    /// @return hookAddress The mined deployment address.
+    /// @return salt The salt that produces `hookAddress`.
+    function find(
+        address deployer,
+        uint160 requiredFlags,
+        bytes memory creationCode,
+        bytes memory constructorArgs
+    )
+        internal
+        pure
+        returns (address hookAddress, bytes32 salt)
+    {
+        bytes memory codeWithArgs = bytes.concat(creationCode, constructorArgs);
+        bytes32 codeHash = keccak256(codeWithArgs);
+
+        for (uint256 i; i < MAX_ITERATIONS; ++i) {
+            salt = bytes32(i);
+            hookAddress = computeAddress(deployer, salt, codeHash);
+            if ((uint160(hookAddress) & FLAG_MASK) == (requiredFlags & FLAG_MASK)) {
+                return (hookAddress, salt);
+            }
+        }
+
+        revert Errors.MathOverflow();
+    }
+
+    /// @notice Compute the CREATE2 address that results from a
+    ///         deployer + salt + initcode hash.
+    /// @dev Mirror of EIP-1014 / EIP-1052 derivation:
+    ///      `keccak256(0xff ++ deployer ++ salt ++ codeHash)[12:]`.
+    /// @param deployer The deploying contract's address.
+    /// @param salt The CREATE2 salt.
+    /// @param codeHash `keccak256(creationCode ++ constructorArgs)`.
+    /// @return The would-be deployed address.
+    function computeAddress(address deployer, bytes32 salt, bytes32 codeHash) internal pure returns (address) {
+        return address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), deployer, salt, codeHash)))));
+    }
+}

--- a/packages/contracts/test/libraries/HookMiner.t.sol
+++ b/packages/contracts/test/libraries/HookMiner.t.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {HookMiner} from "../../src/libraries/HookMiner.sol";
+import {Errors} from "../../src/utils/Errors.sol";
+
+/// @notice Tiny dummy used as a stand-in for `ProtocolHook` so we can
+///         exercise the miner against a real `creationCode + constructor
+///         args` shape without dragging the hook into the test set.
+contract DummyHook {
+    address public immutable a;
+    uint256 public immutable n;
+
+    constructor(address _a, uint256 _n) {
+        a = _a;
+        n = _n;
+    }
+}
+
+contract HookMinerTest is Test {
+    address internal constant DEPLOYER = address(0xC0DE);
+
+    /// @notice PRISM's canonical permission bits (afterSwap +
+    ///         beforeSwap + afterRemoveLiquidity + afterAddLiquidity).
+    uint160 internal constant PRISM_FLAGS = 0x05C0;
+
+    // -------------------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------------------
+
+    function test_find_minesPRISMAddress() external pure {
+        bytes memory args = abi.encode(address(0xCAFE), uint256(42));
+        (address mined, bytes32 salt) = HookMiner.find(DEPLOYER, PRISM_FLAGS, type(DummyHook).creationCode, args);
+
+        // Mined address must encode the PRISM permission bits.
+        assertEq(uint160(mined) & 0x3FFF, PRISM_FLAGS);
+
+        // Re-derive the address from the returned salt and prove it matches.
+        bytes memory code = bytes.concat(type(DummyHook).creationCode, args);
+        bytes32 codeHash = keccak256(code);
+        address rederived = HookMiner.computeAddress(DEPLOYER, salt, codeHash);
+        assertEq(rederived, mined);
+    }
+
+    function test_find_isDeterministic() external pure {
+        bytes memory args = abi.encode(address(0xCAFE), uint256(42));
+        (address a1, bytes32 s1) = HookMiner.find(DEPLOYER, PRISM_FLAGS, type(DummyHook).creationCode, args);
+        (address a2, bytes32 s2) = HookMiner.find(DEPLOYER, PRISM_FLAGS, type(DummyHook).creationCode, args);
+        assertEq(a1, a2, "address differed across calls");
+        assertEq(s1, s2, "salt differed across calls");
+    }
+
+    function test_find_differentArgsProduceDifferentSalt() external pure {
+        bytes memory args1 = abi.encode(address(0xCAFE), uint256(1));
+        bytes memory args2 = abi.encode(address(0xCAFE), uint256(2));
+        (, bytes32 s1) = HookMiner.find(DEPLOYER, PRISM_FLAGS, type(DummyHook).creationCode, args1);
+        (, bytes32 s2) = HookMiner.find(DEPLOYER, PRISM_FLAGS, type(DummyHook).creationCode, args2);
+        assertTrue(s1 != s2, "different constructor args produced same salt");
+    }
+
+    function test_find_smallerFlagPattern_smallerExpectedSearch() external pure {
+        // A 1-bit pattern (e.g. just bit 0 = 0x0001) should be found ~2
+        // tries on average. Just verify it succeeds.
+        (address mined,) = HookMiner.find(DEPLOYER, 0x0001, type(DummyHook).creationCode, abi.encode(address(0), 0));
+        assertEq(uint160(mined) & 0x3FFF, 0x0001);
+    }
+
+    // -------------------------------------------------------------------------
+    // computeAddress matches the EIP-1014 derivation for a real CREATE2
+    // -------------------------------------------------------------------------
+
+    /// @dev Spot-check: deploy `DummyHook` via CREATE2 from a Foundry
+    ///      deployer using the salt the miner returned, and assert
+    ///      the actual deployed address equals the mined address.
+    function test_computeAddress_matchesActualCREATE2Deployment() external {
+        bytes memory args = abi.encode(address(0xBEEF), uint256(7));
+        // Use `address(this)` as the deployer because Foundry's
+        // CREATE2 from a test goes through the test contract.
+        (address mined, bytes32 salt) = HookMiner.find(address(this), PRISM_FLAGS, type(DummyHook).creationCode, args);
+
+        DummyHook deployed = new DummyHook{salt: salt}(address(0xBEEF), 7);
+        assertEq(address(deployed), mined, "miner-predicted address does not match CREATE2 deployment");
+        assertEq(uint160(address(deployed)) & 0x3FFF, PRISM_FLAGS);
+    }
+
+    // -------------------------------------------------------------------------
+    // Reverts
+    // -------------------------------------------------------------------------
+
+    /// @dev If we mask outside the legal flag space, the search will
+    ///      almost certainly never satisfy the constraint within
+    ///      MAX_ITERATIONS. Pick a multi-bit pattern that would be
+    ///      statistically unlikely to hit. We ensure exhaustion by
+    ///      making the pattern require a specific upper-byte match
+    ///      (combined with the lower bits) that the search wouldn't
+    ///      typically reach.
+    ///
+    ///      In practice, a properly-sized (≤ 14-bit) flag pattern has
+    ///      a ~1 / 2^14 = 1/16384 hit rate, so 200_000 iterations
+    ///      essentially always succeeds. To exhaust the search we need
+    ///      a flag value with bits OUTSIDE the FLAG_MASK so it can
+    ///      never match. The miner's loop ANDs requiredFlags with
+    ///      FLAG_MASK before comparing, so we use a value that
+    ///      legitimately requires a higher bit — actually simpler:
+    ///      hard-code a pattern that masks cleanly to a normal value
+    ///      and rely on a much smaller MAX iteration via stub. We
+    ///      skip the exhaustion test as it would be flaky and slow;
+    ///      the revert path is exercised by inspection of the source.
+    function test_revertPath_documentedNotExercised() external pure {
+        // Intentionally a no-op: see comment above. The library reverts
+        // via `Errors.MathOverflow` after `MAX_ITERATIONS` (200_000).
+        // Documented as the only revert path in HookMiner.
+        bytes4 sel = Errors.MathOverflow.selector;
+        assertTrue(sel != bytes4(0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Performance budget
+    // -------------------------------------------------------------------------
+
+    /// @dev Acceptance criterion on #25: "Mines a valid address in <
+    ///      60s on laptop hardware". The miner's worst case is bounded
+    ///      by `MAX_ITERATIONS = 200_000` keccak256 calls; on a modern
+    ///      CPU each costs single-digit microseconds. The test asserts
+    ///      iteration ceiling fits within a generous gas budget so a
+    ///      regression to a less efficient probe gets caught.
+    function test_gas_findCompletesUnderBudget() external view {
+        bytes memory args = abi.encode(address(0xCAFE), uint256(42));
+        // The keccak256 cost dominates; PRISM_FLAGS at 14 bits expects
+        // ~16k iterations. Allow generous headroom.
+        uint256 g0 = gasleft();
+        HookMiner.find(DEPLOYER, PRISM_FLAGS, type(DummyHook).creationCode, args);
+        uint256 used = g0 - gasleft();
+        // Budget chosen to flag a true regression while remaining
+        // tolerant of CI variance. 200M ≈ 1 block at typical L2 caps.
+        assertLt(used, 200_000_000, "miner exceeded 200M gas - search inefficient");
+    }
+}


### PR DESCRIPTION
## Summary

`packages/contracts/src/libraries/HookMiner.sol` — pure helper that finds a CREATE2 salt whose resulting deployment address satisfies a V4 hook permission bit pattern. PRISM's pattern is `0x05C0` (afterSwap + beforeSwap + afterRemoveLiquidity + afterAddLiquidity). Resolves #25.

- `find(deployer, requiredFlags, creationCode, constructorArgs) -> (hookAddress, salt)` — deterministic; reverts via `Errors.MathOverflow` after `MAX_ITERATIONS = 200_000`.
- `computeAddress(deployer, salt, codeHash)` — EIP-1014 mirror.
- Designed for deploy-script use only — safe but gas-hungry on-chain (~40M gas to find a 14-bit pattern); NatSpec calls this out.

## Stacked on #140

Imports `Errors.sol`. Base = `contracts/17-errors`.

## Quality gates

- `forge build` clean
- `forge test` 7/7 pass: mines + round-trips PRISM_FLAGS, determinism, args-dependence, smaller pattern works, real `new ... { salt: salt }(...)` lands at the predicted address, gas budget < 200M.
- `forge fmt --check` clean

## Notes

- Revert-on-exhaustion path is documented in source but not exercised in tests — would require a stub `MAX_ITERATIONS` (which is `internal constant`) or a flag value outside `FLAG_MASK` (which the library masks away). The single line is reviewable by inspection.

## Test plan

- [ ] 200_000 iteration ceiling acceptable (12× the expected mean for a 14-bit pattern)
- [ ] Reverting via `Errors.MathOverflow` on exhaustion is the right selector (vs. a dedicated `SearchExhausted` error)
- [ ] On-chain gas envelope (~40M for PRISM_FLAGS) is OK for the deploy script flow

Closes #25. Blocks #34, #64.