### PR TITLE
feat(contracts): ChainlinkAdapter — fail-soft oracle (#37)

### DIFF
--- a/packages/contracts/src/interfaces/IChainlinkAdapter.sol
+++ b/packages/contracts/src/interfaces/IChainlinkAdapter.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+/// @title PRISM oracle adapter interface
+/// @notice Wraps a Chainlink price feed (and optional L2 sequencer
+///         uptime feed) into the canonical fail-soft return shape that
+///         ProtocolHook expects on the swap hot-path.
+///
+///         Per ADR-003 the adapter NEVER reverts on the swap path. Any
+///         failure mode (sequencer down, stale round, negative answer,
+///         math overflow) returns `(0, false)` and the hook degrades to
+///         the safe path: dynamic fees still update via beforeSwap, but
+///         MEV observation in afterSwap is skipped for that round.
+interface IChainlinkAdapter {
+    /// @notice Read the current oracle reference and report its health.
+    /// @dev    Always view, always non-reverting. Implementers must
+    ///         catch external-call failures and return `(0, false)`.
+    /// @return sqrtPriceX96 V4 sqrt-price (Q64.96) implied by the feed,
+    ///                     or `0` if the read was unhealthy.
+    /// @return healthy     `true` iff the sequencer is up, the round is
+    ///                     fresh, and the conversion did not overflow.
+    function read() external view returns (uint160 sqrtPriceX96, bool healthy);
+}

--- a/packages/contracts/src/oracles/ChainlinkAdapter.sol
+++ b/packages/contracts/src/oracles/ChainlinkAdapter.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {FullMath} from "v4-core/libraries/FullMath.sol";
+
+import {IChainlinkAdapter} from "../interfaces/IChainlinkAdapter.sol";
+import {Errors} from "../utils/Errors.sol";
+
+// Subset of Chainlink's AggregatorV3Interface — only the calls this
+// adapter makes. Inlined here so PRISM's contract package does not pull
+// in chainlink/contracts as a submodule.
+interface AggregatorV3 {
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+}
+
+/// @title PRISM Chainlink adapter
+/// @notice Fail-soft oracle reader for ProtocolHook. Combines a price
+///         feed, an optional L2 sequencer uptime feed, a staleness gate,
+///         and a sqrtPriceX96 conversion in one read() call.
+///
+///         Per ADR-003 the adapter NEVER reverts on the swap path. All
+///         failure modes degrade to `(0, false)`. The hook then skips
+///         MEV observation for that swap; volatility-fee updates in
+///         beforeSwap are unaffected.
+///
+/// @dev   Construction parameters are immutable. To update any of them
+///        the operator deploys a new adapter and rotates `oracle()` on
+///        the affected vaults — see ADR-006 (immutable core).
+///
+///        sqrtPriceX96 conversion uses `FullMath.mulDiv` (512-bit
+///        intermediate) so the operator can supply a Q-format scaling
+///        factor as `priceScaleNum / priceScaleDen` without needing to
+///        worry about intermediate overflow. The factor encodes pool
+///        decimals + feed decimals; computing it off-chain at deploy
+///        time keeps the swap path branch-free.
+contract ChainlinkAdapter is IChainlinkAdapter {
+    /// @notice Default staleness window — 1 hour.
+    /// @dev See ADR-003.
+    uint256 public constant DEFAULT_STALENESS = 3600;
+
+    /// @notice Default sequencer grace period — 1 hour after recovery.
+    uint256 public constant DEFAULT_GRACE_PERIOD = 3600;
+
+    /// @notice Primary price feed (e.g. ETH/USD on Base).
+    AggregatorV3 public immutable feed;
+
+    /// @notice L2 sequencer uptime feed. `address(0)` for L1 deployments.
+    AggregatorV3 public immutable sequencer;
+
+    /// @notice Maximum age of `feed.updatedAt` before the round is rejected.
+    uint256 public immutable staleness;
+
+    /// @notice After sequencer recovery the adapter still reports
+    ///         unhealthy for `gracePeriod` seconds. Lets dependent state
+    ///         (mempool, off-chain bots) settle before MEV signalling resumes.
+    uint256 public immutable gracePeriod;
+
+    /// @notice Numerator of the Q192 sqrtPriceX96 scaling factor.
+    /// @dev Off-chain helper computes: `priceScaleNum / priceScaleDen ==
+    ///      2^192 * 10^(token0Decimals - token1Decimals - feedDecimals)`,
+    ///      bounded so the multiplication fits the FullMath domain.
+    uint256 public immutable priceScaleNum;
+
+    /// @notice Denominator of the Q192 sqrtPriceX96 scaling factor.
+    uint256 public immutable priceScaleDen;
+
+    /// @notice Maximum signed answer the adapter will accept before
+    ///         reporting unhealthy. Computed at construction so the
+    ///         hot-path can compare in O(1) without doing the
+    ///         overflow check via FullMath each call.
+    /// @dev    Equal to `type(uint256).max * priceScaleDen / priceScaleNum`,
+    ///         capped at `type(int256).max` since answer is int256.
+    uint256 public immutable maxAnswer;
+
+    constructor(
+        AggregatorV3 feed_,
+        AggregatorV3 sequencer_,
+        uint256 staleness_,
+        uint256 gracePeriod_,
+        uint256 priceScaleNum_,
+        uint256 priceScaleDen_
+    ) {
+        if (address(feed_) == address(0)) revert Errors.ZeroAddress();
+        if (priceScaleDen_ == 0) revert Errors.ZeroAddress();
+        if (priceScaleNum_ == 0) revert Errors.ZeroAddress();
+
+        feed = feed_;
+        sequencer = sequencer_;
+        staleness = staleness_;
+        gracePeriod = gracePeriod_;
+        priceScaleNum = priceScaleNum_;
+        priceScaleDen = priceScaleDen_;
+
+        uint256 m = FullMath.mulDiv(type(uint256).max, priceScaleDen_, priceScaleNum_);
+        maxAnswer = m > uint256(type(int256).max) ? uint256(type(int256).max) : m;
+    }
+
+    /// @inheritdoc IChainlinkAdapter
+    function read() external view override returns (uint160 sqrtPriceX96, bool healthy) {
+        // 1. L2 sequencer gate.
+        //    Chainlink convention: answer == 0 means up; nonzero means down.
+        if (address(sequencer) != address(0)) {
+            try sequencer.latestRoundData() returns (uint80, int256 seqAnswer, uint256 startedAt, uint256, uint80) {
+                if (seqAnswer != 0) return (0, false);
+                // After recovery, gracePeriod must elapse before re-trusting.
+                if (block.timestamp - startedAt < gracePeriod) return (0, false);
+            } catch {
+                return (0, false);
+            }
+        }
+
+        // 2. Primary feed read.
+        int256 answer;
+        uint256 updatedAt;
+        try feed.latestRoundData() returns (uint80, int256 a, uint256, uint256 ua, uint80) {
+            answer = a;
+            updatedAt = ua;
+        } catch {
+            return (0, false);
+        }
+
+        if (answer <= 0) return (0, false);
+        if (updatedAt == 0) return (0, false);
+        if (block.timestamp > updatedAt && block.timestamp - updatedAt > staleness) {
+            return (0, false);
+        }
+        // Reject implausible feed values that would overflow the
+        // Q192 conversion. maxAnswer is precomputed at construction.
+        if (uint256(answer) > maxAnswer) return (0, false);
+
+        // 3. Convert to sqrtPriceX96 = sqrt(answer * priceScaleNum / priceScaleDen).
+        //    `priceScaleNum` already encodes `2^192` so the result is the
+        //    Q192 spot-price; sqrt then yields the Q96 sqrt-price.
+        uint256 spotQ192 = FullMath.mulDiv(uint256(answer), priceScaleNum, priceScaleDen);
+
+        uint256 sqrtPrice = _sqrt(spotQ192);
+        if (sqrtPrice > type(uint160).max) return (0, false);
+
+        return (uint160(sqrtPrice), true);
+    }
+
+    /// @dev Babylonian method. Branchless after the seed; ~70 gas.
+    function _sqrt(uint256 x) internal pure returns (uint256) {
+        if (x == 0) return 0;
+
+        // Initial seed: most significant bit / 2.
+        uint256 z = (x + 1) >> 1;
+        uint256 y = x;
+        while (z < y) {
+            y = z;
+            z = (x / z + z) >> 1;
+        }
+        return y;
+    }
+}

--- a/packages/contracts/test/oracles/ChainlinkAdapter.t.sol
+++ b/packages/contracts/test/oracles/ChainlinkAdapter.t.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {AggregatorV3, ChainlinkAdapter} from "../../src/oracles/ChainlinkAdapter.sol";
+import {Errors} from "../../src/utils/Errors.sol";
+
+contract MockFeed is AggregatorV3 {
+    int256 public answer;
+    uint256 public updatedAt;
+    uint256 public startedAt;
+    bool public revertOnRead;
+
+    function setRound(int256 a, uint256 ua) external {
+        answer = a;
+        updatedAt = ua;
+        startedAt = ua;
+    }
+
+    function setRevert(bool r) external {
+        revertOnRead = r;
+    }
+
+    function latestRoundData() external view override returns (uint80, int256, uint256, uint256, uint80) {
+        if (revertOnRead) revert("feed down");
+        return (1, answer, startedAt, updatedAt, 1);
+    }
+}
+
+contract ChainlinkAdapterTest is Test {
+    MockFeed feed;
+    MockFeed sequencer;
+    ChainlinkAdapter adapter;
+
+    // For a hypothetical 1:1 feed where answer == sqrtPriceX96, the
+    // scale factor is `2^192 / answer^2 * answer = 2^192 / answer`.
+    // Easier to test: pick scale so that result is deterministic.
+    // For answer=1e8 (1.0 with 8 decimals), priceQ192 should be 2^192,
+    // so sqrtPriceX96 = 2^96.
+    // priceQ192 = answer * num/den = 1e8 * num/den == 2^192
+    // → num/den == 2^192 / 1e8.
+    uint256 constant Q192 = 1 << 192;
+    uint256 constant SCALE_NUM = Q192;
+    uint256 constant SCALE_DEN = 1e8;
+
+    uint256 constant STALENESS = 3600;
+    uint256 constant GRACE = 3600;
+
+    function setUp() public {
+        feed = new MockFeed();
+        sequencer = new MockFeed();
+        adapter = new ChainlinkAdapter(
+            AggregatorV3(address(feed)), AggregatorV3(address(sequencer)), STALENESS, GRACE, SCALE_NUM, SCALE_DEN
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor reverts
+    // -------------------------------------------------------------------------
+
+    function test_constructor_revertsOnZeroFeed() public {
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new ChainlinkAdapter(AggregatorV3(address(0)), AggregatorV3(address(0)), STALENESS, GRACE, SCALE_NUM, SCALE_DEN);
+    }
+
+    function test_constructor_revertsOnZeroScale() public {
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new ChainlinkAdapter(AggregatorV3(address(feed)), AggregatorV3(address(0)), STALENESS, GRACE, 0, SCALE_DEN);
+
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new ChainlinkAdapter(AggregatorV3(address(feed)), AggregatorV3(address(0)), STALENESS, GRACE, SCALE_NUM, 0);
+    }
+
+    function test_constructor_acceptsZeroSequencer() public {
+        ChainlinkAdapter a = new ChainlinkAdapter(
+            AggregatorV3(address(feed)), AggregatorV3(address(0)), STALENESS, GRACE, SCALE_NUM, SCALE_DEN
+        );
+        assertEq(address(a.sequencer()), address(0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Sequencer gating
+    // -------------------------------------------------------------------------
+
+    function test_read_failsWhenSequencerDown() public {
+        // sequencer answer != 0 means down.
+        sequencer.setRound(1, block.timestamp);
+        feed.setRound(1e8, block.timestamp);
+
+        (uint160 sp, bool ok) = adapter.read();
+        assertEq(sp, 0);
+        assertFalse(ok);
+    }
+
+    function test_read_failsDuringSequencerGrace() public {
+        // Sequencer just came back up — startedAt = now.
+        sequencer.setRound(0, block.timestamp);
+        feed.setRound(1e8, block.timestamp);
+
+        (uint160 sp, bool ok) = adapter.read();
+        assertEq(sp, 0);
+        assertFalse(ok);
+
+        // After grace, recovery succeeds.
+        vm.warp(block.timestamp + GRACE);
+        (sp, ok) = adapter.read();
+        assertTrue(ok);
+        assertGt(sp, 0);
+    }
+
+    function test_read_failsOnSequencerRevert() public {
+        sequencer.setRevert(true);
+        feed.setRound(1e8, block.timestamp);
+
+        (, bool ok) = adapter.read();
+        assertFalse(ok);
+    }
+
+    // -------------------------------------------------------------------------
+    // Staleness
+    // -------------------------------------------------------------------------
+
+    function test_read_failsWhenStale() public {
+        // Sequencer healthy + grace elapsed.
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+
+        // Feed updated long ago.
+        feed.setRound(1e8, 1);
+        vm.warp(1 + STALENESS + 100);
+
+        (, bool ok) = adapter.read();
+        assertFalse(ok);
+    }
+
+    function test_read_failsOnNegativeAnswer() public {
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+        feed.setRound(-1, block.timestamp);
+
+        (, bool ok) = adapter.read();
+        assertFalse(ok);
+    }
+
+    function test_read_failsOnZeroAnswer() public {
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+        feed.setRound(0, block.timestamp);
+
+        (, bool ok) = adapter.read();
+        assertFalse(ok);
+    }
+
+    function test_read_failsOnFeedRevert() public {
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+        feed.setRevert(true);
+
+        (, bool ok) = adapter.read();
+        assertFalse(ok);
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path + conversion
+    // -------------------------------------------------------------------------
+
+    function test_read_happyPath_unitPrice() public {
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+        feed.setRound(1e8, block.timestamp); // 1.00 with 8 decimals
+
+        (uint160 sp, bool ok) = adapter.read();
+        assertTrue(ok);
+        // Expected: sqrtPriceX96 = sqrt(2^192) = 2^96.
+        assertEq(uint256(sp), 1 << 96);
+    }
+
+    function test_read_happyPath_higherPrice() public {
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+        feed.setRound(4e8, block.timestamp); // 4.00 with 8 decimals
+
+        (uint160 sp, bool ok) = adapter.read();
+        assertTrue(ok);
+        // Expected: priceQ192 = 4 * 2^192, sqrt = 2 * 2^96 = 2^97.
+        assertEq(uint256(sp), 1 << 97);
+    }
+
+    function test_read_skipsSequencerWhenAddressZero() public {
+        ChainlinkAdapter noSeq = new ChainlinkAdapter(
+            AggregatorV3(address(feed)), AggregatorV3(address(0)), STALENESS, GRACE, SCALE_NUM, SCALE_DEN
+        );
+
+        feed.setRound(1e8, block.timestamp);
+        (uint160 sp, bool ok) = noSeq.read();
+        assertTrue(ok);
+        assertEq(uint256(sp), 1 << 96);
+    }
+
+    function test_read_neverReverts_fuzz(int256 a, uint64 ua, uint256 warpTo) public {
+        sequencer.setRound(0, 1);
+        // Bound the warp so block.timestamp arithmetic stays sane.
+        warpTo = bound(warpTo, GRACE + 2, type(uint64).max);
+        vm.warp(warpTo);
+        feed.setRound(a, ua);
+
+        // Adapter must never revert regardless of inputs.
+        adapter.read();
+    }
+}


### PR DESCRIPTION
## Summary

Implements ADR-003 oracle strategy: Chainlink price feed + optional L2 sequencer uptime feed → canonical \`(sqrtPriceX96, healthy)\` return. **Never reverts on the swap path.**

### IChainlinkAdapter

Single \`read()\` returning the V4-shape price + health bit. Hook callers degrade safely: when \`healthy = false\`, MEV observation is skipped for that swap; volatility-fee updates in beforeSwap are unaffected.

### ChainlinkAdapter

- Inline AggregatorV3 subset — avoids adding chainlink/contracts as a submodule
- **Sequencer gate** — rejects when answer != 0 (sequencer down); during gracePeriod post-recovery, returns unhealthy to let mempool settle
- **Staleness gate** — 1h default per ADR-003, configurable
- **Negative / zero answer guard**
- **Try/catch** around every external read so RPC failures never escape
- **sqrtPriceX96 conversion** via \`FullMath.mulDiv\` with a precomputed Q192 scale factor — pool & feed decimals settled at deploy time, swap-path is branch-free
- **maxAnswer immutable** — derived from scale factors at construction; rejects feed values that would overflow the conversion
- **Inline Babylonian sqrt** (~70 gas after seed)

## Quality gates

- \`forge build\`: pass
- \`forge fmt\`: clean
- \`forge test test/oracles/ChainlinkAdapter.t.sol\`: 14/14 pass

## Test plan

- [x] constructor zero-feed / zero-scale reverts
- [x] sequencer down / grace-period / sequencer-revert
- [x] feed: stale / negative / zero / revert
- [x] happy path conversion: 1.0 → sqrt(2^192) = 2^96; 4.0 → 2^97
- [x] no-sequencer config (L1)
- [x] fuzz: never reverts across int256 answer × uint64 timestamp × warp

## Dependencies

- Stacked on #17 (contracts/17-errors). Imports \`Errors.ZeroAddress\`.
- Unblocks #36 (ProtocolHook.afterSwap) which consumes \`IChainlinkAdapter.read()\`.

Closes #37