### PR TITLE
feat(frontend): @prism/shared — types, addresses, ABI seam (#45)

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@prism/shared",
+  "version": "0.0.0",
+  "private": true,
+  "description": "PRISM shared types, ABIs, and chain addresses",
+  "license": "BUSL-1.1",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./abi": "./src/abi.ts",
+    "./addresses": "./src/addresses.ts",
+    "./types": "./src/types.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"no lint yet\" && exit 0",
+    "test": "echo \"no tests yet\" && exit 0",
+    "build": "echo \"source-only package\" && exit 0"
+  },
+  "peerDependencies": {
+    "viem": "^2.48.4"
+  },
+  "devDependencies": {
+    "typescript": "5.6.3",
+    "viem": "^2.48.4"
+  }
+}

--- a/packages/shared/src/abi.ts
+++ b/packages/shared/src/abi.ts
@@ -1,0 +1,25 @@
+// PRISM contract ABIs.
+//
+// These are placeholders. Issue #46 (scripts/export-abis.ts) reads the Foundry
+// `out/` directory after `forge build` and overwrites this file with the real
+// ABIs typed as readonly tuples (so viem/wagmi can infer return + arg types).
+//
+// Until then each ABI is exported as an empty `readonly []` so consumers can
+// import the names without runtime errors. Calling these contracts off these
+// stubs will return `unknown` types — that is intentional, the goal is only
+// to lock the export shape.
+
+export const VaultAbi = [] as const;
+export type VaultAbi = typeof VaultAbi;
+
+export const VaultFactoryAbi = [] as const;
+export type VaultFactoryAbi = typeof VaultFactoryAbi;
+
+export const ProtocolHookAbi = [] as const;
+export type ProtocolHookAbi = typeof ProtocolHookAbi;
+
+export const BellStrategyAbi = [] as const;
+export type BellStrategyAbi = typeof BellStrategyAbi;
+
+export const ChainlinkAdapterAbi = [] as const;
+export type ChainlinkAdapterAbi = typeof ChainlinkAdapterAbi;

--- a/packages/shared/src/addresses.ts
+++ b/packages/shared/src/addresses.ts
@@ -1,0 +1,43 @@
+import type { Address } from "viem";
+
+export const CHAIN_IDS = {
+  baseSepolia: 84_532,
+  base: 8_453,
+} as const satisfies Record<string, number>;
+
+export type SupportedChainId = (typeof CHAIN_IDS)[keyof typeof CHAIN_IDS];
+
+export interface DeploymentAddresses {
+  vaultFactory: Address;
+  protocolHook: Address;
+  bellStrategy: Address;
+  chainlinkAdapter: Address;
+  poolManager: Address;
+}
+
+const ZERO: Address = "0x0000000000000000000000000000000000000000";
+
+const PLACEHOLDER: DeploymentAddresses = {
+  vaultFactory: ZERO,
+  protocolHook: ZERO,
+  bellStrategy: ZERO,
+  chainlinkAdapter: ZERO,
+  poolManager: ZERO,
+};
+
+export const ADDRESSES: Record<SupportedChainId, DeploymentAddresses | undefined> = {
+  [CHAIN_IDS.baseSepolia]: PLACEHOLDER,
+  // Mainnet deployment is gated on M5 audit completion. See ADR-006.
+  [CHAIN_IDS.base]: undefined,
+};
+
+export function getAddresses(chainId: number): DeploymentAddresses | undefined {
+  if (chainId !== CHAIN_IDS.baseSepolia && chainId !== CHAIN_IDS.base) {
+    return undefined;
+  }
+  return ADDRESSES[chainId as SupportedChainId];
+}
+
+export function isSupportedChain(chainId: number): chainId is SupportedChainId {
+  return chainId === CHAIN_IDS.baseSepolia || chainId === CHAIN_IDS.base;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./abi";
+export * from "./addresses";
+export * from "./types";

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,52 @@
+import type { Address, Hex } from "viem";
+
+export interface PoolKey {
+  currency0: Address;
+  currency1: Address;
+  fee: number;
+  tickSpacing: number;
+  hooks: Address;
+}
+
+export interface Position {
+  tickLower: number;
+  tickUpper: number;
+  liquidity: bigint;
+}
+
+export interface TargetPosition {
+  positions: readonly Position[];
+  totalLiquidity: bigint;
+}
+
+export type TxStatus =
+  | { kind: "idle" }
+  | { kind: "pending"; hash: Hex }
+  | { kind: "success"; hash: Hex }
+  | { kind: "error"; error: Error }
+  | { kind: "wrong-network"; expectedChainId: number };
+
+export interface VaultTotals {
+  totalSupply: bigint;
+  totalAmount0: bigint;
+  totalAmount1: bigint;
+  pricePerShare0: bigint;
+  pricePerShare1: bigint;
+}
+
+export interface MEVProfits {
+  cumulativeProfit0: bigint;
+  cumulativeProfit1: bigint;
+  lastDistributionAt: bigint;
+}
+
+export interface RebalanceEvent {
+  vault: Address;
+  blockNumber: bigint;
+  txHash: Hex;
+  oldSqrtPriceX96: bigint;
+  newSqrtPriceX96: bigint;
+  positionsCleared: number;
+  positionsCreated: number;
+  feeBps: number;
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "declaration": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,15 @@ importers:
         specifier: 5.6.3
         version: 5.6.3
 
+  packages/shared:
+    devDependencies:
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
+      viem:
+        specifier: ^2.48.4
+        version: 2.48.4(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+
 packages:
 
   '@adraffy/ens-normalize@1.11.1':
@@ -2037,6 +2046,7 @@ packages:
   glob@10.3.10:
     resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
@@ -4428,7 +4438,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -7294,10 +7304,25 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  ox@0.14.20(typescript@5.6.3)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.6.3)(zod@4.3.6)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - zod
+
   ox@0.6.7(typescript@5.6.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
@@ -7311,7 +7336,7 @@ snapshots:
   ox@0.6.9(typescript@5.6.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
@@ -8179,6 +8204,23 @@ snapshots:
       abitype: 1.2.3(typescript@5.6.3)(zod@3.25.76)
       isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ox: 0.14.20(typescript@5.6.3)(zod@3.25.76)
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.48.4(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@4.3.6):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.6.3)(zod@4.3.6)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ox: 0.14.20(typescript@5.6.3)(zod@4.3.6)
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.6.3


### PR DESCRIPTION
## Summary

Source-only workspace package `@prism/shared` that frontend code (and later, scripts) consume for shared types, contract ABIs, and chain-keyed deployment addresses.

- `package.json` — `@prism/shared`, viem peer dep, source-only (no build step)
- `tsconfig.json` — strict + `noUncheckedIndexedAccess`, bundler resolution
- `src/abi.ts` — placeholder `readonly []` consts for Vault, VaultFactory, ProtocolHook, BellStrategy, ChainlinkAdapter. Populated by #46 from Foundry `out/`.
- `src/addresses.ts` — `CHAIN_IDS` (baseSepolia 84532, base 8453), `DeploymentAddresses` interface, `getAddresses(chainId)` helper, `isSupportedChain` guard. Mainnet returns `undefined` pre-audit per ADR-006.
- `src/types.ts` — `Position`, `TargetPosition`, `PoolKey`, `TxStatus` discriminated union, `VaultTotals`, `MEVProfits`, `RebalanceEvent`.

## Why this PR is stacked on #44

`@prism/shared` itself only depends on `viem` types, but pnpm sees every `apps/*` and `packages/*` package.json at install time. Branching off `main` (which has no `apps/web/`) produced a polluted lockfile. Stacking onto #44 keeps the workspace consistent.

Merge order: #43 → #44 → #45.

## Quality gates

- `pnpm --filter @prism/shared typecheck` → pass
- `pnpm --filter @prism/web typecheck` → pass (no consumer changes yet)

## Test plan

- [x] `@prism/shared` package resolves via pnpm workspace
- [x] strict TS compile with `noUncheckedIndexedAccess`
- [x] apps/web typecheck unaffected
- [ ] consumer wiring lands in #47 (app shell)

## Dependencies

- Stacked on #44 (frontend/44-providers)
- Unblocks #46 (export-abis script overwrites `src/abi.ts`)
- Unblocks #47 (app shell consumes types + addresses)

Closes #45