### PR TITLE
feat(frontend): wallet + network error UI (#54)

### DIFF
--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -2,11 +2,13 @@ import type {ReactNode} from "react";
 
 import {Footer} from "./Footer";
 import {Header} from "./Header";
+import {WrongNetworkBanner} from "./WrongNetworkBanner";
 
 export function AppShell({children}: {children: ReactNode}) {
   return (
     <div className="flex min-h-screen flex-col">
       <Header />
+      <WrongNetworkBanner />
       <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-8">{children}</main>
       <Footer />
     </div>

--- a/apps/web/components/TxErrorToast.tsx
+++ b/apps/web/components/TxErrorToast.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import {useEffect} from "react";
+
+import {classifyTxError, type TxError} from "@/lib/tx-errors";
+
+type Props = {
+  error: unknown;
+  onDismiss: () => void;
+};
+
+const TITLES: Record<TxError["kind"], string> = {
+  rejected: "Rejected",
+  "insufficient-funds": "Insufficient funds",
+  "wrong-network": "Wrong network",
+  rpc: "RPC error",
+  unknown: "Transaction failed",
+};
+
+/**
+ * Inline toast-style banner for failed transactions.
+ *
+ * v1.0 surfaces tx errors inline next to the form rather than via a
+ * global toast portal — that lands with #4 component library
+ * (Sonner-backed). For now this is a self-contained, dismissable card
+ * that classifies the error into one of five tiers via tx-errors.ts.
+ */
+export function TxErrorToast({error, onDismiss}: Props) {
+  const classified = classifyTxError(error);
+
+  // Auto-dismiss user-rejection errors after 5s — they're not actionable.
+  // Other classes persist until manual dismiss; per design spec
+  // (component-library.md), error toasts must not vanish before reading.
+  useEffect(() => {
+    if (classified.kind !== "rejected") return;
+    const id = setTimeout(onDismiss, 5_000);
+    return () => clearTimeout(id);
+  }, [classified.kind, onDismiss]);
+
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-3 rounded-lg border border-danger/40 bg-danger/10 p-4 text-sm"
+    >
+      <span aria-hidden className="mt-0.5 h-2 w-2 flex-shrink-0 rounded-pill bg-danger" />
+      <div className="flex-1">
+        <p className="font-medium text-danger">{TITLES[classified.kind]}</p>
+        <p className="mt-1 text-text-muted">{classified.message}</p>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        className="text-text-faint transition-colors duration-fast ease-standard hover:text-text"
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
+          <path d="M1 1l12 12M13 1L1 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/apps/web/components/WrongNetworkBanner.tsx
+++ b/apps/web/components/WrongNetworkBanner.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import {useEffect, useState} from "react";
+import {useAccount, useSwitchChain} from "wagmi";
+import {baseSepolia} from "wagmi/chains";
+
+const EXPECTED_CHAIN_ID = baseSepolia.id; // 84_532
+
+/**
+ * Sticky banner shown when a connected wallet is on the wrong chain.
+ *
+ * v1.0 supports Base Sepolia only. Mainnet (Base, 8453) is gated on
+ * audit completion (M5) — even Base mainnet is treated as "wrong
+ * network" until then so users don't accidentally interact with
+ * non-existent contracts.
+ *
+ * The banner gates wagmi hook usage behind a useMounted guard so the
+ * Next 14 static prerender doesn't try to read indexedDB or wagmi
+ * context (neither exists during export).
+ */
+export function WrongNetworkBanner() {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+  return <WrongNetworkBannerInner />;
+}
+
+function WrongNetworkBannerInner() {
+  const {isConnected, chainId} = useAccount();
+  const {switchChain, isPending: isSwitching} = useSwitchChain();
+
+  if (!isConnected) return null;
+  if (chainId === EXPECTED_CHAIN_ID) return null;
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="border-b border-warning/40 bg-warning/10 px-4 py-2 text-sm"
+    >
+      <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-2">
+        <span className="text-warning">
+          Wrong network — PRISM v1.0 runs on Base Sepolia (chain {EXPECTED_CHAIN_ID}).
+        </span>
+        <button
+          type="button"
+          onClick={() => switchChain({chainId: EXPECTED_CHAIN_ID})}
+          disabled={isSwitching}
+          className="rounded-md border border-warning/60 bg-warning/20 px-3 py-1 text-xs text-warning transition-colors duration-fast ease-standard hover:bg-warning/30 disabled:opacity-60"
+        >
+          {isSwitching ? "Switching…" : "Switch network"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/tx-errors.ts
+++ b/apps/web/lib/tx-errors.ts
@@ -1,0 +1,39 @@
+import {BaseError, UserRejectedRequestError} from "viem";
+
+export type TxError =
+  | {kind: "rejected"; message: string}
+  | {kind: "insufficient-funds"; message: string}
+  | {kind: "wrong-network"; message: string}
+  | {kind: "rpc"; message: string}
+  | {kind: "unknown"; message: string};
+
+const INSUFFICIENT_FUNDS_RE = /insufficient (funds|balance)/i;
+const WRONG_NETWORK_RE = /chain.*mismatch|unsupported chain|wrong network/i;
+
+export function classifyTxError(err: unknown): TxError {
+  if (err instanceof UserRejectedRequestError) {
+    return {kind: "rejected", message: "Transaction was rejected in your wallet."};
+  }
+
+  if (err instanceof BaseError) {
+    const walked = err.walk((e) => e instanceof UserRejectedRequestError);
+    if (walked instanceof UserRejectedRequestError) {
+      return {kind: "rejected", message: "Transaction was rejected in your wallet."};
+    }
+
+    const shortMsg = err.shortMessage ?? err.message;
+    if (INSUFFICIENT_FUNDS_RE.test(shortMsg)) {
+      return {kind: "insufficient-funds", message: shortMsg};
+    }
+    if (WRONG_NETWORK_RE.test(shortMsg)) {
+      return {kind: "wrong-network", message: shortMsg};
+    }
+    return {kind: "rpc", message: shortMsg};
+  }
+
+  if (err instanceof Error) {
+    return {kind: "unknown", message: err.message};
+  }
+
+  return {kind: "unknown", message: "An unexpected error occurred."};
+}


### PR DESCRIPTION
## Summary

Three surfaces for the common wallet/network error states. Pairs with the design contract in #4 (Toast variants) and the \`TxStatus\` discriminated union already in \`@prism/shared\`.

### What's added

- \`components/WrongNetworkBanner.tsx\` — sticky banner under the Header when a connected wallet is on the wrong chain. Calls \`useSwitchChain\` to flip to Base Sepolia (84_532). Mount-guarded so wagmi hooks don't run during static prerender.
- \`lib/tx-errors.ts\` — \`classifyTxError(err)\`: walks viem errors via \`err.walk()\` and returns one of \`{rejected, insufficient-funds, wrong-network, rpc, unknown}\`. Each tier has user-facing copy.
- \`components/TxErrorToast.tsx\` — inline toast (no portal yet; Sonner lands with #4 impl). User-rejected errors auto-dismiss after 5s; everything else persists until manual close (design rule: "errors must not vanish before reading").

### AppShell wiring

\`AppShell\` mounts the WrongNetworkBanner once below the Header — every page surfaces the network state without per-page wiring.

## Quality gates

- \`pnpm --filter @prism/web typecheck\` → pass
- \`pnpm --filter @prism/web lint\` → no warnings
- \`pnpm --filter @prism/web build\` → pass (static prerender clean)

## Test plan

- [x] typecheck, lint, build green
- [ ] connect a wallet on Ethereum mainnet → banner shows + switch button works (browser test)
- [ ] reject a tx in MetaMask → \`TxErrorToast\` shows "Rejected" and auto-dismisses
- [ ] portal-based Sonner replacement lands with #4 impl

## Dependencies

- Stacked on #47 (frontend/47-app-shell). Header / providers already in place.

Closes #54