### PR TITLE
ci: contracts workflow (#61)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,64 @@
+# CI workflows
+
+Pre-merge gates for `ozpool/prism`.
+
+## `contracts.yml`
+
+Runs on every PR that touches `packages/contracts/**` (or the workflow
+itself), and on every push to `main` with the same path filter.
+
+Four jobs run in parallel:
+
+| Job | Tool | Action |
+|---|---|---|
+| `build-and-test` | Foundry | `forge build --sizes` + `forge test -vvv` + `forge snapshot --check` |
+| `slither` | Slither (Python) | static analysis — `--fail-medium` blocks merge |
+| `aderyn` | Aderyn (Rust) | second static analyser, complementary rule set |
+| `fmt` | Foundry | `forge fmt --check` |
+
+### Pinned versions
+
+All toolchain versions are pinned at the top of the workflow file. Bump
+deliberately:
+
+| Tool | Pin | How to bump |
+|---|---|---|
+| Foundry | nightly SHA | edit `FOUNDRY_VERSION`; verify with `foundryup --version $sha` locally |
+| Slither | semver | edit `SLITHER_VERSION` |
+| Aderyn | git tag | edit `ADERYN_VERSION` |
+| Python (Slither runtime) | minor | edit `PYTHON_VERSION` |
+
+### Submodule cache
+
+`packages/contracts/lib/` is cached keyed by `hashFiles('.gitmodules')`
+so submodule bumps invalidate cleanly. Manually invalidate by editing
+the cache key or deleting the cache from the Actions UI.
+
+## Required-status-checks (manual setup)
+
+Repository-level branch protection on `main` MUST require all four
+jobs from `contracts.yml`:
+
+- `build-and-test`
+- `slither`
+- `aderyn`
+- `fmt`
+
+Set under **Settings → Branches → main → Require status checks to pass
+before merging**. This is not configurable from the workflow itself —
+ozpool needs to flip the toggle once.
+
+## Rollback
+
+If a CI change breaks main:
+
+1. Revert the offending commit on `main` (or temporarily disable the
+   workflow by adding `if: false` to the affected job).
+2. Open a follow-up PR that fixes forward.
+
+If a tool pin starts producing false positives that block legitimate
+PRs:
+
+1. Pin the tool back to the previous known-good version in `env`.
+2. File an issue in the repo describing the regression.
+3. Bump again deliberately when the upstream tool releases a fix.

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,198 @@
+name: contracts
+
+on:
+  pull_request:
+    paths:
+      - "packages/contracts/**"
+      - ".github/workflows/contracts.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/contracts/**"
+      - ".github/workflows/contracts.yml"
+
+permissions:
+  contents: read
+
+# Pinning toolchain versions in one place. Bump deliberately; avoid
+# floating ranges that drift CI behaviour out from under us.
+env:
+  FOUNDRY_VERSION: nightly-de33b6af53005037b463318d2628b5cfcaf39916
+  SLITHER_VERSION: 0.10.4
+  ADERYN_VERSION: v0.5.4
+  PYTHON_VERSION: "3.12"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # -------------------------------------------------------------------------
+  # forge build + forge test + forge snapshot --check
+  #
+  # Runs in `packages/contracts`. Caches the lib/ submodule directory
+  # across runs (it is git-ignored relative to the workspace but lives
+  # under the package; the cache key incorporates a hash of any pinned
+  # commits we record in `.gitmodules` so a submodule bump invalidates
+  # the cache cleanly).
+  # -------------------------------------------------------------------------
+  build-and-test:
+    name: build · test · snapshot
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/contracts
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ env.FOUNDRY_VERSION }}
+
+      - name: Cache lib/
+        uses: actions/cache@v4
+        with:
+          path: packages/contracts/lib
+          key: lib-${{ runner.os }}-${{ hashFiles('.gitmodules') }}
+          restore-keys: |
+            lib-${{ runner.os }}-
+
+      - name: forge --version
+        run: forge --version
+
+      - name: forge build
+        run: forge build --sizes
+
+      - name: forge test
+        run: forge test -vvv
+
+      - name: forge snapshot --check
+        run: forge snapshot --check
+        # First-run note: when no .gas-snapshot is present in the
+        # repo, snapshot --check exits 0 and writes one. After it
+        # lands on main, subsequent PRs are checked against it.
+        continue-on-error: false
+
+  # -------------------------------------------------------------------------
+  # Slither — static analysis. Fails the job on any finding above
+  # informational severity. The PRD names Slither + Aderyn as the
+  # required pre-merge gate for contracts (CLAUDE.md §Standing Rules).
+  # -------------------------------------------------------------------------
+  slither:
+    name: slither
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/contracts
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ env.FOUNDRY_VERSION }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Slither
+        run: pip install --no-cache-dir slither-analyzer==${{ env.SLITHER_VERSION }}
+
+      - name: Cache lib/
+        uses: actions/cache@v4
+        with:
+          path: packages/contracts/lib
+          key: lib-${{ runner.os }}-${{ hashFiles('.gitmodules') }}
+          restore-keys: |
+            lib-${{ runner.os }}-
+
+      - name: forge build (Slither needs out/)
+        run: forge build --build-info
+
+      - name: Slither
+        # `--fail-medium` blocks the merge on medium and high findings;
+        # informational and low surface in the summary but do not gate.
+        run: |
+          slither . \
+            --foundry-out-directory out \
+            --foundry-ignore-compile \
+            --filter-paths "lib/" \
+            --exclude-low \
+            --exclude-informational \
+            --fail-medium
+
+  # -------------------------------------------------------------------------
+  # Aderyn — second static analyser; complements Slither. Different
+  # rule set, lower false-positive rate on V4-style hooks.
+  # -------------------------------------------------------------------------
+  aderyn:
+    name: aderyn
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/contracts
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ env.FOUNDRY_VERSION }}
+
+      - name: Cache lib/
+        uses: actions/cache@v4
+        with:
+          path: packages/contracts/lib
+          key: lib-${{ runner.os }}-${{ hashFiles('.gitmodules') }}
+          restore-keys: |
+            lib-${{ runner.os }}-
+
+      - name: Install Aderyn
+        run: cargo install aderyn --version ${{ env.ADERYN_VERSION }} --locked
+
+      - name: forge build (Aderyn needs out/)
+        run: forge build
+
+      - name: Aderyn
+        run: aderyn .
+
+  # -------------------------------------------------------------------------
+  # Format gate — `forge fmt --check`. Runs without the heavy
+  # toolchain so PRs that touch only formatting fail fast.
+  # -------------------------------------------------------------------------
+  fmt:
+    name: forge fmt --check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/contracts
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+          fetch-depth: 1
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ env.FOUNDRY_VERSION }}
+
+      - name: forge fmt --check
+        run: forge fmt --check


### PR DESCRIPTION
## Summary

`.github/workflows/contracts.yml` — pre-merge gate on PRs touching `packages/contracts/**`. Resolves #61.

Four parallel jobs:
- **build-and-test**: `forge build --sizes` + `forge test -vvv` + `forge snapshot --check`
- **slither**: `--fail-medium` (low + informational excluded)
- **aderyn**: second static analyser
- **fmt**: `forge fmt --check`, runs without the heavy toolchain

Toolchain versions pinned at the top of the workflow (Foundry nightly SHA, Slither 0.10.4, Aderyn v0.5.4, Python 3.12). `packages/contracts/lib` cached keyed by `hashFiles('.gitmodules')`.

`.github/workflows/README.md` documents bump procedure, manual required-status-check setup, and rollback paths.

## Manual follow-up

Branch protection on `main` needs to be flipped once via Settings → Branches to require these four status checks. Not configurable from the workflow itself.

## Test plan

- [ ] First CI run on this PR is green (or close enough that I can iterate)
- [ ] Foundry nightly SHA pin acceptable (vs. tracking `stable` channel)
- [ ] Slither's `--fail-medium` is the right severity gate (vs. `--fail-high`)
- [ ] No secrets needed (workflow uses public images + tools only — confirmed)

Closes #61. Blocks #38, #39, #40, #41.