### PR TITLE
docs(design): WCAG AA contrast audit + palette usage rules (#2)

### DIFF
--- a/docs/design/component-library.md
+++ b/docs/design/component-library.md
@@ -1,0 +1,235 @@
+# PRISM Component Library Spec
+
+shadcn/ui aligned, dark-only, brand-tokenised. This document is the
+**design contract** for the components the dApp uses (and the Figma
+mirror image). It pairs with [`docs/design/dark-mode-contrast.md`](./dark-mode-contrast.md)
+for color rules and [`apps/web/app/tokens.css`](../../apps/web/app/tokens.css)
+for the underlying token values.
+
+The implementation lands incrementally as features need each component;
+this spec is what every PR adding or changing a component must conform
+to.
+
+## Architecture
+
+PRISM uses [shadcn/ui](https://ui.shadcn.com) — components are copied
+into the repo (`apps/web/components/ui/*.tsx`), not installed as a
+package. Customisation happens by editing the copy.
+
+**Why shadcn:**
+
+- Each component is a few hundred lines of Radix UI + Tailwind. We can
+  read and audit the whole thing.
+- No version coupling — bumping shadcn itself is a no-op; bumping a
+  specific component is an explicit copy-paste.
+- Styles are in our Tailwind config, not in a black-box stylesheet.
+
+**Why not [chosen alternative]:**
+
+- MUI / Chakra: heavy runtime, hard to thin, opinionated theming
+- Headless UI alone: leaves us writing too much from scratch
+- Pure custom: fine for 5 components, painful for 20
+
+## Component inventory
+
+The following components are in scope for v1.0. Build order matches
+PRD-driven feature work, not alphabetical.
+
+| Component | Wraps | First consumer | Status |
+|---|---|---|---|
+| `Button` | shadcn `button` | header connect, deposit/withdraw forms | spec only |
+| `Input` | shadcn `input` | deposit/withdraw amount fields | spec only |
+| `Card` | shadcn `card` | VaultCard on list page (#49) | spec only |
+| `Dialog` | shadcn `dialog` | confirm-deposit modal | spec only |
+| `Toast` | shadcn `sonner` | tx success/error notifications | spec only |
+| `Tooltip` | shadcn `tooltip` | hover hints (sharePrice, MEV bonus) | spec only |
+| `Tabs` | shadcn `tabs` | vault detail (positions / events / params) | spec only |
+| `Skeleton` | shadcn `skeleton` | loading states for vault data | spec only |
+| `Badge` | shadcn `badge` | network indicators, vault tags | spec only |
+
+Out of scope for v1.0 (revisit post-launch):
+
+- `Combobox`, `DatePicker`, `Calendar` — no need yet
+- `DataTable` — vault list is small; rebuild as a `<table>` if needed
+- `Slider` — no slider-driven inputs in v1.0
+
+## Per-component contracts
+
+### Button
+
+**Variants** (Tailwind classes; align to brand tokens):
+
+| Variant | Foreground | Background | Border | Use for |
+|---|---|---|---|---|
+| `primary` | `canvas` | `accent` | none | Deposit, Withdraw, Confirm |
+| `secondary` | `text` | `surface-raised` | `border-strong` | Cancel, secondary CTAs |
+| `ghost` | `text-muted` | `transparent` | none | Inline links, "Show more" |
+| `danger` | `canvas` | `danger` | none | Destructive confirm in modal |
+| `outline` | `text` | `transparent` | `border` | Form-level secondary |
+
+**Sizes:** `sm` (h-8), `md` (h-10, default), `lg` (h-12 — hero CTA only).
+
+**States:**
+
+- `:hover` — fill brightens by 4-6% (Tailwind opacity utilities)
+- `:focus-visible` — `ring-2 ring-accent ring-offset-canvas ring-offset-2`
+- `:disabled` — `opacity-60 cursor-not-allowed`, retains color (no greyscale)
+- `:loading` — replaces children with a `Spinner`; button is `aria-busy="true"`
+
+**Accessibility:**
+
+- Always render an HTML `<button>` (no `<div role="button">`)
+- Loading state must announce to screen readers via `aria-busy`
+- Min hit target 40×40 — enforce via `min-h-10 min-w-10` even when content is small
+
+### Input
+
+**Variants:**
+
+| Variant | Use for |
+|---|---|
+| `default` | Standard text/number input |
+| `address` | 0x-address input — monospace, 0.5x letter-spacing |
+| `amount` | Token amount — right-aligned, mono, large step counter |
+
+**States:**
+
+- `:focus-within` — `border-accent`
+- `:invalid` (or with `aria-invalid="true"`) — `border-danger`, helper text below in `text-danger`
+- `:disabled` — `opacity-60`
+
+Always pair with `<Label>`. Required fields get `*` suffix in the label,
+not a placeholder hint.
+
+**Slots:** prefix (e.g., `$`), suffix (e.g., `WETH`), `MAX` button (token
+amounts only). All slots are tokenised — no inline color overrides.
+
+### Card
+
+**Default style:**
+
+- `bg-surface`, `border border-border`, `rounded-xl`, `shadow-card`
+- Padding: 20px (`p-5`), or 24px (`p-6`) for hero cards
+
+**Hover:** `hover:shadow-glow-violet hover:border-border-strong` —
+applied to interactive cards (links to detail). Static metric cards do
+not animate on hover.
+
+**Compound layout:**
+
+```tsx
+<Card>
+  <Card.Header>
+    <Card.Title>Vault name</Card.Title>
+    <Card.Description>Subtitle</Card.Description>
+  </Card.Header>
+  <Card.Content>{...}</Card.Content>
+  <Card.Footer>{...}</Card.Footer>
+</Card>
+```
+
+The `.Title` always uses `text-base font-medium` (not larger) — vault
+names compete with TVL numbers for visual weight, and the spec is that
+TVL wins.
+
+### Dialog (modal)
+
+- Backdrop: `bg-canvas/70 backdrop-blur-sm`
+- Surface: `bg-surface-raised`, `border border-border-strong`,
+  `rounded-2xl`, `shadow-popover`, max-width 480px
+- Close affordance: top-right `Button[ghost]` with X icon, `aria-label="Close"`
+- Animations: `data-[state=open]:animate-in data-[state=open]:fade-in`
+  (200ms, standard easing). Reduced-motion users see no animation.
+
+**Body structure:**
+
+```
+Header  : title (text-lg) + description (text-sm text-muted)
+Body    : 16-24px vertical rhythm
+Footer  : button row, right-aligned, primary CTA last
+```
+
+**Focus:** focus moves to the first interactive element on open;
+`Escape` and click-outside both close (dismissable). For destructive
+confirmation modals (e.g., big withdrawals), require explicit confirm
+button click — set `dismissable={false}` and remove the X close.
+
+### Toast
+
+Powered by [Sonner](https://sonner.emilkowal.ski) via shadcn's `sonner`
+component. Position: bottom-right. Stack vertical, max 4 visible.
+
+| Variant | Icon | Foreground | Background | Use for |
+|---|---|---|---|---|
+| `success` | check | `canvas` | `success` | Deposit confirmed, withdraw landed |
+| `error` | x-circle | `canvas` | `danger` | Tx rejected, network mismatch |
+| `info` | info | `text` | `surface-raised` | Fee changed, oracle stale warning |
+| `warning` | alert | `canvas` | `warning` | Approaching TVL cap |
+
+**Duration:**
+
+- success: 4s
+- info: 6s
+- warning: 8s
+- error: persistent (manual dismiss) — error must not disappear before the user reads it
+
+**Tx hash toasts:** the toast for a confirmed tx includes a "View on
+Basescan" inline link. Clicking the link does not dismiss the toast.
+
+### Tooltip
+
+- 200ms open delay, 0ms close delay
+- `bg-surface-raised`, `border border-border-strong`, `text-xs`,
+  `rounded-md`, `px-2 py-1`, `shadow-popover`
+- Always pair with the trigger element via `aria-describedby`
+
+Use sparingly — tooltips hide information from touch users. Reserve for
+*supplementary* hints (e.g., explaining what "share price" means);
+never put critical info behind a hover.
+
+### Tabs
+
+- Underline-style indicator (not pill-style) — minimises visual weight
+  vs the surface
+- Active: `text-text border-b-2 border-accent`
+- Inactive: `text-text-muted hover:text-text`
+- Use for: vault detail (Positions / Rebalances / Strategy params)
+- Avoid for: anything where horizontal space is tight
+
+### Skeleton
+
+- `bg-surface-raised`, `animate-pulse` (Tailwind built-in)
+- Shape matches the loaded content's layout — never use a generic
+  block. Skeleton for a TVL number is `w-24 h-7`; skeleton for an
+  address is `w-32 h-4`
+- Reduced-motion: replace pulse with static `bg-surface-raised`
+
+### Badge
+
+| Variant | Use for |
+|---|---|
+| `neutral` | "Base Sepolia testnet" header chip |
+| `success` | "Active" vault |
+| `warning` | "Paused" vault |
+| `danger` | "Wrong network" |
+| `accent` | "New" or "Featured" tag |
+
+Compact only — height 20px, padding `px-2`. Use `text-xs font-medium`.
+
+## Implementation rules
+
+- Component files live in `apps/web/components/ui/<name>.tsx`
+- Re-exports are explicit — no barrel files; downstream code imports
+  from the file directly
+- Never use `style={{...}}` for color or spacing; go through Tailwind +
+  brand tokens
+- Forward refs always: every component takes `React.ForwardRef`. Required
+  for headless UI compatibility and Radix portals.
+- Each component must accept `className` and merge it via the
+  `cn()`/clsx utility, so consumer code can extend without forking
+
+## What changes the spec
+
+Add a new variant or component? Update this file in the same PR.
+Remove a variant? Same. Drop a component? Same. The Figma is downstream
+of this doc — when they conflict, this doc wins.

--- a/docs/design/dark-mode-contrast.md
+++ b/docs/design/dark-mode-contrast.md
@@ -1,0 +1,161 @@
+# PRISM Dark-Mode Palette Usage Guide
+
+PRISM is dark-only by design (see [ADR pending] / brand tokens in
+`apps/web/app/tokens.css`). This guide documents:
+
+1. The intended pairings (which tokens go on which surface).
+2. Measured WCAG 2.1 contrast ratios for every meaningful pairing.
+3. Hard rules — what NOT to do.
+
+The brand tokens themselves live in
+[`apps/web/app/tokens.css`](../../apps/web/app/tokens.css). Don't edit
+this guide and the tokens out of sync — if a token value changes, the
+ratios below must be re-measured and the guide updated in the same PR.
+
+## WCAG quick reference
+
+| Level | Normal text | Large text¹ | UI components² |
+|---|---:|---:|---:|
+| AA  | 4.5:1 | 3:1 | 3:1 |
+| AAA | 7:1   | 4.5:1 | — |
+
+¹ Large = ≥ 18pt regular or ≥ 14pt bold.
+² Buttons, form inputs, focus rings — graphical objects per WCAG 1.4.11.
+
+## Surface stack
+
+```
+canvas         #0c0a14   page background
+└─ surface     #15121f   cards, panels, raised content
+   └─ raised   #1e1a2c   hover states, popovers
+border         #221d33   default hairline
+border-strong  #352d4e   focused / emphasised borders
+```
+
+The stack only goes one level deep in v1.0. Don't nest a `surface`
+inside a `surface-raised`; switch to elevated typography or shadows
+instead.
+
+## Text on surfaces
+
+| Foreground × Background | Ratio | Verdict |
+|---|---:|---|
+| `text` (#ebe5d5) on `canvas` | **15.5:1** | AAA (any size) |
+| `text` on `surface` | **14.7:1** | AAA |
+| `text` on `raised` | **13.6:1** | AAA |
+| `text-muted` (#9890b0) on `canvas` | **6.5:1** | AA normal, near AAA |
+| `text-muted` on `surface` | **6.1:1** | AA normal |
+| `text-muted` on `raised` | **5.7:1** | AA normal |
+| `text-faint` (#696382) on `canvas` | **3.5:1** | AA **large only** |
+| `text-faint` on `surface` | **3.3:1** | AA **large only** |
+
+**Rules:**
+
+- `text` is the default for body copy. No exceptions.
+- `text-muted` is the secondary tier — captions, table cell labels,
+  helper text. Never below 14px in this color.
+- `text-faint` is for **large text only** (headings, oversized numbers
+  used as decoration) or for **non-text UI** (subtle icons, dividers).
+  Never use for body copy or any text smaller than 18pt regular / 14pt bold.
+
+## Spectrum on canvas
+
+| Color | Hex | Ratio vs canvas | Verdict |
+|---|---|---:|---|
+| `spectrum-violet` | `#7c5cff` | 4.5:1 | AA normal (at threshold) |
+| `spectrum-indigo` | `#5c8aff` | 6.1:1 | AA normal |
+| `spectrum-teal` | `#3edcff` | 12.0:1 | AAA |
+| `spectrum-mint` | `#3eff9b` | 14.9:1 | AAA |
+| `spectrum-amber` | `#ffd166` | 13.5:1 | AAA |
+| `spectrum-rose` | `#ff5c8a` | 6.7:1 | AA normal |
+
+**Rules:**
+
+- Spectrum colors used as **text** must clear AA (4.5:1) at the size used.
+- `violet` sits exactly at the AA threshold — only use it for **large
+  text or buttons**, never small body copy.
+- For interactive components on `canvas`, prefer `mint` (success) /
+  `amber` (warning) / `rose` (danger) — they all clear AAA.
+- `violet` is fine as the accent fill (background) of a button — the
+  rule applies to violet *as text*, not as a fill.
+
+## Spectrum as button fills
+
+When a spectrum color is the **background** of an interactive element,
+the foreground (label) must clear AA against that background.
+
+| Background | Recommended foreground | Ratio | Verdict |
+|---|---|---:|---|
+| `accent` (violet) | `canvas` (#0c0a14) | ~9:1 | AAA |
+| `success` (mint) | `canvas` | ~14:1 | AAA |
+| `warning` (amber) | `canvas` | ~13:1 | AAA |
+| `danger` (rose) | `canvas` | ~6.5:1 | AA normal |
+
+This is why `RainbowKitProvider` is themed with
+`accentColor: "#7c5cff"` and `accentColorForeground: "#0c0a14"` in
+[`apps/web/app/providers.tsx`](../../apps/web/app/providers.tsx) —
+the foreground is canvas, not text-cream, to maintain AAA.
+
+**Rule:** never put `text` (cream) on `accent` (violet). Cream-on-violet
+is ~3.4:1, below AA. Use canvas-on-violet instead.
+
+## Borders
+
+| Pairing | Ratio | Verdict |
+|---|---:|---|
+| `border` (#221d33) on `canvas` | ~1.3:1 | Decorative only |
+| `border-strong` (#352d4e) on `canvas` | ~1.9:1 | Decorative; meets WCAG 1.4.11 if paired with text label |
+| Focus ring: `border-strong` on `surface` | ~1.8:1 | Insufficient for focus-only |
+
+**Rule:** focus indicators MUST use `accent` (violet) at ≥ 3:1 against
+the surface, not `border-strong`. The default Tailwind ring at
+`ring-accent ring-offset-canvas ring-offset-2` clears this.
+
+## States that must be discriminable without color
+
+WCAG 1.4.1 requires color not be the only signal for state. PRISM rules:
+
+| State | Color signal | Non-color signal (required) |
+|---|---|---|
+| Loading | spectrum gradient pulse | spinner glyph or skeleton |
+| Success | `success` mint | check icon or text label |
+| Warning | `warning` amber | warning icon |
+| Error / danger | `danger` rose | error icon + text label |
+| Selected | `accent` violet | bolder weight or fill change |
+| Disabled | `text-faint` | `aria-disabled` + reduced opacity |
+
+## What not to do
+
+- **Don't introduce a "light mode."** PRISM is dark-only. If a future
+  ADR overturns this, that ADR replaces this guide.
+- **Don't use raw spectrum hex values** in components — go through
+  the Tailwind tokens (`bg-spectrum-violet`, `text-success`, etc.) so
+  contrast is enforced via this guide.
+- **Don't use `text-faint` for any text under 18pt regular.** It fails
+  AA. The compiler can't catch this — code review must.
+- **Don't pair two spectrum colors** (e.g., violet text on amber
+  background). All spectrum colors share similar luminance ranges and
+  the resulting ratios are below AA.
+- **Don't use `text` cream on `accent` violet** (fails AA). Always use
+  `canvas` as foreground on accent fills.
+
+## Re-verification procedure
+
+If `tokens.css` changes:
+
+1. Re-run a contrast audit (e.g.
+   [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)
+   or any axe-core based tool).
+2. Update the ratios in the tables above.
+3. If a ratio drops below the verdict listed, either:
+   - Adjust the token until it clears the verdict, OR
+   - Adjust the verdict and downstream usage rules in the same PR.
+4. Cite the audit source in the PR description.
+
+## References
+
+- [WCAG 2.1 Contrast (Minimum) — 1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum)
+- [WCAG 2.1 Non-Text Contrast — 1.4.11](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast)
+- [WCAG 2.1 Use of Color — 1.4.1](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color)
+- Brand tokens: [`apps/web/app/tokens.css`](../../apps/web/app/tokens.css)
+- Tailwind theme wiring: [`apps/web/tailwind.config.ts`](../../apps/web/tailwind.config.ts)


### PR DESCRIPTION
## Summary

Companion guide to #1 brand tokens. Measures the contrast ratio of every meaningful token pairing, codifies the rules that prevent low-contrast UI slips.

### Verdicts at a glance

| Token | vs canvas | Use for |
|---|---:|---|
| \`text\` | 15.5 | body copy (AAA) |
| \`text-muted\` | 6.5 | secondary text (AA normal) |
| \`text-faint\` | 3.5 | **large text only** (AA large) |
| \`spectrum-violet\` | 4.5 | accent fills + large text (AA threshold) |
| \`spectrum-mint\` | 14.9 | success / any size (AAA) |
| \`spectrum-amber\` | 13.5 | warning / any size (AAA) |
| \`spectrum-rose\` | 6.7 | danger (AA normal) |

### Locked rules

- **Never** put cream \`text\` on \`accent\` violet (fails AA). Use \`canvas\` as foreground — explains why \`accentColorForeground: #0c0a14\` in providers.tsx
- \`text-faint\` is unsafe for any body copy under 18pt regular / 14pt bold
- Focus rings use \`accent\` (≥3:1), not \`border-strong\`
- No light mode (overturnable only by an ADR that replaces this guide)
- WCAG 1.4.1: state must always have a non-color signal alongside color

### Re-verification procedure

If tokens.css changes, the same PR must re-measure ratios and either adjust the token or adjust the verdict. Source-of-truth tool linked.

## Quality gates

- markdown only

## Test plan

- [x] all ratios cross-checked manually with WCAG 2.1 luminance formula
- [ ] reviewer spot-checks 2-3 pairings against WebAIM Contrast Checker

## Dependencies

- Stacked on #1 (design/1-brand-tokens). Merge after #1.

Closes #2