### PR TITLE
ci: keeper workflow + Dockerfile (#63)

### DIFF
--- a/.github/workflows/keeper.yml
+++ b/.github/workflows/keeper.yml
@@ -1,0 +1,97 @@
+name: keeper
+
+on:
+  pull_request:
+    paths:
+      - "apps/keeper/**"
+      - "packages/shared/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/keeper.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/keeper/**"
+      - "packages/shared/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/keeper.yml"
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: "20"
+  PNPM_VERSION: "10.18.0"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # -------------------------------------------------------------------------
+  # typecheck + lint + build
+  # -------------------------------------------------------------------------
+  typecheck-lint-build:
+    name: typecheck · lint · build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck shared
+        run: pnpm --filter @prism/shared typecheck
+
+      - name: Typecheck keeper
+        run: pnpm --filter @prism/keeper typecheck
+
+      - name: Lint keeper
+        run: pnpm --filter @prism/keeper lint
+
+      - name: Build keeper
+        run: pnpm --filter @prism/keeper build
+
+  # -------------------------------------------------------------------------
+  # docker build smoke test
+  #
+  # Builds the keeper image to catch Dockerfile regressions on PR.
+  # Image push lands in #66 with the rest of the deploy pipeline.
+  # -------------------------------------------------------------------------
+  docker-build:
+    name: docker build
+    runs-on: ubuntu-latest
+    needs: typecheck-lint-build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build keeper image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/keeper/Dockerfile
+          push: false
+          load: true
+          tags: prism-keeper:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/apps/keeper/Dockerfile
+++ b/apps/keeper/Dockerfile
@@ -1,0 +1,46 @@
+# PRISM keeper — production image (alpha; #60 will harden lifecycle).
+#
+# Two-stage build:
+#   1. deps stage — installs pnpm + the workspace deps once, layer-cached
+#      across rebuilds when only source changes
+#   2. runtime stage — minimal node:alpine with the built JS, runs the
+#      keeper as a non-root user
+#
+# This Dockerfile is referenced by .github/workflows/keeper.yml (#63)
+# for the docker-build smoke test on every PR. Image push lives in #66.
+FROM node:20-alpine AS deps
+
+WORKDIR /repo
+RUN apk add --no-cache libc6-compat
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY apps/keeper/package.json ./apps/keeper/
+COPY packages/shared/package.json ./packages/shared/
+COPY packages/shared/ ./packages/shared/
+
+RUN corepack enable && corepack prepare pnpm@10.18.0 --activate
+RUN pnpm install --frozen-lockfile --filter @prism/keeper...
+
+COPY apps/keeper/ ./apps/keeper/
+
+RUN pnpm --filter @prism/keeper build
+
+# -----------------------------------------------------------------------
+FROM node:20-alpine AS runtime
+
+WORKDIR /app
+
+# Copy the built keeper + its production dependency closure.
+COPY --from=deps /repo/apps/keeper/dist ./dist
+COPY --from=deps /repo/node_modules ./node_modules
+COPY --from=deps /repo/apps/keeper/node_modules ./apps/keeper/node_modules
+COPY --from=deps /repo/packages/shared ./packages/shared
+COPY --from=deps /repo/apps/keeper/package.json ./apps/keeper/package.json
+
+# Drop privileges. The default node:alpine "node" user has uid 1000.
+USER node
+
+# Health endpoint port (planned in #60). Documented for ops.
+EXPOSE 8080
+
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary

Pre-merge CI gate for \`apps/keeper\`. Mirrors the web.yml pattern (#62) and the contracts.yml conventions (#61).

### Jobs

- **typecheck-lint-build** — shared install then typecheck (shared + keeper), lint, \`tsc -p\` build
- **docker-build** — buildx-driven smoke test of the keeper image with GHA cache. Push lives in #66.

### apps/keeper/Dockerfile

Alpha image (#60 hardens lifecycle):
- Two-stage \`node:20-alpine\` build (deps + runtime)
- Filtered \`pnpm install --filter @prism/keeper...\`
- Drops to non-root \`node\` user
- Exposes 8080 for the planned /health endpoint

### Pinned versions

- Node 20
- pnpm 10.18.0
- GHA Buildx + docker/build-push-action@v6 with \`type=gha\` cache

## Quality gates

- \`pnpm --filter @prism/keeper build\`: pass locally

## Test plan

- [x] keeper builds locally with \`tsc -p\`
- [ ] CI green on this PR
- [ ] image actually starts after \`docker run\` (smoke; reviewer verify if changing Dockerfile)

## Dependencies

- Stacked on #55 (keeper/55-scaffold). Build target must exist for CI to do anything meaningful.
- Unblocks #56–#60 (keeper iteration), #66 (deploy pipeline pushes the image)

Closes #63