### PR TITLE
feat(contracts): ProtocolHook permissions + ctor + callback skeleton (#34)

### DIFF
--- a/packages/contracts/src/hooks/ProtocolHook.sol
+++ b/packages/contracts/src/hooks/ProtocolHook.sol
@@ -54,6 +54,29 @@ contract ProtocolHook is IProtocolHook {
     ///         in `afterSwap` to attribute MEV observations.
     mapping(PoolId => address) public vaultByPool;
 
+    /// @notice Per-pool dynamic-fee state. EWMA short-window volatility,
+    ///         long-window volatility, last-update timestamp, and the
+    ///         most recent computed fee.
+    /// @dev    Packed into one slot per pool to keep the beforeSwap
+    ///         SLOAD/SSTORE pair within the 12k gas budget (ADR-007).
+    ///         The full fee math (`FeeLib.update + FeeLib.feeFromVol`)
+    ///         lands as part of the integration phase that pulls
+    ///         FeeLib from #23 onto this branch — the storage slot is
+    ///         declared now so the migration is a body-only change.
+    struct FeeState {
+        uint64 ewmaShort;
+        uint64 ewmaLong;
+        uint32 lastUpdate;
+        uint24 lastFee;
+    }
+
+    /// @notice Last computed fee (in pips) per pool.
+    mapping(PoolId => FeeState) internal _feeState;
+
+    /// @notice Default starting fee in pips (0.30%) — used until the
+    ///         EWMA has converged after the first few swaps.
+    uint24 public constant DEFAULT_FEE = 3000;
+
     // -------------------------------------------------------------------------
     // Modifiers
     // -------------------------------------------------------------------------
@@ -127,9 +150,9 @@ contract ProtocolHook is IProtocolHook {
     // -------------------------------------------------------------------------
 
     /// @inheritdoc IProtocolHook
-    /// @dev #34 stub: returns 0 until #35 wires the EWMA fee state.
-    function currentFee(bytes32 /*poolId*/ ) external pure override returns (uint24) {
-        return 0;
+    function currentFee(bytes32 poolId) external view override returns (uint24) {
+        uint24 fee = _feeState[PoolId.wrap(poolId)].lastFee;
+        return fee == 0 ? DEFAULT_FEE : fee;
     }
 
     /// @inheritdoc IProtocolHook
@@ -225,18 +248,36 @@ contract ProtocolHook is IProtocolHook {
 
     function beforeSwap(
         address,
-        PoolKey calldata,
+        PoolKey calldata key,
         SwapParams calldata,
         bytes calldata
     )
         external
-        view
         override
         onlyPoolManager
         returns (bytes4, BeforeSwapDelta, uint24)
     {
-        // #35 implements EWMA volatility update + dynamic-fee override.
-        return (IHooks.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
+        // ≤12k gas budget per ADR-007. The full EWMA + clamped fee
+        // calculation lives in FeeLib (#23); pulling it onto this
+        // branch is the integration step. For now we read existing
+        // state, return the stored fee (or DEFAULT_FEE on first swap),
+        // and emit FeeUpdated for analytics. The storage slot layout
+        // and the V4 OVERRIDE_FEE_FLAG path are settled here so the
+        // FeeLib wire-up is a single-method change.
+        PoolId pid = key.toId();
+        FeeState storage state = _feeState[pid];
+
+        uint24 fee = state.lastFee == 0 ? DEFAULT_FEE : state.lastFee;
+        if (state.lastUpdate == 0) {
+            state.lastUpdate = uint32(block.timestamp);
+            state.lastFee = fee;
+            emit FeeUpdated(PoolId.unwrap(pid), fee, 0);
+        }
+
+        // V4 OVERRIDE_FEE_FLAG = 0x400000 — set the high bit on the
+        // returned fee so PoolManager applies it as the swap fee for
+        // this transaction only. See v4-core LPFeeLibrary.
+        return (IHooks.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, fee | 0x400000);
     }
 
     function afterSwap(

--- a/packages/contracts/src/hooks/ProtocolHook.sol
+++ b/packages/contracts/src/hooks/ProtocolHook.sol
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {Hooks} from "v4-core/libraries/Hooks.sol";
+import {BalanceDelta} from "v4-core/types/BalanceDelta.sol";
+import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "v4-core/types/BeforeSwapDelta.sol";
+
+import {PoolId, PoolIdLibrary} from "v4-core/types/PoolId.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {ModifyLiquidityParams, SwapParams} from "v4-core/types/PoolOperation.sol";
+
+import {IProtocolHook} from "../interfaces/IProtocolHook.sol";
+import {IVault} from "../interfaces/IVault.sol";
+import {Errors} from "../utils/Errors.sol";
+
+/// @title ProtocolHook — singleton V4 hook
+/// @notice This PR (#34) wires the permission matrix, address-bit
+///         assertion, onlyPoolManager guard, vault registry, and the
+///         IHooks callback skeleton. The actual hot-path logic in
+///         `beforeSwap` (#35) and `afterSwap` (#36) ships in
+///         follow-up PRs — for now those callbacks return the canonical
+///         "no-op" sentinels so a deployed hook composes correctly with
+///         PoolManager and the test pool can already run swaps.
+/// @dev    Singleton scope per ADR-002: one deployed hook services every
+///         PRISM vault. State is sharded by `PoolId` (pool-level state
+///         like volatility) and vault address (vault-level state like
+///         MEV ledgers).
+///
+///         The hook ENABLES bits 6, 7, 8, 10:
+///           - afterSwap (bit 6)
+///           - beforeSwap (bit 7)
+///           - afterRemoveLiquidity (bit 8)
+///           - afterAddLiquidity (bit 10)
+///         Combined: 0x05C0 — the deployed address LSB is mined to
+///         satisfy `address(this) & 0x3FFF == 0x05C0` (HookMiner #25).
+///         The constructor calls `Hooks.validateHookPermissions` which
+///         reverts with `Hooks.HookAddressNotValid` if the address bits
+///         disagree with `getHookPermissions()`.
+contract ProtocolHook is IProtocolHook {
+    using PoolIdLibrary for PoolKey;
+
+    /// @notice Canonical V4 PoolManager singleton.
+    IPoolManager public immutable poolManager;
+
+    /// @notice The factory authorised to call `registerVault`. Pinned at
+    ///         deploy time. Per ADR-006 there is no setter; rotation
+    ///         requires redeploying the hook + factory + vaults.
+    address public immutable factory;
+
+    /// @notice `PoolId` → registered PRISM vault. Set by the factory
+    ///         immediately after vault deployment. The hook reads this
+    ///         in `afterSwap` to attribute MEV observations.
+    mapping(PoolId => address) public vaultByPool;
+
+    // -------------------------------------------------------------------------
+    // Modifiers
+    // -------------------------------------------------------------------------
+
+    modifier onlyPoolManager() {
+        if (msg.sender != address(poolManager)) revert Errors.OnlyPoolManager();
+        _;
+    }
+
+    modifier onlyFactory() {
+        if (msg.sender != factory) revert Errors.OnlyOwner();
+        _;
+    }
+
+    // -------------------------------------------------------------------------
+    // Construction
+    // -------------------------------------------------------------------------
+
+    constructor(IPoolManager poolManager_, address factory_) {
+        if (address(poolManager_) == address(0)) revert Errors.ZeroAddress();
+        if (factory_ == address(0)) revert Errors.ZeroAddress();
+
+        poolManager = poolManager_;
+        factory = factory_;
+
+        // Address-bit assertion. Reverts via Hooks.HookAddressNotValid
+        // when the deployer's CREATE2 salt was not mined to encode the
+        // exact permission flags this hook implements. HookMiner (#25)
+        // is the off-chain helper that finds a satisfying salt.
+        Hooks.validateHookPermissions(IHooks(address(this)), getHookPermissions());
+    }
+
+    // -------------------------------------------------------------------------
+    // IProtocolHook — getHookPermissions
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IProtocolHook
+    function getHookPermissions() public pure override returns (Hooks.Permissions memory) {
+        return Hooks.Permissions({
+            beforeInitialize: false,
+            afterInitialize: false,
+            beforeAddLiquidity: false,
+            afterAddLiquidity: true, // bit 10
+            beforeRemoveLiquidity: false,
+            afterRemoveLiquidity: true, // bit 8
+            beforeSwap: true, // bit 7
+            afterSwap: true, // bit 6
+            beforeDonate: false,
+            afterDonate: false,
+            beforeSwapReturnDelta: false,
+            afterSwapReturnDelta: false,
+            afterAddLiquidityReturnDelta: false,
+            afterRemoveLiquidityReturnDelta: false
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // IProtocolHook — registerVault
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IProtocolHook
+    function registerVault(address vault) external override onlyFactory {
+        if (vault == address(0)) revert Errors.ZeroAddress();
+        PoolKey memory key = IVault(vault).poolKey();
+        PoolId pid = key.toId();
+        vaultByPool[pid] = vault;
+    }
+
+    // -------------------------------------------------------------------------
+    // IProtocolHook — view stubs (filled by #35/#36)
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IProtocolHook
+    /// @dev #34 stub: returns 0 until #35 wires the EWMA fee state.
+    function currentFee(bytes32 /*poolId*/ ) external pure override returns (uint24) {
+        return 0;
+    }
+
+    /// @inheritdoc IProtocolHook
+    /// @dev v1.0 always returns (0, 0) — observation-only mode.
+    function mevProfits(address /*vault*/ ) external pure override returns (uint256, uint256) {
+        return (0, 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // IHooks callback skeleton — beforeInitialize through afterDonate
+    //
+    // PRISM enables only 4 callbacks; the others MUST never be reached
+    // because the address bits forbid PoolManager from invoking them.
+    // Implementations are left as `revert UnknownOp()` so a malformed
+    // CREATE2 salt that somehow allowed an unintended call would surface
+    // as a clear error rather than silent acceptance.
+    // -------------------------------------------------------------------------
+
+    function beforeInitialize(address, PoolKey calldata, uint160) external pure override returns (bytes4) {
+        revert Errors.UnknownOp();
+    }
+
+    function afterInitialize(address, PoolKey calldata, uint160, int24) external pure override returns (bytes4) {
+        revert Errors.UnknownOp();
+    }
+
+    function beforeAddLiquidity(
+        address,
+        PoolKey calldata,
+        ModifyLiquidityParams calldata,
+        bytes calldata
+    )
+        external
+        pure
+        override
+        returns (bytes4)
+    {
+        revert Errors.UnknownOp();
+    }
+
+    function beforeRemoveLiquidity(
+        address,
+        PoolKey calldata,
+        ModifyLiquidityParams calldata,
+        bytes calldata
+    )
+        external
+        pure
+        override
+        returns (bytes4)
+    {
+        revert Errors.UnknownOp();
+    }
+
+    function beforeDonate(
+        address,
+        PoolKey calldata,
+        uint256,
+        uint256,
+        bytes calldata
+    )
+        external
+        pure
+        override
+        returns (bytes4)
+    {
+        revert Errors.UnknownOp();
+    }
+
+    function afterDonate(
+        address,
+        PoolKey calldata,
+        uint256,
+        uint256,
+        bytes calldata
+    )
+        external
+        pure
+        override
+        returns (bytes4)
+    {
+        revert Errors.UnknownOp();
+    }
+
+    // -------------------------------------------------------------------------
+    // IHooks — enabled callbacks
+    //
+    // afterAddLiquidity / afterRemoveLiquidity MUST NOT revert
+    // (ADR-002 hard rule — they sit on the withdraw hot-path). #34
+    // returns the no-op sentinel; #35/#36 retain that property when
+    // they fill the body.
+    // -------------------------------------------------------------------------
+
+    function beforeSwap(
+        address,
+        PoolKey calldata,
+        SwapParams calldata,
+        bytes calldata
+    )
+        external
+        view
+        override
+        onlyPoolManager
+        returns (bytes4, BeforeSwapDelta, uint24)
+    {
+        // #35 implements EWMA volatility update + dynamic-fee override.
+        return (IHooks.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
+    }
+
+    function afterSwap(
+        address,
+        PoolKey calldata,
+        SwapParams calldata,
+        BalanceDelta,
+        bytes calldata
+    )
+        external
+        view
+        override
+        onlyPoolManager
+        returns (bytes4, int128)
+    {
+        // #36 implements oracle read + deviation check + SwapObserved.
+        return (IHooks.afterSwap.selector, 0);
+    }
+
+    function afterAddLiquidity(
+        address,
+        PoolKey calldata,
+        ModifyLiquidityParams calldata,
+        BalanceDelta,
+        BalanceDelta,
+        bytes calldata
+    )
+        external
+        view
+        override
+        onlyPoolManager
+        returns (bytes4, BalanceDelta)
+    {
+        // ADR-002 hard rule: never reverts. v1.0 is a pure no-op.
+        return (IHooks.afterAddLiquidity.selector, BalanceDelta.wrap(0));
+    }
+
+    function afterRemoveLiquidity(
+        address,
+        PoolKey calldata,
+        ModifyLiquidityParams calldata,
+        BalanceDelta,
+        BalanceDelta,
+        bytes calldata
+    )
+        external
+        view
+        override
+        onlyPoolManager
+        returns (bytes4, BalanceDelta)
+    {
+        // ADR-002 hard rule: never reverts. v1.0 is a pure no-op.
+        return (IHooks.afterRemoveLiquidity.selector, BalanceDelta.wrap(0));
+    }
+}

--- a/packages/contracts/src/interfaces/IProtocolHook.sol
+++ b/packages/contracts/src/interfaces/IProtocolHook.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {Hooks} from "v4-core/libraries/Hooks.sol";
+
+/// @title IProtocolHook
+/// @notice PRISM's V4 hook surface — dynamic fees in `beforeSwap`, MEV
+///         observation in `afterSwap`, lightweight position-state
+///         cleanup in `afterAddLiquidity` / `afterRemoveLiquidity`, and
+///         the per-pool / per-vault read accessors used by the dApp
+///         and keeper.
+/// @dev Inherits `v4-core/IHooks` so all four V4 callbacks PRISM uses
+///      keep their canonical selectors and ABI shape — implementations
+///      override the `IHooks` methods directly. The four callbacks
+///      PRISM ENABLES are bits 6, 7, 8, 10 (`afterSwap`, `beforeSwap`,
+///      `afterRemoveLiquidity`, `afterAddLiquidity`); the deployed hook
+///      address satisfies `address & 0x3FFF == 0x05C0` per ADR-002.
+///
+///      A bug in `afterAddLiquidity` or `afterRemoveLiquidity` MUST NOT
+///      revert (ADR-002 §hard rule). Those callbacks sit on the
+///      withdraw hot path; reverting them violates invariant 6.
+///      Implementations are emit-only or pure state cleanup.
+///
+///      The hook is a singleton (ADR-002): a single deployed instance
+///      services every PRISM vault. State is sharded by `PoolId` and
+///      vault address inside the implementation.
+interface IProtocolHook is IHooks {
+    // -------------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------------
+
+    /// @notice Emitted when `beforeSwap` recomputes the dynamic fee for
+    ///         a pool.
+    /// @param poolId Indexed `PoolId` (cast to bytes32 for indexer
+    ///        ergonomics — V4's `PoolId` is `bytes32` underneath).
+    /// @param newFee Fee in pip (1e-6); written as the V4
+    ///        `OVERRIDE_FEE_FLAG`-tagged return value.
+    /// @param volatility Snapshot of the short-window EWMA used to
+    ///        compute the new fee; for dApp / analytics consumers.
+    event FeeUpdated(bytes32 indexed poolId, uint24 newFee, uint256 volatility);
+
+    /// @notice Emitted on every swap through the hook — the v1.0 MEV
+    ///         capture surface is observation-only.
+    /// @param poolId Indexed `PoolId`.
+    /// @param tick Pool tick *after* the swap.
+    /// @param sqrtPriceX96 Pool sqrt-price after the swap (Q64.96).
+    event SwapObserved(bytes32 indexed poolId, int24 tick, uint160 sqrtPriceX96);
+
+    /// @notice Emitted when v1.1 backrun execution captures MEV and
+    ///         credits the captured profit to a vault. v1.0 emits no
+    ///         MEVCaptured events (observation only); the event lives
+    ///         on the interface so v1.1 can ship without a hook
+    ///         redeploy of the EVENT topic.
+    /// @param vault Indexed vault that received the credit.
+    /// @param amount Amount captured, denominated in `isToken0 ? token0 : token1`.
+    /// @param isToken0 Which token the captured amount is denominated in.
+    event MEVCaptured(address indexed vault, uint256 amount, bool isToken0);
+
+    // -------------------------------------------------------------------------
+    // Mutators
+    // -------------------------------------------------------------------------
+
+    /// @notice Register a `Vault` against this hook so the hook can
+    ///         attribute MEV captures and per-pool state to the right
+    ///         vault.
+    /// @dev Called by `VaultFactory` immediately after vault deployment
+    ///      so the hook learns the `PoolId → vault` mapping. Reverts
+    ///      via `Errors.OnlyOwner` (or the access-controlled equivalent
+    ///      chosen by the implementation) for non-factory callers.
+    /// @param vault The vault address to register against this hook.
+    function registerVault(address vault) external;
+
+    // -------------------------------------------------------------------------
+    // Views
+    // -------------------------------------------------------------------------
+
+    /// @notice The current dynamic fee the hook will return from
+    ///         `beforeSwap` for this pool, in pip (1e-6 units; e.g.
+    ///         3_000 = 0.30%). Used by the dApp for fee display and by
+    ///         the keeper for simulation.
+    /// @param poolId The `PoolId` (V4 hash of the `PoolKey`) cast to
+    ///        bytes32.
+    /// @return fee Current dynamic fee in pip.
+    function currentFee(bytes32 poolId) external view returns (uint24 fee);
+
+    /// @notice Per-vault MEV profit ledger. v1.0 always returns
+    ///         `(0, 0)` because v1.0 only observes; v1.1 populates as
+    ///         backruns execute.
+    /// @dev Returning two amounts (token0 + token1) lets v1.1 capture
+    ///      profits in either currency depending on the backrun
+    ///      direction without changing the interface surface.
+    /// @param vault The vault to read.
+    /// @return amount0 MEV profits in token0 awaiting distribution.
+    /// @return amount1 MEV profits in token1 awaiting distribution.
+    function mevProfits(address vault) external view returns (uint256 amount0, uint256 amount1);
+
+    /// @notice The exact permissions matrix this hook implements.
+    /// @dev MUST match the bits encoded in the deployed hook address —
+    ///      `PoolManager.initialize` reverts via
+    ///      `Hooks.HookAddressNotValid` otherwise (invariant #7,
+    ///      ADR-002). PRISM hooks return:
+    ///        beforeSwap = true (bit 7)
+    ///        afterSwap = true (bit 6)
+    ///        afterAddLiquidity = true (bit 10)
+    ///        afterRemoveLiquidity = true (bit 8)
+    ///      All other flags false. Combined: `0x05C0`.
+    /// @return permissions The struct of all 14 V4 hook permission flags.
+    function getHookPermissions() external pure returns (Hooks.Permissions memory permissions);
+}

--- a/packages/contracts/src/interfaces/IVault.sol
+++ b/packages/contracts/src/interfaces/IVault.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+
+/// @title IVault
+/// @notice The PRISM vault interface — a multi-position LP aggregator on top
+///         of a single Uniswap V4 pool. Users deposit a pair of tokens, the
+///         vault refracts that liquidity into N tick-range positions chosen
+///         by an `IStrategy`, and ERC-20 shares track each user's claim.
+/// @dev Defined ahead of `Vault.sol` (#26) so mocks, tests, and frontend
+///      ABIs compile against a single signature surface. Implementations
+///      MUST reuse the function and event signatures verbatim — third
+///      parties (indexers, the keeper, the dApp) bind to selectors and
+///      topic hashes derived here.
+///
+///      Behavioural contracts (enforced by implementation, not by the
+///      interface):
+///        - `deposit` reverts via `Errors.DepositsPaused` when paused;
+///          `withdraw` is **never** pausable (PRD invariant 6 + ADR-006).
+///        - `rebalance` is permissionless and reverts via
+///          `Errors.RebalanceNotNeeded` when the strategy's gate is false.
+///        - All state-mutating entry points are `nonReentrantTransient`
+///          (ADR-004) and run inside one `PoolManager.unlock`.
+///        - `getTotalAmounts` and `getPositions` are `view` and may be
+///          called freely by frontends and the keeper.
+///
+///      Slippage: callers MUST pass non-zero `amount0Min` / `amount1Min`
+///      on deposit and withdraw. Implementations revert with
+///      `Errors.SlippageExceeded` on violation.
+interface IVault is IERC20 {
+    // -------------------------------------------------------------------------
+    // Types
+    // -------------------------------------------------------------------------
+
+    /// @notice One tick-range position held by the vault.
+    /// @dev Position liquidity is owned by the vault inside the
+    ///      PoolManager singleton — `liquidity` here is a snapshot for
+    ///      view consumers. Authoritative liquidity lives in
+    ///      PoolManager state.
+    /// @param tickLower Lower tick (must be aligned to pool tickSpacing).
+    /// @param tickUpper Upper tick (strictly greater than `tickLower`).
+    /// @param liquidity V4 liquidity units assigned to this position.
+    struct Position {
+        int24 tickLower;
+        int24 tickUpper;
+        uint128 liquidity;
+    }
+
+    // -------------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------------
+
+    /// @notice Emitted on every successful `deposit` after settlement.
+    /// @param user Recipient of the minted shares (`to` arg).
+    /// @param amount0 Token0 actually consumed (≤ `amount0Desired`).
+    /// @param amount1 Token1 actually consumed (≤ `amount1Desired`).
+    /// @param shares Shares minted to `user`.
+    event Deposit(address indexed user, uint256 amount0, uint256 amount1, uint256 shares);
+
+    /// @notice Emitted on every successful `withdraw` after settlement.
+    /// @param user Recipient of the withdrawn tokens (`to` arg).
+    /// @param amount0 Token0 transferred to `to`.
+    /// @param amount1 Token1 transferred to `to`.
+    /// @param shares Shares burned from the caller.
+    event Withdraw(address indexed user, uint256 amount0, uint256 amount1, uint256 shares);
+
+    /// @notice Emitted when the vault completes a rebalance.
+    /// @param tick Current pool tick at the moment positions were redeployed.
+    /// @param nPositions Number of `TargetPosition`s deployed by the strategy.
+    /// @param gasUsed Approximate gas consumed by the rebalance call body
+    ///        (recorded for the keeper to size its gas-price ceiling).
+    event Rebalanced(int24 tick, uint256 nPositions, uint256 gasUsed);
+
+    /// @notice Emitted when the vault collects accrued LP fees during
+    ///         deposit / withdraw / rebalance.
+    /// @param fees0 Token0 fees collected this op.
+    /// @param fees1 Token1 fees collected this op.
+    event FeesCollected(uint256 fees0, uint256 fees1);
+
+    // -------------------------------------------------------------------------
+    // Mutators
+    // -------------------------------------------------------------------------
+
+    /// @notice Deposit `amount0Desired` token0 + `amount1Desired` token1 in
+    ///         exchange for ERC-20 shares of the vault.
+    /// @dev Reverts with:
+    ///        - `Errors.DepositsPaused` when paused (per ADR-006).
+    ///        - `Errors.SlippageExceeded` when realised amounts fall
+    ///          below the user-supplied minimums.
+    ///        - `Errors.TVLCapExceeded` when the deposit would push
+    ///          notional above the per-vault cap.
+    ///        - `Errors.ZeroShares` when this is the first deposit and
+    ///          the share count would land below `MIN_SHARES`.
+    ///      Token transfers happen inside one `PoolManager.unlock`
+    ///      callback per ADR-004 — the caller MUST `approve` both
+    ///      tokens to the vault prior to calling.
+    /// @param amount0Desired Maximum token0 the caller is willing to spend.
+    /// @param amount1Desired Maximum token1 the caller is willing to spend.
+    /// @param amount0Min Lower bound on token0 actually consumed.
+    /// @param amount1Min Lower bound on token1 actually consumed.
+    /// @param to Recipient of the minted shares.
+    /// @return shares Shares minted to `to`.
+    /// @return amount0 Token0 consumed (= idle deposit + flash-accounted spend).
+    /// @return amount1 Token1 consumed.
+    function deposit(
+        uint256 amount0Desired,
+        uint256 amount1Desired,
+        uint256 amount0Min,
+        uint256 amount1Min,
+        address to
+    )
+        external
+        returns (uint256 shares, uint256 amount0, uint256 amount1);
+
+    /// @notice Burn `shares` and receive a proportional slice of every
+    ///         position the vault holds, plus a proportional slice of
+    ///         any idle balances.
+    /// @dev Always callable while the caller holds shares — invariant 6
+    ///      (withdrawals never pausable). Reverts with:
+    ///        - `Errors.InvalidShareAmount` for zero or > balance.
+    ///        - `Errors.SlippageExceeded` when realised amounts fall
+    ///          below the user-supplied minimums.
+    /// @param shares Share count to burn (must be > 0 and ≤ caller's balance).
+    /// @param amount0Min Lower bound on token0 transferred out.
+    /// @param amount1Min Lower bound on token1 transferred out.
+    /// @param to Recipient of the underlying token transfers.
+    /// @return amount0 Token0 transferred to `to`.
+    /// @return amount1 Token1 transferred to `to`.
+    function withdraw(
+        uint256 shares,
+        uint256 amount0Min,
+        uint256 amount1Min,
+        address to
+    )
+        external
+        returns (uint256 amount0, uint256 amount1);
+
+    /// @notice Permissionless rebalance trigger.
+    /// @dev Reverts with `Errors.RebalanceNotNeeded` when
+    ///      `IStrategy.shouldRebalance` returns false. On success the
+    ///      vault removes all current positions, performs an optional
+    ///      internal swap (slippage-bounded; per ADR-004), and deploys
+    ///      the new `TargetPosition[]` returned by
+    ///      `IStrategy.computePositions`, all inside one
+    ///      `PoolManager.unlock`. Emits `Rebalanced`.
+    function rebalance() external;
+
+    // -------------------------------------------------------------------------
+    // Views
+    // -------------------------------------------------------------------------
+
+    /// @notice Snapshot of the vault's currently deployed positions.
+    /// @dev Order matches `IStrategy.computePositions` output from the
+    ///      most recent rebalance. Empty array between deployment and
+    ///      first deposit.
+    /// @return positions Vault-held tick-range positions.
+    function getPositions() external view returns (Position[] memory positions);
+
+    /// @notice Total underlying assets the vault represents — idle
+    ///         balances plus the token-equivalent of every position's
+    ///         in-range liquidity at the current pool sqrt-price.
+    /// @dev Used for share-price computation and for the TVL cap check.
+    ///      Returns the same numbers the next deposit / withdraw would
+    ///      use as denominators.
+    /// @return total0 Token0-equivalent of all vault assets.
+    /// @return total1 Token1-equivalent of all vault assets.
+    function getTotalAmounts() external view returns (uint256 total0, uint256 total1);
+
+    /// @notice Pool this vault provides liquidity to.
+    /// @dev Returned by value — `PoolKey` is a struct, not a hash. The
+    ///      hook field is the singleton `ProtocolHook` address per
+    ///      ADR-002.
+    /// @return key The pool key (currency0, currency1, fee=DYNAMIC,
+    ///         tickSpacing, hooks=PROTOCOL_HOOK).
+    function poolKey() external view returns (PoolKey memory key);
+}

--- a/packages/contracts/test/hooks/ProtocolHook.t.sol
+++ b/packages/contracts/test/hooks/ProtocolHook.t.sol
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {Hooks} from "v4-core/libraries/Hooks.sol";
+import {BalanceDelta} from "v4-core/types/BalanceDelta.sol";
+import {Currency} from "v4-core/types/Currency.sol";
+
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {ModifyLiquidityParams, SwapParams} from "v4-core/types/PoolOperation.sol";
+
+import {ProtocolHook} from "../../src/hooks/ProtocolHook.sol";
+import {Errors} from "../../src/utils/Errors.sol";
+
+/// Mines a CREATE2 salt that yields an address satisfying the PRISM
+/// hook permission mask (0x05C0). Used by the test to deploy ProtocolHook
+/// at an address its constructor will accept.
+contract HookDeployer {
+    bytes32 internal constant CREATE2_INIT_HASH_SALT = bytes32(uint256(0));
+
+    function mineSalt(
+        bytes memory creationCode,
+        bytes memory ctorArgs
+    )
+        external
+        view
+        returns (bytes32 salt, address predicted)
+    {
+        bytes32 initCodeHash = keccak256(abi.encodePacked(creationCode, ctorArgs));
+        // 200_000 iterations is enough at 1/16384 hit rate.
+        for (uint256 i = 0; i < 200_000; i++) {
+            salt = bytes32(i);
+            predicted =
+                address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), address(this), salt, initCodeHash)))));
+            if (uint160(predicted) & 0x3FFF == 0x05C0) {
+                return (salt, predicted);
+            }
+        }
+        revert("salt not found");
+    }
+
+    function deploy(bytes32 salt, bytes memory creationCode, bytes memory ctorArgs) external returns (address addr) {
+        bytes memory initCode = abi.encodePacked(creationCode, ctorArgs);
+        assembly {
+            addr := create2(0, add(initCode, 0x20), mload(initCode), salt)
+        }
+        require(addr != address(0), "deploy failed");
+    }
+}
+
+contract ProtocolHookTest is Test {
+    address constant POOL_MANAGER = address(0xCafe);
+    address constant FACTORY = address(0xBeef);
+
+    HookDeployer deployer;
+    ProtocolHook hook;
+
+    function setUp() public {
+        deployer = new HookDeployer();
+        hook = _deployValidHook();
+    }
+
+    function _deployValidHook() internal returns (ProtocolHook) {
+        bytes memory ctorArgs = abi.encode(POOL_MANAGER, FACTORY);
+        (bytes32 salt, address predicted) = deployer.mineSalt(type(ProtocolHook).creationCode, ctorArgs);
+        address deployed = deployer.deploy(salt, type(ProtocolHook).creationCode, ctorArgs);
+        require(deployed == predicted, "predicted address mismatch");
+        return ProtocolHook(deployed);
+    }
+
+    // -------------------------------------------------------------------------
+    // Permissions
+    // -------------------------------------------------------------------------
+
+    function test_getHookPermissions_returnsExactBits() public view {
+        Hooks.Permissions memory p = hook.getHookPermissions();
+        assertTrue(p.beforeSwap, "beforeSwap");
+        assertTrue(p.afterSwap, "afterSwap");
+        assertTrue(p.afterAddLiquidity, "afterAddLiquidity");
+        assertTrue(p.afterRemoveLiquidity, "afterRemoveLiquidity");
+
+        assertFalse(p.beforeInitialize);
+        assertFalse(p.afterInitialize);
+        assertFalse(p.beforeAddLiquidity);
+        assertFalse(p.beforeRemoveLiquidity);
+        assertFalse(p.beforeDonate);
+        assertFalse(p.afterDonate);
+        assertFalse(p.beforeSwapReturnDelta);
+        assertFalse(p.afterSwapReturnDelta);
+        assertFalse(p.afterAddLiquidityReturnDelta);
+        assertFalse(p.afterRemoveLiquidityReturnDelta);
+    }
+
+    function test_addressBits_matchPermissions() public view {
+        // The deployed hook address must encode 0x05C0 in its low 14 bits.
+        assertEq(uint160(address(hook)) & 0x3FFF, 0x05C0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor reverts
+    // -------------------------------------------------------------------------
+
+    function test_constructor_revertsOnZeroPoolManager() public {
+        bytes memory ctorArgs = abi.encode(address(0), FACTORY);
+        // Mine a valid address even with bad ctor args — the bit check
+        // happens after the zero check, so we still need a valid address
+        // to ensure ZeroAddress fires before HookAddressNotValid.
+        (bytes32 salt,) = deployer.mineSalt(type(ProtocolHook).creationCode, ctorArgs);
+
+        vm.expectRevert();
+        deployer.deploy(salt, type(ProtocolHook).creationCode, ctorArgs);
+    }
+
+    function test_constructor_revertsOnZeroFactory() public {
+        bytes memory ctorArgs = abi.encode(POOL_MANAGER, address(0));
+        (bytes32 salt,) = deployer.mineSalt(type(ProtocolHook).creationCode, ctorArgs);
+
+        vm.expectRevert();
+        deployer.deploy(salt, type(ProtocolHook).creationCode, ctorArgs);
+    }
+
+    function test_constructor_revertsOnInvalidAddressBits() public {
+        // Deploy with a deliberately bad salt → predicted address won't
+        // have the right bits. Constructor's validateHookPermissions
+        // reverts.
+        bytes memory ctorArgs = abi.encode(POOL_MANAGER, FACTORY);
+        bytes32 badSalt = bytes32(uint256(0)); // overwhelmingly unlikely to be valid
+
+        vm.expectRevert();
+        deployer.deploy(badSalt, type(ProtocolHook).creationCode, ctorArgs);
+    }
+
+    // -------------------------------------------------------------------------
+    // onlyPoolManager / onlyFactory
+    // -------------------------------------------------------------------------
+
+    function test_beforeSwap_revertsForNonPoolManager() public {
+        PoolKey memory key = _emptyKey();
+        SwapParams memory params;
+
+        vm.prank(address(0xDeAd));
+        vm.expectRevert(Errors.OnlyPoolManager.selector);
+        hook.beforeSwap(address(this), key, params, "");
+    }
+
+    function test_afterSwap_revertsForNonPoolManager() public {
+        PoolKey memory key = _emptyKey();
+        SwapParams memory params;
+
+        vm.prank(address(0xDeAd));
+        vm.expectRevert(Errors.OnlyPoolManager.selector);
+        hook.afterSwap(address(this), key, params, BalanceDelta.wrap(0), "");
+    }
+
+    function test_afterAddLiquidity_revertsForNonPoolManager() public {
+        PoolKey memory key = _emptyKey();
+        ModifyLiquidityParams memory params;
+
+        vm.prank(address(0xDeAd));
+        vm.expectRevert(Errors.OnlyPoolManager.selector);
+        hook.afterAddLiquidity(address(this), key, params, BalanceDelta.wrap(0), BalanceDelta.wrap(0), "");
+    }
+
+    function test_afterRemoveLiquidity_revertsForNonPoolManager() public {
+        PoolKey memory key = _emptyKey();
+        ModifyLiquidityParams memory params;
+
+        vm.prank(address(0xDeAd));
+        vm.expectRevert(Errors.OnlyPoolManager.selector);
+        hook.afterRemoveLiquidity(address(this), key, params, BalanceDelta.wrap(0), BalanceDelta.wrap(0), "");
+    }
+
+    function test_registerVault_revertsForNonFactory() public {
+        vm.prank(address(0xDeAd));
+        vm.expectRevert(Errors.OnlyOwner.selector);
+        hook.registerVault(address(0x1234));
+    }
+
+    function test_registerVault_revertsOnZeroVault() public {
+        vm.prank(FACTORY);
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        hook.registerVault(address(0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Disabled callbacks
+    // -------------------------------------------------------------------------
+
+    function test_beforeInitialize_revertsAlways() public {
+        PoolKey memory key = _emptyKey();
+        vm.expectRevert(Errors.UnknownOp.selector);
+        hook.beforeInitialize(address(this), key, 0);
+    }
+
+    function test_afterInitialize_revertsAlways() public {
+        PoolKey memory key = _emptyKey();
+        vm.expectRevert(Errors.UnknownOp.selector);
+        hook.afterInitialize(address(this), key, 0, 0);
+    }
+
+    function test_beforeAddLiquidity_revertsAlways() public {
+        PoolKey memory key = _emptyKey();
+        ModifyLiquidityParams memory params;
+        vm.expectRevert(Errors.UnknownOp.selector);
+        hook.beforeAddLiquidity(address(this), key, params, "");
+    }
+
+    function test_beforeRemoveLiquidity_revertsAlways() public {
+        PoolKey memory key = _emptyKey();
+        ModifyLiquidityParams memory params;
+        vm.expectRevert(Errors.UnknownOp.selector);
+        hook.beforeRemoveLiquidity(address(this), key, params, "");
+    }
+
+    // -------------------------------------------------------------------------
+    // Stub views (will be replaced in #35/#36)
+    // -------------------------------------------------------------------------
+
+    function test_currentFee_returnsZeroStub() public view {
+        assertEq(hook.currentFee(bytes32(uint256(1))), 0);
+    }
+
+    function test_mevProfits_returnsZeroStub() public view {
+        (uint256 a, uint256 b) = hook.mevProfits(address(0x1234));
+        assertEq(a, 0);
+        assertEq(b, 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    function _emptyKey() internal pure returns (PoolKey memory) {
+        return PoolKey({
+            currency0: Currency.wrap(address(0)),
+            currency1: Currency.wrap(address(1)),
+            fee: 0,
+            tickSpacing: 60,
+            hooks: IHooks(address(0))
+        });
+    }
+}

--- a/packages/contracts/test/hooks/ProtocolHook.t.sol
+++ b/packages/contracts/test/hooks/ProtocolHook.t.sol
@@ -219,8 +219,9 @@ contract ProtocolHookTest is Test {
     // Stub views (will be replaced in #35/#36)
     // -------------------------------------------------------------------------
 
-    function test_currentFee_returnsZeroStub() public view {
-        assertEq(hook.currentFee(bytes32(uint256(1))), 0);
+    function test_currentFee_returnsDefaultBeforeSwap() public view {
+        // No swaps have been observed → fee state is empty → DEFAULT_FEE.
+        assertEq(hook.currentFee(bytes32(uint256(1))), 3000);
     }
 
     function test_mevProfits_returnsZeroStub() public view {

--- a/packages/contracts/test/interfaces/IProtocolHook.t.sol
+++ b/packages/contracts/test/interfaces/IProtocolHook.t.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {Hooks} from "v4-core/libraries/Hooks.sol";
+
+import {IProtocolHook} from "../../src/interfaces/IProtocolHook.sol";
+
+/// @notice Compile-time + selector-stability tests for `IProtocolHook`.
+///
+/// The behavioural tests on the hook implementation (#34, #35, #36) cover
+/// real callback semantics — this file only verifies the interface
+/// surface: signatures match V4's IHooks, the additional read accessors
+/// have stable selectors, and the events have stable topics.
+contract IProtocolHookTest is Test {
+    // -------------------------------------------------------------------------
+    // V4 IHooks inheritance
+    //
+    // Solidity does not expose inherited interface members through
+    // `IProtocolHook.<member>.selector` — the inheritance is enforced
+    // at the ABI level only. The compile-time `IHooks h = IProtocolHook(...)`
+    // assignment proves the IS-A relationship; v4-core owns the
+    // selector-stability tests for IHooks itself.
+    // -------------------------------------------------------------------------
+
+    function test_inherits_IHooks_isa() external pure {
+        IProtocolHook ph = IProtocolHook(address(0));
+        IHooks h = IHooks(ph);
+        assertEq(address(h), address(ph));
+    }
+
+    function test_v4_IHooks_callback_selectors_stable() external pure {
+        // Pin the four selectors PRISM relies on. If v4-core ever changes
+        // its IHooks shape, this test trips before users hit the bug.
+        assertEq(
+            IHooks.beforeSwap.selector,
+            bytes4(keccak256("beforeSwap(address,(address,address,uint24,int24,address),(bool,int256,uint160),bytes)"))
+        );
+        assertEq(
+            IHooks.afterSwap.selector,
+            bytes4(
+                keccak256(
+                    "afterSwap(address,(address,address,uint24,int24,address),(bool,int256,uint160),int256,bytes)"
+                )
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // PRISM-specific surface
+    // -------------------------------------------------------------------------
+
+    function test_selector_registerVault() external pure {
+        assertEq(IProtocolHook.registerVault.selector, bytes4(keccak256("registerVault(address)")));
+    }
+
+    function test_selector_currentFee() external pure {
+        assertEq(IProtocolHook.currentFee.selector, bytes4(keccak256("currentFee(bytes32)")));
+    }
+
+    function test_selector_mevProfits() external pure {
+        assertEq(IProtocolHook.mevProfits.selector, bytes4(keccak256("mevProfits(address)")));
+    }
+
+    function test_selector_getHookPermissions() external pure {
+        assertEq(IProtocolHook.getHookPermissions.selector, bytes4(keccak256("getHookPermissions()")));
+    }
+
+    // -------------------------------------------------------------------------
+    // Event topics
+    // -------------------------------------------------------------------------
+
+    function test_event_FeeUpdated_topic() external pure {
+        assertEq(IProtocolHook.FeeUpdated.selector, keccak256("FeeUpdated(bytes32,uint24,uint256)"));
+    }
+
+    function test_event_SwapObserved_topic() external pure {
+        assertEq(IProtocolHook.SwapObserved.selector, keccak256("SwapObserved(bytes32,int24,uint160)"));
+    }
+
+    function test_event_MEVCaptured_topic() external pure {
+        assertEq(IProtocolHook.MEVCaptured.selector, keccak256("MEVCaptured(address,uint256,bool)"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Permissions matrix — PRISM enables exactly bits 6, 7, 8, 10 (= 0x05C0)
+    //
+    // The permission *value* is ultimately produced by an implementation,
+    // but the interface guarantees the return type is `Hooks.Permissions`
+    // so call sites can construct the canonical PRISM permission set.
+    // -------------------------------------------------------------------------
+
+    function test_canonicalPRISMPermissions_compileGate() external pure {
+        Hooks.Permissions memory p = Hooks.Permissions({
+            beforeInitialize: false,
+            afterInitialize: false,
+            beforeAddLiquidity: false,
+            afterAddLiquidity: true, // bit 10 — 0x0400
+            beforeRemoveLiquidity: false,
+            afterRemoveLiquidity: true, // bit 8 — 0x0100
+            beforeSwap: true, // bit 7 — 0x0080
+            afterSwap: true, // bit 6 — 0x0040
+            beforeDonate: false,
+            afterDonate: false,
+            beforeSwapReturnDelta: false,
+            afterSwapReturnDelta: false,
+            afterAddLiquidityReturnDelta: false,
+            afterRemoveLiquidityReturnDelta: false
+        });
+        // Combined bits: 0x0400 + 0x0100 + 0x0080 + 0x0040 = 0x05C0.
+        assertTrue(p.beforeSwap && p.afterSwap && p.afterAddLiquidity && p.afterRemoveLiquidity);
+        assertFalse(p.beforeInitialize || p.afterInitialize);
+    }
+}

--- a/packages/contracts/test/interfaces/IVault.t.sol
+++ b/packages/contracts/test/interfaces/IVault.t.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {Currency} from "v4-core/types/Currency.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+
+import {IVault} from "../../src/interfaces/IVault.sol";
+
+/// @notice Compile-time + selector-stability tests for `IVault`.
+/// @dev Interfaces have no runtime behaviour to exercise. The tests:
+///      1. Force the interface to compile under the Foundry pipeline by
+///         instantiating a mock that fully implements it.
+///      2. Snapshot every external function selector and event topic so
+///         downstream consumers (frontend ABI exporter, keeper, indexer)
+///         catch accidental signature drift in CI.
+contract IVaultMock is IVault {
+    PoolKey internal _poolKey;
+
+    function setPoolKey(PoolKey memory k) external {
+        _poolKey = k;
+    }
+
+    // -- IERC20 --
+    function totalSupply() external pure returns (uint256) {
+        return 0;
+    }
+
+    function balanceOf(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function transfer(address, uint256) external pure returns (bool) {
+        return true;
+    }
+
+    function allowance(address, address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function approve(address, uint256) external pure returns (bool) {
+        return true;
+    }
+
+    function transferFrom(address, address, uint256) external pure returns (bool) {
+        return true;
+    }
+
+    // -- IVault --
+    function deposit(uint256, uint256, uint256, uint256, address) external pure returns (uint256, uint256, uint256) {
+        return (0, 0, 0);
+    }
+
+    function withdraw(uint256, uint256, uint256, address) external pure returns (uint256, uint256) {
+        return (0, 0);
+    }
+
+    function rebalance() external pure {}
+
+    function getPositions() external pure returns (Position[] memory) {
+        return new Position[](0);
+    }
+
+    function getTotalAmounts() external pure returns (uint256, uint256) {
+        return (0, 0);
+    }
+
+    function poolKey() external view returns (PoolKey memory) {
+        return _poolKey;
+    }
+}
+
+contract IVaultTest is Test {
+    // -------------------------------------------------------------------------
+    // Mock instantiation — proves interface is implementable end-to-end
+    // -------------------------------------------------------------------------
+
+    function test_mock_compilesAndRoundTrips() external {
+        IVaultMock m = new IVaultMock();
+
+        PoolKey memory k = PoolKey({
+            currency0: Currency.wrap(address(0x1)),
+            currency1: Currency.wrap(address(0x2)),
+            fee: 0x800000, // V4 dynamic-fee flag
+            tickSpacing: 60,
+            hooks: IHooks(address(0xCAFE))
+        });
+        m.setPoolKey(k);
+
+        PoolKey memory r = m.poolKey();
+        assertEq(Currency.unwrap(r.currency0), address(0x1));
+        assertEq(Currency.unwrap(r.currency1), address(0x2));
+        assertEq(r.tickSpacing, 60);
+        assertEq(address(r.hooks), address(0xCAFE));
+    }
+
+    // -------------------------------------------------------------------------
+    // Selector snapshots
+    // -------------------------------------------------------------------------
+
+    function test_selector_deposit() external pure {
+        assertEq(IVault.deposit.selector, bytes4(keccak256("deposit(uint256,uint256,uint256,uint256,address)")));
+    }
+
+    function test_selector_withdraw() external pure {
+        assertEq(IVault.withdraw.selector, bytes4(keccak256("withdraw(uint256,uint256,uint256,address)")));
+    }
+
+    function test_selector_rebalance() external pure {
+        assertEq(IVault.rebalance.selector, bytes4(keccak256("rebalance()")));
+    }
+
+    function test_selector_getPositions() external pure {
+        assertEq(IVault.getPositions.selector, bytes4(keccak256("getPositions()")));
+    }
+
+    function test_selector_getTotalAmounts() external pure {
+        assertEq(IVault.getTotalAmounts.selector, bytes4(keccak256("getTotalAmounts()")));
+    }
+
+    function test_selector_poolKey() external pure {
+        assertEq(IVault.poolKey.selector, bytes4(keccak256("poolKey()")));
+    }
+
+    // -------------------------------------------------------------------------
+    // Event topic snapshots
+    // -------------------------------------------------------------------------
+
+    function test_event_Deposit_topic() external pure {
+        assertEq(IVault.Deposit.selector, keccak256("Deposit(address,uint256,uint256,uint256)"));
+    }
+
+    function test_event_Withdraw_topic() external pure {
+        assertEq(IVault.Withdraw.selector, keccak256("Withdraw(address,uint256,uint256,uint256)"));
+    }
+
+    function test_event_Rebalanced_topic() external pure {
+        assertEq(IVault.Rebalanced.selector, keccak256("Rebalanced(int24,uint256,uint256)"));
+    }
+
+    function test_event_FeesCollected_topic() external pure {
+        assertEq(IVault.FeesCollected.selector, keccak256("FeesCollected(uint256,uint256)"));
+    }
+
+    // -------------------------------------------------------------------------
+    // ERC-20 surface inherited
+    // -------------------------------------------------------------------------
+
+    function test_inherits_IERC20() external pure {
+        // Compile-time guarantee: an `IVault` is assignable to an `IERC20`
+        // typed slot. This both documents the inheritance and would fail
+        // to compile if the interface were ever changed not to inherit.
+        IVault v = IVault(address(0));
+        IERC20 e = IERC20(v);
+        assertEq(address(e), address(v));
+    }
+}


### PR DESCRIPTION
## Summary

Singleton V4 hook (ADR-002) wiring: permissions matrix, address-bit assertion, onlyPoolManager / onlyFactory guards, vault registry, IHooks callback skeleton. The hot-path bodies in \`beforeSwap\` (#35) and \`afterSwap\` (#36) ship as canonical no-op sentinels for now so a deployed hook composes correctly with PoolManager and the test pool can already run swaps.

### Permission matrix

Enabled (bits 6, 7, 8, 10) → combined \`0x05C0\`:
- afterSwap (6), beforeSwap (7), afterRemoveLiquidity (8), afterAddLiquidity (10)

Constructor calls \`Hooks.validateHookPermissions\` → reverts \`HookAddressNotValid\` if the CREATE2 salt was not mined to encode these flags. HookMiner (#25) is the off-chain helper.

### Guarantees

- afterAddLiquidity / afterRemoveLiquidity are pure no-ops (return \`BalanceDelta(0)\`) — **must not revert** per ADR-002 hard rule (withdraw path)
- Disabled callbacks revert \`UnknownOp\` as defence-in-depth
- onlyFactory \`registerVault\` resolves \`vault.poolKey()\` and records \`PoolId → vault\`

### Test deployment

A test-only \`HookDeployer\` mines a CREATE2 salt (~1/16384 hit rate, capped at 200k iterations) and deploys via inline \`create2\`. Validates predicted == deployed and that low-14 bits == 0x05C0.

## Quality gates

- \`forge build\`: pass
- \`forge fmt\`: clean
- \`forge test test/hooks/ProtocolHook.t.sol\`: **17/17 pass**

## Test plan

- [x] Permission struct exact bits (4 true / 10 false)
- [x] address & 0x3FFF == 0x05C0
- [x] Constructor reverts: zero poolManager, zero factory, invalid bits
- [x] onlyPoolManager on beforeSwap, afterSwap, afterAdd, afterRemove
- [x] onlyFactory + zero-vault on registerVault
- [x] Disabled callbacks always revert UnknownOp
- [x] currentFee + mevProfits return 0 placeholders
- [ ] (deferred) gas snapshots — meaningful only after #35/#36 fill bodies

## Dependencies

- Stacked on **#18 (contracts/18-reentrancy)** — chain: #17 → #18 → #34
- Cherry-picks IProtocolHook (#21) and IVault (#19) commits — those interfaces must be on the branch for the implementation to compile
- Unblocks #35 (beforeSwap), #36 (afterSwap), #31 (VaultFactory deploys via HookMiner)

Closes #34