### PR TITLE
feat(frontend): app shell + error boundaries (#47)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,0 +1,119 @@
+name: web
+
+on:
+  pull_request:
+    paths:
+      - "apps/web/**"
+      - "packages/shared/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/web.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/web/**"
+      - "packages/shared/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/web.yml"
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: "20"
+  PNPM_VERSION: "10.18.0"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # -------------------------------------------------------------------------
+  # typecheck + lint + build
+  #
+  # Single job — these are fast (<60s combined) and share the same
+  # node_modules, so paying the install cost once is cheaper than
+  # parallelising into three jobs each with its own install.
+  #
+  # Playwright lives in a separate job because it needs the production
+  # build artefact and a browser install.
+  # -------------------------------------------------------------------------
+  typecheck-lint-build:
+    name: typecheck · lint · build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck shared
+        run: pnpm --filter @prism/shared typecheck
+
+      - name: Typecheck web
+        run: pnpm --filter @prism/web typecheck
+
+      - name: Lint web
+        run: pnpm --filter @prism/web lint
+
+      - name: Build web
+        run: pnpm --filter @prism/web build
+        env:
+          # Required by RainbowKit/wagmi for build-time WC project init.
+          # Use a placeholder; tests / Playwright run with real values.
+          NEXT_PUBLIC_WC_PROJECT_ID: PRISM_CI_PLACEHOLDER
+
+  # -------------------------------------------------------------------------
+  # Playwright E2E
+  #
+  # Issue #67 (happy path) and #68 (error paths) populate the spec
+  # files; until those land, this job runs `playwright test` against an
+  # empty suite which exits 0. Keeping the job in CI now means
+  # spec-adding PRs don't have to wire CI in the same change.
+  # -------------------------------------------------------------------------
+  playwright:
+    name: playwright e2e
+    runs-on: ubuntu-latest
+    needs: typecheck-lint-build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Playwright (skipped until #67 lands)
+        run: |
+          if [ -d "apps/web/tests-e2e" ]; then
+            pnpm --filter @prism/web exec playwright install --with-deps chromium
+            pnpm --filter @prism/web exec playwright test
+          else
+            echo "No Playwright suite yet — see #67."
+          fi

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import {useEffect} from "react";
+
+// Route-level error boundary. Caught errors render this page inside the
+// app shell (Header + Footer remain mounted). Uncaught errors during the
+// initial render bubble up to global-error.tsx instead.
+export default function RouteError({
+  error,
+  reset,
+}: {
+  error: Error & {digest?: string};
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Surface during dev; replace with a real telemetry sink (Sentry, etc.)
+    // when telemetry lands.
+    console.error("[prism] route error", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-start gap-4 py-12">
+      <span className="inline-flex items-center gap-2 rounded-pill border border-danger/40 bg-danger/10 px-3 py-1 text-xs text-danger">
+        <span className="h-1.5 w-1.5 rounded-pill bg-danger" />
+        Something went wrong
+      </span>
+      <h1 className="text-2xl font-semibold tracking-tight text-text">
+        We couldn&apos;t load this page
+      </h1>
+      <p className="max-w-prose text-sm text-text-muted">
+        {error.message || "An unexpected error occurred while rendering."}
+        {error.digest ? <span className="ml-2 font-mono text-xs text-text-faint">[{error.digest}]</span> : null}
+      </p>
+      <button
+        type="button"
+        onClick={reset}
+        className="mt-2 rounded-md border border-border-strong bg-surface px-4 py-2 text-sm text-text transition-colors duration-fast ease-standard hover:bg-surface-raised"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+// Root-level error boundary. Renders only when the root layout itself
+// fails (i.e. something below <Providers> threw before the AppShell could
+// mount). Must define its own <html>/<body> because Next replaces the root.
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & {digest?: string};
+  reset: () => void;
+}) {
+  return (
+    <html lang="en" className="dark">
+      <body
+        style={{
+          background: "#0c0a14",
+          color: "#ebe5d5",
+          minHeight: "100vh",
+          margin: 0,
+          fontFamily:
+            "ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "2rem",
+        }}
+      >
+        <div style={{maxWidth: 480}}>
+          <h1 style={{fontSize: 24, fontWeight: 600, marginBottom: 12}}>
+            PRISM failed to start
+          </h1>
+          <p style={{color: "#9890b0", fontSize: 14, marginBottom: 16}}>
+            {error.message || "An unexpected error occurred."}
+            {error.digest ? <span style={{marginLeft: 8, fontFamily: "ui-monospace, monospace", fontSize: 12, color: "#696382"}}>[{error.digest}]</span> : null}
+          </p>
+          <button
+            type="button"
+            onClick={reset}
+            style={{
+              background: "#15121f",
+              color: "#ebe5d5",
+              border: "1px solid #352d4e",
+              padding: "8px 16px",
+              borderRadius: 10,
+              fontSize: 14,
+              cursor: "pointer",
+            }}
+          >
+            Reload
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,8 @@
 import type {Metadata} from "next";
 import type {ReactNode} from "react";
 
+import {AppShell} from "@/components/AppShell";
+
 import "./globals.css";
 import {Providers} from "./providers";
 
@@ -17,7 +19,9 @@ export default function RootLayout({children}: {children: ReactNode}) {
   return (
     <html lang="en" className="dark">
       <body className="min-h-screen antialiased">
-        <Providers>{children}</Providers>
+        <Providers>
+          <AppShell>{children}</AppShell>
+        </Providers>
       </body>
     </html>
   );

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-start gap-4 py-12">
+      <span className="inline-flex items-center gap-2 rounded-pill border border-border bg-surface/60 px-3 py-1 text-xs text-text-muted">
+        404
+      </span>
+      <h1 className="text-2xl font-semibold tracking-tight text-text">
+        Page not found
+      </h1>
+      <p className="max-w-prose text-sm text-text-muted">
+        The page you&apos;re looking for doesn&apos;t exist yet — or it lives
+        somewhere else now.
+      </p>
+      <Link
+        href="/"
+        className="mt-2 rounded-md border border-border-strong bg-surface px-4 py-2 text-sm text-text transition-colors duration-fast ease-standard hover:bg-surface-raised"
+      >
+        Back home
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,19 +1,35 @@
-/**
- * Placeholder landing page — proves the scaffold renders end-to-end.
- *
- * #47 replaces this with the full app shell (header + nav + footer +
- * error boundary) once the design tokens (#1) and providers (#44)
- * are in place.
- */
 export default function HomePage() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-6 px-6 text-center">
-      <h1 className="text-4xl font-semibold tracking-tight">PRISM</h1>
-      <p className="max-w-prose text-lg opacity-80">
-        Permissionless automated liquidity management on Uniswap V4. One LP deposit refracted into N tick-range
-        positions.
-      </p>
-      <p className="text-sm opacity-50">App shell + wallet connect coming online in subsequent issues.</p>
-    </main>
+    <div className="flex flex-col items-start gap-10 py-12">
+      <header className="flex flex-col gap-4">
+        <span className="inline-flex items-center gap-2 rounded-pill border border-border bg-surface/60 px-3 py-1 text-xs text-text-muted">
+          <span className="h-1.5 w-1.5 rounded-pill bg-spectrum-mint" />
+          Base Sepolia testnet
+        </span>
+        <h1 className="bg-spectrum-arc bg-clip-text text-display font-semibold tracking-tight text-transparent">
+          PRISM
+        </h1>
+        <p className="max-w-2xl text-lg text-text-muted">
+          Permissionless automated liquidity management on Uniswap V4. One LP
+          deposit, refracted into N tick-range positions — rebalanced on
+          volatility, paid for by MEV.
+        </p>
+      </header>
+
+      <section className="grid w-full grid-cols-1 gap-4 md:grid-cols-3">
+        <Card title="Vaults" body="Create or deposit into permissionless ALM vaults. Coming online with M2." />
+        <Card title="Rebalances" body="Trigger and watch on-chain rebalances. Surface lands with M3." />
+        <Card title="MEV-funded" body="Hook captures arb deltas at every swap and routes them back to LPs." />
+      </section>
+    </div>
+  );
+}
+
+function Card({title, body}: {title: string; body: string}) {
+  return (
+    <article className="rounded-xl border border-border bg-surface p-5 shadow-card transition-shadow duration-base ease-standard hover:shadow-glow-violet">
+      <h3 className="mb-2 text-sm font-medium text-text">{title}</h3>
+      <p className="text-sm text-text-muted">{body}</p>
+    </article>
   );
 }

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -9,6 +9,16 @@ import {WagmiProvider} from "wagmi";
 
 import {wagmiConfig} from "@/lib/wagmi";
 
+// PRISM-themed RainbowKit modal — keeps wallet UI visually consistent with
+// the brand-token palette defined in app/tokens.css.
+const prismRainbowTheme = darkTheme({
+  accentColor: "#7c5cff", // --color-spectrum-violet
+  accentColorForeground: "#0c0a14", // --color-canvas (high contrast on violet)
+  borderRadius: "medium",
+  fontStack: "system",
+  overlayBlur: "small",
+});
+
 /**
  * Top-level web3 provider tree.
  *
@@ -27,7 +37,7 @@ export function Providers({children}: {children: ReactNode}) {
   return (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
-        <RainbowKitProvider theme={darkTheme()} modalSize="compact">
+        <RainbowKitProvider theme={prismRainbowTheme} modalSize="compact">
           {children}
         </RainbowKitProvider>
       </QueryClientProvider>

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -2,11 +2,13 @@ import type {ReactNode} from "react";
 
 import {Footer} from "./Footer";
 import {Header} from "./Header";
+import {WrongNetworkBanner} from "./WrongNetworkBanner";
 
 export function AppShell({children}: {children: ReactNode}) {
   return (
     <div className="flex min-h-screen flex-col">
       <Header />
+      <WrongNetworkBanner />
       <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-8">{children}</main>
       <Footer />
     </div>

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -1,0 +1,14 @@
+import type {ReactNode} from "react";
+
+import {Footer} from "./Footer";
+import {Header} from "./Header";
+
+export function AppShell({children}: {children: ReactNode}) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-8">{children}</main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/web/components/Footer.tsx
+++ b/apps/web/components/Footer.tsx
@@ -1,0 +1,26 @@
+export function Footer() {
+  return (
+    <footer className="mt-auto border-t border-border bg-canvas/60">
+      <div className="mx-auto flex max-w-6xl flex-col items-start justify-between gap-2 px-4 py-6 text-xs text-text-muted md:flex-row md:items-center">
+        <p>
+          PRISM v0.0.0 — Base Sepolia testnet only. Mainnet release gated on
+          M5 audit.
+        </p>
+        <div className="flex items-center gap-4">
+          <a
+            href="https://github.com/ozpool/prism"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="transition-colors duration-fast ease-standard hover:text-text"
+          >
+            GitHub
+          </a>
+          <span aria-hidden className="opacity-50">
+            •
+          </span>
+          <span>BUSL-1.1</span>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/apps/web/components/Header.tsx
+++ b/apps/web/components/Header.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import {Logo} from "./Logo";
+import {Nav} from "./Nav";
+
+// RainbowKit's ConnectButton calls wagmi hooks at render time, which trips
+// Next 14's static prerender (no WagmiProvider context yet, no indexedDB).
+// Loading it client-only sidesteps prerender entirely; the button slot
+// remains empty until hydration, which is the right UX for wallet UI.
+const ConnectButton = dynamic(
+  () => import("@rainbow-me/rainbowkit").then((m) => m.ConnectButton),
+  {ssr: false},
+);
+
+export function Header() {
+  return (
+    <header className="sticky top-0 z-40 border-b border-border bg-canvas/80 backdrop-blur-md">
+      <div className="mx-auto flex h-14 max-w-6xl items-center justify-between gap-4 px-4">
+        <div className="flex items-center gap-8">
+          <Logo />
+          <Nav />
+        </div>
+        <ConnectButton accountStatus="address" chainStatus="icon" showBalance={false} />
+      </div>
+    </header>
+  );
+}

--- a/apps/web/components/Logo.tsx
+++ b/apps/web/components/Logo.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export function Logo({className = ""}: {className?: string}) {
+  return (
+    <Link
+      href="/"
+      className={`group inline-flex items-center gap-2 ${className}`}
+      aria-label="PRISM home"
+    >
+      <span
+        aria-hidden
+        className="h-5 w-5 rounded-md bg-spectrum-arc shadow-glow-violet transition-shadow duration-base ease-standard group-hover:shadow-glow-mint"
+      />
+      <span className="bg-spectrum-arc bg-clip-text text-lg font-semibold tracking-tight text-transparent">
+        PRISM
+      </span>
+    </Link>
+  );
+}

--- a/apps/web/components/Nav.tsx
+++ b/apps/web/components/Nav.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from "next/link";
+import {usePathname} from "next/navigation";
+
+const LINKS = [
+  {href: "/", label: "Vaults"},
+  {href: "/rebalances", label: "Rebalances"},
+  {href: "/docs", label: "Docs"},
+] as const;
+
+export function Nav() {
+  const pathname = usePathname();
+  return (
+    <nav aria-label="Primary" className="hidden md:block">
+      <ul className="flex items-center gap-6 text-sm">
+        {LINKS.map(({href, label}) => {
+          const active = pathname === href || (href !== "/" && pathname.startsWith(href));
+          return (
+            <li key={href}>
+              <Link
+                href={href}
+                className={`transition-colors duration-fast ease-standard ${
+                  active ? "text-text" : "text-text-muted hover:text-text"
+                }`}
+                aria-current={active ? "page" : undefined}
+              >
+                {label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/apps/web/components/TxErrorToast.tsx
+++ b/apps/web/components/TxErrorToast.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import {useEffect} from "react";
+
+import {classifyTxError, type TxError} from "@/lib/tx-errors";
+
+type Props = {
+  error: unknown;
+  onDismiss: () => void;
+};
+
+const TITLES: Record<TxError["kind"], string> = {
+  rejected: "Rejected",
+  "insufficient-funds": "Insufficient funds",
+  "wrong-network": "Wrong network",
+  rpc: "RPC error",
+  unknown: "Transaction failed",
+};
+
+/**
+ * Inline toast-style banner for failed transactions.
+ *
+ * v1.0 surfaces tx errors inline next to the form rather than via a
+ * global toast portal — that lands with #4 component library
+ * (Sonner-backed). For now this is a self-contained, dismissable card
+ * that classifies the error into one of five tiers via tx-errors.ts.
+ */
+export function TxErrorToast({error, onDismiss}: Props) {
+  const classified = classifyTxError(error);
+
+  // Auto-dismiss user-rejection errors after 5s — they're not actionable.
+  // Other classes persist until manual dismiss; per design spec
+  // (component-library.md), error toasts must not vanish before reading.
+  useEffect(() => {
+    if (classified.kind !== "rejected") return;
+    const id = setTimeout(onDismiss, 5_000);
+    return () => clearTimeout(id);
+  }, [classified.kind, onDismiss]);
+
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-3 rounded-lg border border-danger/40 bg-danger/10 p-4 text-sm"
+    >
+      <span aria-hidden className="mt-0.5 h-2 w-2 flex-shrink-0 rounded-pill bg-danger" />
+      <div className="flex-1">
+        <p className="font-medium text-danger">{TITLES[classified.kind]}</p>
+        <p className="mt-1 text-text-muted">{classified.message}</p>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        className="text-text-faint transition-colors duration-fast ease-standard hover:text-text"
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
+          <path d="M1 1l12 12M13 1L1 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/apps/web/components/WrongNetworkBanner.tsx
+++ b/apps/web/components/WrongNetworkBanner.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import {useEffect, useState} from "react";
+import {useAccount, useSwitchChain} from "wagmi";
+import {baseSepolia} from "wagmi/chains";
+
+const EXPECTED_CHAIN_ID = baseSepolia.id; // 84_532
+
+/**
+ * Sticky banner shown when a connected wallet is on the wrong chain.
+ *
+ * v1.0 supports Base Sepolia only. Mainnet (Base, 8453) is gated on
+ * audit completion (M5) — even Base mainnet is treated as "wrong
+ * network" until then so users don't accidentally interact with
+ * non-existent contracts.
+ *
+ * The banner gates wagmi hook usage behind a useMounted guard so the
+ * Next 14 static prerender doesn't try to read indexedDB or wagmi
+ * context (neither exists during export).
+ */
+export function WrongNetworkBanner() {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+  return <WrongNetworkBannerInner />;
+}
+
+function WrongNetworkBannerInner() {
+  const {isConnected, chainId} = useAccount();
+  const {switchChain, isPending: isSwitching} = useSwitchChain();
+
+  if (!isConnected) return null;
+  if (chainId === EXPECTED_CHAIN_ID) return null;
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="border-b border-warning/40 bg-warning/10 px-4 py-2 text-sm"
+    >
+      <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-2">
+        <span className="text-warning">
+          Wrong network — PRISM v1.0 runs on Base Sepolia (chain {EXPECTED_CHAIN_ID}).
+        </span>
+        <button
+          type="button"
+          onClick={() => switchChain({chainId: EXPECTED_CHAIN_ID})}
+          disabled={isSwitching}
+          className="rounded-md border border-warning/60 bg-warning/20 px-3 py-1 text-xs text-warning transition-colors duration-fast ease-standard hover:bg-warning/30 disabled:opacity-60"
+        >
+          {isSwitching ? "Switching…" : "Switch network"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/tx-errors.ts
+++ b/apps/web/lib/tx-errors.ts
@@ -1,0 +1,39 @@
+import {BaseError, UserRejectedRequestError} from "viem";
+
+export type TxError =
+  | {kind: "rejected"; message: string}
+  | {kind: "insufficient-funds"; message: string}
+  | {kind: "wrong-network"; message: string}
+  | {kind: "rpc"; message: string}
+  | {kind: "unknown"; message: string};
+
+const INSUFFICIENT_FUNDS_RE = /insufficient (funds|balance)/i;
+const WRONG_NETWORK_RE = /chain.*mismatch|unsupported chain|wrong network/i;
+
+export function classifyTxError(err: unknown): TxError {
+  if (err instanceof UserRejectedRequestError) {
+    return {kind: "rejected", message: "Transaction was rejected in your wallet."};
+  }
+
+  if (err instanceof BaseError) {
+    const walked = err.walk((e) => e instanceof UserRejectedRequestError);
+    if (walked instanceof UserRejectedRequestError) {
+      return {kind: "rejected", message: "Transaction was rejected in your wallet."};
+    }
+
+    const shortMsg = err.shortMessage ?? err.message;
+    if (INSUFFICIENT_FUNDS_RE.test(shortMsg)) {
+      return {kind: "insufficient-funds", message: shortMsg};
+    }
+    if (WRONG_NETWORK_RE.test(shortMsg)) {
+      return {kind: "wrong-network", message: shortMsg};
+    }
+    return {kind: "rpc", message: shortMsg};
+  }
+
+  if (err instanceof Error) {
+    return {kind: "unknown", message: err.message};
+  }
+
+  return {kind: "unknown", message: "An unexpected error occurred."};
+}


### PR DESCRIPTION
## Summary

Persistent chrome around every page — header (logo + nav + wallet connect), footer, and route-level + root-level error boundaries. Consumes brand tokens from #1 and providers from #44; the home page is themed up to demonstrate the tokens in context.

### Components
- `AppShell` — flex layout: sticky header, scrollable main (max-w-6xl), footer pinned to bottom
- `Header` — sticky, `bg-canvas/80 backdrop-blur-md`. **RainbowKit `ConnectButton` is dynamically imported with `ssr: false`** to sidestep prerender-time wagmi context misses (otherwise Next 14 throws `WagmiProviderNotFoundError` during static export)
- `Logo` — spectrum-arc gradient text + glow chip; hover transitions glow from violet to mint
- `Nav` — client component, `usePathname()` for active highlighting
- `Footer` — version notice (Base Sepolia testnet only), GitHub link, BUSL-1.1

### App routes
- `app/layout.tsx` — wraps children in `<AppShell>`
- `app/providers.tsx` — PRISM-themed RainbowKit (`accentColor = #7c5cff`, `accentColorForeground = #0c0a14` for contrast)
- `app/page.tsx` — hero + 3-card teaser grid using brand tokens
- `app/error.tsx` — route-level boundary with reset action + console log (telemetry sink TBD)
- `app/global-error.tsx` — root-level fatal boundary. Inlines styles (must define its own `<html>/<body>` since it replaces the root)
- `app/not-found.tsx` — themed 404

## Quality gates

- `pnpm --filter @prism/web typecheck` → pass
- `pnpm --filter @prism/web lint` → no warnings/errors
- `pnpm --filter @prism/web build` → pass (static prerender; wallet code hydrates on client only)

## Test plan

- [x] Typecheck, lint, build all green
- [x] Production build prerenders both routes
- [ ] Visual spot-check via `pnpm --filter @prism/web dev` (header sticks on scroll, gradient logo, nav active states, mobile responsive collapse, ConnectButton modal)
- [ ] Trigger /error route to verify boundary

> **Reviewer note:** I did not run a browser for visual verification in this environment. Please confirm header rendering, gradient text, and ConnectButton modal in the browser before merge.

## Dependencies

- Stacked on #1 (design/1-brand-tokens). Merge order: #43 → #44 → #45 → #46 → #1 → #47.

Closes #47