### PR TITLE
feat(design): PRISM brand tokens — spectrum palette + type + radii (#1)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,8 +1,9 @@
+@import "./tokens.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-/* Brand tokens land in #1 (design/1-brand-tokens). */
 :root {
   color-scheme: dark;
 }
@@ -10,6 +11,18 @@
 html,
 body {
   height: 100%;
-  background: #0c0a14;
-  color: #ebe5d5;
+}
+
+body {
+  background: rgb(var(--color-canvas));
+  color: rgb(var(--color-text));
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+::selection {
+  background: rgb(var(--color-spectrum-violet) / 0.4);
+  color: rgb(var(--color-text));
 }

--- a/apps/web/app/tokens.css
+++ b/apps/web/app/tokens.css
@@ -1,0 +1,73 @@
+/*
+ * PRISM brand tokens.
+ *
+ * The palette is built around the metaphor of a prism refracting white light
+ * into its spectrum — a violet → rose arc on a deep, warm-tinted dark canvas.
+ * Tokens are exposed as CSS custom properties so both Tailwind utilities and
+ * raw CSS can consume them; Tailwind's `theme.extend` references these vars.
+ */
+
+:root {
+  /* Surfaces — deep, warm-cooled neutrals. */
+  --color-canvas: 12 10 20;            /*  #0c0a14  app background           */
+  --color-surface: 21 18 31;           /*  #15121f  cards, panels            */
+  --color-surface-raised: 30 26 44;    /*  #1e1a2c  hover, popovers          */
+  --color-border: 34 29 51;            /*  #221d33  hairline borders         */
+  --color-border-strong: 53 45 78;     /*  #352d4e  focused borders          */
+
+  /* Text — warm cream descending to muted lavender. */
+  --color-text: 235 229 213;           /*  #ebe5d5  primary copy             */
+  --color-text-muted: 152 144 176;     /*  #9890b0  secondary copy           */
+  --color-text-faint: 105 99 130;      /*  #696382  hints, disabled labels   */
+
+  /* Spectrum — six stops, ordered violet → rose. */
+  --color-spectrum-violet: 124 92 255; /*  #7c5cff                            */
+  --color-spectrum-indigo: 92 138 255; /*  #5c8aff                            */
+  --color-spectrum-teal:   62 220 255; /*  #3edcff                            */
+  --color-spectrum-mint:   62 255 155; /*  #3eff9b                            */
+  --color-spectrum-amber:  255 209 102;/*  #ffd166                            */
+  --color-spectrum-rose:   255  92 138;/*  #ff5c8a                            */
+
+  /* Semantic — single source of meaning, mapped to the spectrum. */
+  --color-accent: var(--color-spectrum-violet);
+  --color-success: var(--color-spectrum-mint);
+  --color-warning: var(--color-spectrum-amber);
+  --color-danger: var(--color-spectrum-rose);
+
+  /* Type — system stack first to avoid web-font flash; mono for addresses. */
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Code",
+    "Roboto Mono", "Courier New", monospace;
+
+  /* Type scale — Tailwind-aligned with a `display` step for hero numbers. */
+  --text-xs: 0.75rem;       /* 12px */
+  --text-sm: 0.875rem;      /* 14px */
+  --text-base: 1rem;        /* 16px */
+  --text-lg: 1.125rem;      /* 18px */
+  --text-xl: 1.25rem;       /* 20px */
+  --text-2xl: 1.5rem;       /* 24px */
+  --text-3xl: 1.875rem;     /* 30px */
+  --text-display: 2.5rem;   /* 40px — vault TVL / yield numbers */
+
+  /* Radii. */
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-xl: 18px;
+  --radius-2xl: 24px;
+  --radius-pill: 9999px;
+
+  /* Shadows — flat by default, glowing only on accent state. */
+  --shadow-card: 0 1px 0 rgb(255 255 255 / 0.02), 0 8px 24px rgb(0 0 0 / 0.32);
+  --shadow-popover: 0 12px 40px rgb(0 0 0 / 0.45);
+  --shadow-glow-violet: 0 0 32px rgb(124 92 255 / 0.35);
+  --shadow-glow-mint:   0 0 32px rgb(62 255 155 / 0.30);
+  --shadow-glow-rose:   0 0 32px rgb(255 92 138 / 0.30);
+
+  /* Motion — kept minimal; UI is finance-sober, not playful. */
+  --motion-fast: 120ms;
+  --motion-base: 200ms;
+  --motion-slow: 360ms;
+  --easing-standard: cubic-bezier(0.2, 0.7, 0.2, 1);
+}

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,5 +1,10 @@
 import type {Config} from "tailwindcss";
 
+// PRISM theme — sources values from app/tokens.css via CSS custom properties.
+// The `<alpha-value>` placeholder lets Tailwind's `bg-canvas/80`, `text-text-muted/60`,
+// etc. work alongside the variables.
+const rgb = (varName: string) => `rgb(var(${varName}) / <alpha-value>)`;
+
 const config: Config = {
   // PRISM is dark-only; the `dark` class is applied to <html> in
   // `app/layout.tsx`. Class strategy keeps SSR predictable.
@@ -7,9 +12,70 @@ const config: Config = {
   content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
   theme: {
     extend: {
-      // Real brand tokens land in #1 (apps/web/styles/tokens.css /
-      // tailwind theme extend). This file ships with empty extends
-      // so #1 can drop them in without churn.
+      colors: {
+        canvas: rgb("--color-canvas"),
+        surface: rgb("--color-surface"),
+        "surface-raised": rgb("--color-surface-raised"),
+        border: rgb("--color-border"),
+        "border-strong": rgb("--color-border-strong"),
+        text: rgb("--color-text"),
+        "text-muted": rgb("--color-text-muted"),
+        "text-faint": rgb("--color-text-faint"),
+        spectrum: {
+          violet: rgb("--color-spectrum-violet"),
+          indigo: rgb("--color-spectrum-indigo"),
+          teal: rgb("--color-spectrum-teal"),
+          mint: rgb("--color-spectrum-mint"),
+          amber: rgb("--color-spectrum-amber"),
+          rose: rgb("--color-spectrum-rose"),
+        },
+        accent: rgb("--color-accent"),
+        success: rgb("--color-success"),
+        warning: rgb("--color-warning"),
+        danger: rgb("--color-danger"),
+      },
+      fontFamily: {
+        sans: "var(--font-sans)",
+        mono: "var(--font-mono)",
+      },
+      fontSize: {
+        xs: "var(--text-xs)",
+        sm: "var(--text-sm)",
+        base: "var(--text-base)",
+        lg: "var(--text-lg)",
+        xl: "var(--text-xl)",
+        "2xl": "var(--text-2xl)",
+        "3xl": "var(--text-3xl)",
+        display: "var(--text-display)",
+      },
+      borderRadius: {
+        sm: "var(--radius-sm)",
+        md: "var(--radius-md)",
+        lg: "var(--radius-lg)",
+        xl: "var(--radius-xl)",
+        "2xl": "var(--radius-2xl)",
+        pill: "var(--radius-pill)",
+      },
+      boxShadow: {
+        card: "var(--shadow-card)",
+        popover: "var(--shadow-popover)",
+        "glow-violet": "var(--shadow-glow-violet)",
+        "glow-mint": "var(--shadow-glow-mint)",
+        "glow-rose": "var(--shadow-glow-rose)",
+      },
+      transitionDuration: {
+        fast: "var(--motion-fast)",
+        base: "var(--motion-base)",
+        slow: "var(--motion-slow)",
+      },
+      transitionTimingFunction: {
+        standard: "var(--easing-standard)",
+      },
+      backgroundImage: {
+        // Hero gradient — the prism refraction itself.
+        "spectrum-arc":
+          "linear-gradient(135deg, rgb(var(--color-spectrum-violet)) 0%, rgb(var(--color-spectrum-indigo)) 25%, rgb(var(--color-spectrum-teal)) 50%, rgb(var(--color-spectrum-mint)) 75%, rgb(var(--color-spectrum-amber)) 100%)",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary

Establishes the visual foundation before app-shell work lands in #47. Tokens live as CSS custom properties (consumable by non-Tailwind CSS), and Tailwind's `theme.extend` references them via `rgb(var(--token) / <alpha-value>)` so utility-with-alpha (`bg-canvas/80`) keeps working.

**Palette** — prism refraction metaphor:
- Canvas: `#0c0a14`, surface `#15121f`, raised `#1e1a2c`
- Text: cream `#ebe5d5` → muted lavender `#9890b0` → faint `#696382`
- Spectrum (violet→indigo→teal→mint→amber→rose) — 6 stops
- Semantic: accent=violet, success=mint, warning=amber, danger=rose

**Other tokens:**
- Type scale: `xs` → `3xl` plus `display` (40px) for hero numbers; system sans + mono stacks
- Radii: `sm` (6px) → `2xl` (24px) + `pill`
- Shadows: `card`, `popover`, plus accent glows (`glow-violet`, `glow-mint`, `glow-rose`)
- Motion: `fast`/`base`/`slow` durations + `standard` easing
- Bonus: `bg-spectrum-arc` gradient utility (the prism arc itself)

## Files

- `apps/web/app/tokens.css` — all CSS custom properties
- `apps/web/tailwind.config.ts` — `theme.extend` wiring + gradient utility
- `apps/web/app/globals.css` — imports tokens, system font, spectrum-violet selection color

## Quality gates

- `pnpm --filter @prism/web typecheck` → pass
- `pnpm --filter @prism/web build` → pass (Next 14 production build)

## Test plan

- [x] tokens compile + build cleanly
- [x] alpha-modifier syntax (`bg-canvas/80`) works
- [ ] visual spot-check via `next dev` once app shell #47 lands

## Dependencies

- Stacked on #46 (frontend/46-export-abis). Merge order: #43 → #44 → #45 → #46 → #1.
- Unblocks #47 (app shell consumes the tokens directly).

Closes #1