### PR TITLE
feat(frontend): /vaults/[address] detail layout (#50)

### DIFF
--- a/apps/web/app/vaults/[address]/page.tsx
+++ b/apps/web/app/vaults/[address]/page.tsx
@@ -2,8 +2,9 @@
 
 import {notFound} from "next/navigation";
 import {useMemo} from "react";
-import {isAddress} from "viem";
+import {isAddress, zeroAddress, type Address} from "viem";
 
+import {DepositForm} from "@/components/DepositForm";
 import {PrismVisual, type PrismPosition} from "@/components/PrismVisual";
 import {formatBps, formatUsd} from "@/lib/vault-list";
 
@@ -41,7 +42,11 @@ export default function VaultDetailPage({params}: PageProps) {
 
       <PositionsTable positions={detail.positions} />
 
-      <DepositPanel placeholder />
+      <DepositForm
+        vaultAddress={detail.address as Address}
+        token0={detail.token0}
+        token1={detail.token1}
+      />
     </article>
   );
 }
@@ -108,22 +113,15 @@ function PositionsTable({positions}: {positions: PlaceholderPosition[]}) {
   );
 }
 
-function DepositPanel({placeholder}: {placeholder: boolean}) {
-  return (
-    <section className="rounded-xl border border-border bg-surface p-5 shadow-card">
-      <h2 className="mb-2 text-base font-medium text-text">Deposit</h2>
-      <p className="text-sm text-text-muted">
-        {placeholder
-          ? "Form lands with #52 (deposit form). Wallet + wagmi reads are wired; M2 contracts surface the on-chain state."
-          : null}
-      </p>
-    </section>
-  );
-}
-
 interface PlaceholderPosition extends PrismPosition {
   token0: bigint;
   token1: bigint;
+}
+
+interface PlaceholderToken {
+  address: Address;
+  symbol: string;
+  decimals: number;
 }
 
 interface PlaceholderDetail {
@@ -136,6 +134,8 @@ interface PlaceholderDetail {
   positions: PlaceholderPosition[];
   currentTick: number;
   tickSpacing: number;
+  token0: PlaceholderToken;
+  token1: PlaceholderToken;
 }
 
 function usePlaceholderVault(address: string): PlaceholderDetail {
@@ -157,6 +157,10 @@ function usePlaceholderVault(address: string): PlaceholderDetail {
       ],
       currentTick: 0,
       tickSpacing: 60,
+      // Token metadata is fixed for the placeholder vault; real values
+      // come from the data layer once #31 (VaultFactory) lands.
+      token0: {address: zeroAddress, symbol: "WETH", decimals: 18},
+      token1: {address: zeroAddress, symbol: "USDC", decimals: 6},
     }),
     [address],
   );

--- a/apps/web/app/vaults/[address]/page.tsx
+++ b/apps/web/app/vaults/[address]/page.tsx
@@ -4,6 +4,7 @@ import {notFound} from "next/navigation";
 import {useMemo} from "react";
 import {isAddress} from "viem";
 
+import {PrismVisual, type PrismPosition} from "@/components/PrismVisual";
 import {formatBps, formatUsd} from "@/lib/vault-list";
 
 interface PageProps {
@@ -31,6 +32,12 @@ export default function VaultDetailPage({params}: PageProps) {
         <Metric label="APR (24h)" value={formatBps(detail.apr24hBps)} />
         <Metric label="Share price" value={formatUsd(detail.sharePriceUsd)} />
       </section>
+
+      <PrismVisual
+        positions={detail.positions}
+        currentTick={detail.currentTick}
+        tickSpacing={detail.tickSpacing}
+      />
 
       <PositionsTable positions={detail.positions} />
 
@@ -114,10 +121,7 @@ function DepositPanel({placeholder}: {placeholder: boolean}) {
   );
 }
 
-interface PlaceholderPosition {
-  tickLower: number;
-  tickUpper: number;
-  liquidity: bigint;
+interface PlaceholderPosition extends PrismPosition {
   token0: bigint;
   token1: bigint;
 }
@@ -130,6 +134,8 @@ interface PlaceholderDetail {
   apr24hBps: number;
   sharePriceUsd: bigint;
   positions: PlaceholderPosition[];
+  currentTick: number;
+  tickSpacing: number;
 }
 
 function usePlaceholderVault(address: string): PlaceholderDetail {
@@ -141,7 +147,16 @@ function usePlaceholderVault(address: string): PlaceholderDetail {
       tvlUsd: 0n,
       apr24hBps: 0,
       sharePriceUsd: 1_000_000n, // 1.000000 USDC (6 decimals)
-      positions: [],
+      // Placeholder shape — three positions either side of tick 0,
+      // weighted to draw a recognisable bell. Real values land with
+      // #31 (VaultFactory) + getTotalAmounts wire-up in M2.
+      positions: [
+        {tickLower: -1200, tickUpper: -600, liquidity: 4_000_000n, token0: 0n, token1: 0n},
+        {tickLower: -600, tickUpper: 600, liquidity: 10_000_000n, token0: 0n, token1: 0n},
+        {tickLower: 600, tickUpper: 1200, liquidity: 4_000_000n, token0: 0n, token1: 0n},
+      ],
+      currentTick: 0,
+      tickSpacing: 60,
     }),
     [address],
   );

--- a/apps/web/app/vaults/[address]/page.tsx
+++ b/apps/web/app/vaults/[address]/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import {notFound} from "next/navigation";
+import {useMemo} from "react";
+import {isAddress} from "viem";
+
+import {formatBps, formatUsd} from "@/lib/vault-list";
+
+interface PageProps {
+  params: {address: string};
+}
+
+export default function VaultDetailPage({params}: PageProps) {
+  const {address} = params;
+  if (!isAddress(address)) {
+    notFound();
+  }
+
+  // Real reads land in M2 once #31 (VaultFactory) ships and the data
+  // layer can resolve a vault address to its config + on-chain state.
+  // Until then we render the layout with placeholder values so the
+  // page composes correctly under the app shell + brand tokens.
+  const detail = usePlaceholderVault(address);
+
+  return (
+    <article className="flex flex-col gap-8 py-2">
+      <Header pairName={detail.pairName} versionLabel={detail.versionLabel} address={detail.address} />
+
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <Metric label="TVL" value={formatUsd(detail.tvlUsd)} />
+        <Metric label="APR (24h)" value={formatBps(detail.apr24hBps)} />
+        <Metric label="Share price" value={formatUsd(detail.sharePriceUsd)} />
+      </section>
+
+      <PositionsTable positions={detail.positions} />
+
+      <DepositPanel placeholder />
+    </article>
+  );
+}
+
+function Header({pairName, versionLabel, address}: {pairName: string; versionLabel: string; address: string}) {
+  return (
+    <header className="flex flex-col gap-3">
+      <span className="inline-flex items-center gap-2">
+        <span aria-hidden className="h-6 w-6 rounded-md bg-spectrum-arc shadow-glow-violet" />
+        <h1 className="text-3xl font-semibold tracking-tight text-text">{pairName}</h1>
+        <span className="rounded-pill border border-accent/40 bg-accent/10 px-2 py-0.5 text-xs text-accent">
+          {versionLabel}
+        </span>
+      </span>
+      <p className="font-mono text-xs text-text-faint" aria-label={`Vault address ${address}`}>
+        {address}
+      </p>
+    </header>
+  );
+}
+
+function Metric({label, value}: {label: string; value: string}) {
+  return (
+    <div className="rounded-xl border border-border bg-surface p-5 shadow-card">
+      <p className="text-xs uppercase tracking-wide text-text-faint">{label}</p>
+      <p className="mt-2 font-mono text-2xl font-semibold text-text">{value}</p>
+    </div>
+  );
+}
+
+function PositionsTable({positions}: {positions: PlaceholderPosition[]}) {
+  return (
+    <section className="rounded-xl border border-border bg-surface p-5 shadow-card">
+      <h2 className="mb-4 text-base font-medium text-text">Positions</h2>
+      {positions.length === 0 ? (
+        <p className="text-sm text-text-muted">No positions deployed yet.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="text-xs uppercase tracking-wide text-text-faint">
+              <tr>
+                <th className="py-2 text-left font-medium">Range</th>
+                <th className="py-2 text-right font-medium">Liquidity</th>
+                <th className="py-2 text-right font-medium">Token0</th>
+                <th className="py-2 text-right font-medium">Token1</th>
+              </tr>
+            </thead>
+            <tbody>
+              {positions.map((p, i) => (
+                <tr key={i} className="border-t border-border">
+                  <td className="py-3 font-mono text-text">
+                    {p.tickLower} → {p.tickUpper}
+                  </td>
+                  <td className="py-3 text-right font-mono text-text-muted">{p.liquidity.toString()}</td>
+                  <td className="py-3 text-right font-mono text-text-muted">{p.token0.toString()}</td>
+                  <td className="py-3 text-right font-mono text-text-muted">{p.token1.toString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DepositPanel({placeholder}: {placeholder: boolean}) {
+  return (
+    <section className="rounded-xl border border-border bg-surface p-5 shadow-card">
+      <h2 className="mb-2 text-base font-medium text-text">Deposit</h2>
+      <p className="text-sm text-text-muted">
+        {placeholder
+          ? "Form lands with #52 (deposit form). Wallet + wagmi reads are wired; M2 contracts surface the on-chain state."
+          : null}
+      </p>
+    </section>
+  );
+}
+
+interface PlaceholderPosition {
+  tickLower: number;
+  tickUpper: number;
+  liquidity: bigint;
+  token0: bigint;
+  token1: bigint;
+}
+
+interface PlaceholderDetail {
+  address: string;
+  pairName: string;
+  versionLabel: string;
+  tvlUsd: bigint;
+  apr24hBps: number;
+  sharePriceUsd: bigint;
+  positions: PlaceholderPosition[];
+}
+
+function usePlaceholderVault(address: string): PlaceholderDetail {
+  return useMemo(
+    () => ({
+      address,
+      pairName: "WETH / USDC",
+      versionLabel: "v1",
+      tvlUsd: 0n,
+      apr24hBps: 0,
+      sharePriceUsd: 1_000_000n, // 1.000000 USDC (6 decimals)
+      positions: [],
+    }),
+    [address],
+  );
+}

--- a/apps/web/components/DepositForm.tsx
+++ b/apps/web/components/DepositForm.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import {useEffect, useMemo, useState} from "react";
+import {erc20Abi, formatUnits, parseUnits, zeroAddress, type Address, type Hex} from "viem";
+import {
+  useAccount,
+  useReadContracts,
+  useSimulateContract,
+  useWaitForTransactionReceipt,
+  useWriteContract,
+} from "wagmi";
+
+import {VaultAbi} from "@prism/shared";
+import {classifyTxError} from "@/lib/tx-errors";
+import {isBusy, statusLabel, type TxFlowStatus} from "@/lib/tx-status";
+
+export interface DepositFormToken {
+  address: Address;
+  symbol: string;
+  decimals: number;
+}
+
+interface DepositFormProps {
+  vaultAddress: Address;
+  token0: DepositFormToken;
+  token1: DepositFormToken;
+  /// Default slippage as basis points. 50 = 0.5%.
+  defaultSlippageBps?: number;
+}
+
+/**
+ * Deposit form for a PRISM vault. Walks the user through:
+ *   1. Approve token0 (if allowance < amount0Desired)
+ *   2. Approve token1 (if allowance < amount1Desired)
+ *   3. Deposit
+ *
+ * State machine in `status: TxFlowStatus` — see `lib/tx-status.ts`.
+ *
+ * The simulate hook runs whenever inputs are valid and both allowances
+ * cover the desired amounts; its return value drives the submit
+ * button's enabled state and surfaces revert reasons before the user
+ * pays gas.
+ */
+export function DepositForm({vaultAddress, token0, token1, defaultSlippageBps = 50}: DepositFormProps) {
+  const {address: account, chainId} = useAccount();
+
+  const [amount0, setAmount0] = useState("");
+  const [amount1, setAmount1] = useState("");
+  const [slippageBps, setSlippageBps] = useState(defaultSlippageBps);
+  const [status, setStatus] = useState<TxFlowStatus>({kind: "idle"});
+
+  const placeholderVault = vaultAddress === zeroAddress;
+
+  const amount0Desired = useMemo(
+    () => parseAmountSafe(amount0, token0.decimals),
+    [amount0, token0.decimals],
+  );
+  const amount1Desired = useMemo(
+    () => parseAmountSafe(amount1, token1.decimals),
+    [amount1, token1.decimals],
+  );
+
+  const inputsValid = (amount0Desired > 0n || amount1Desired > 0n) && !!account;
+
+  // Read balances + allowances for both tokens in one batch.
+  const {data: tokenReads, refetch: refetchTokenReads} = useReadContracts({
+    contracts: account
+      ? [
+        {
+          address: token0.address,
+          abi: erc20Abi,
+          functionName: "balanceOf",
+          args: [account],
+        },
+        {
+          address: token0.address,
+          abi: erc20Abi,
+          functionName: "allowance",
+          args: [account, vaultAddress],
+        },
+        {
+          address: token1.address,
+          abi: erc20Abi,
+          functionName: "balanceOf",
+          args: [account],
+        },
+        {
+          address: token1.address,
+          abi: erc20Abi,
+          functionName: "allowance",
+          args: [account, vaultAddress],
+        },
+      ]
+      : [],
+    query: {enabled: !!account && !placeholderVault},
+  });
+
+  const balance0 = (tokenReads?.[0]?.result as bigint | undefined) ?? 0n;
+  const allowance0 = (tokenReads?.[1]?.result as bigint | undefined) ?? 0n;
+  const balance1 = (tokenReads?.[2]?.result as bigint | undefined) ?? 0n;
+  const allowance1 = (tokenReads?.[3]?.result as bigint | undefined) ?? 0n;
+
+  const needsApproval0 = amount0Desired > allowance0 && amount0Desired > 0n;
+  const needsApproval1 = amount1Desired > allowance1 && amount1Desired > 0n;
+  const allowancesOk = !needsApproval0 && !needsApproval1;
+
+  const amount0Min = applySlippage(amount0Desired, slippageBps);
+  const amount1Min = applySlippage(amount1Desired, slippageBps);
+
+  // Pre-flight simulate the deposit only when allowances cover the
+  // intended amounts — running it earlier would always revert with
+  // ERC-20 transfer failure noise and obscure real reverts.
+  const simulate = useSimulateContract({
+    address: vaultAddress,
+    abi: VaultAbi,
+    functionName: "deposit",
+    args: account
+      ? [amount0Desired, amount1Desired, amount0Min, amount1Min, account]
+      : undefined,
+    query: {enabled: inputsValid && allowancesOk && !placeholderVault},
+  });
+
+  const {writeContractAsync: writeApprove, data: approveHash} = useWriteContract();
+  const {writeContractAsync: writeDeposit, data: depositHash} = useWriteContract();
+
+  const approveReceipt = useWaitForTransactionReceipt({hash: approveHash});
+  const depositReceipt = useWaitForTransactionReceipt({hash: depositHash});
+
+  // Refresh allowances when an approval lands so the form transitions
+  // out of `awaiting-approval` automatically.
+  useEffect(() => {
+    if (approveReceipt.isSuccess) {
+      void refetchTokenReads();
+      setStatus({kind: "awaiting-submit"});
+    }
+  }, [approveReceipt.isSuccess, refetchTokenReads]);
+
+  useEffect(() => {
+    if (depositReceipt.isSuccess && depositHash) {
+      setStatus({kind: "confirmed", hash: depositHash});
+      void refetchTokenReads();
+    }
+  }, [depositReceipt.isSuccess, depositHash, refetchTokenReads]);
+
+  const insufficient0 = amount0Desired > balance0;
+  const insufficient1 = amount1Desired > balance1;
+  const insufficientBalance = insufficient0 || insufficient1;
+
+  const submitDisabled =
+    !inputsValid ||
+    isBusy(status) ||
+    insufficientBalance ||
+    (allowancesOk && simulate.status === "error") ||
+    placeholderVault;
+
+  async function onApprove(token: DepositFormToken, amount: bigint) {
+    setStatus({kind: "awaiting-approval", token: token.address});
+    try {
+      const hash = await writeApprove({
+        address: token.address,
+        abi: erc20Abi,
+        functionName: "approve",
+        args: [vaultAddress, amount],
+      });
+      setStatus({kind: "approving", token: token.address, hash});
+    } catch (err) {
+      const e = classifyTxError(err);
+      setStatus({kind: "failed", reason: e.message});
+    }
+  }
+
+  async function onDeposit() {
+    if (!account) return;
+
+    if (needsApproval0) {
+      await onApprove(token0, amount0Desired);
+      return;
+    }
+    if (needsApproval1) {
+      await onApprove(token1, amount1Desired);
+      return;
+    }
+
+    setStatus({kind: "simulating"});
+    if (simulate.status !== "success") {
+      const reason = simulate.error?.message ?? "Simulation did not produce a request.";
+      setStatus({kind: "simulation-failed", reason});
+      return;
+    }
+
+    setStatus({kind: "awaiting-submit"});
+    try {
+      const hash = await writeDeposit(simulate.data.request);
+      setStatus({kind: "pending", hash});
+    } catch (err) {
+      const e = classifyTxError(err);
+      setStatus({kind: "failed", reason: e.message});
+    }
+  }
+
+  return (
+    <section className="rounded-xl border border-border bg-surface p-5 shadow-card" aria-label="Deposit">
+      <h2 className="mb-4 text-base font-medium text-text">Deposit</h2>
+
+      <div className="flex flex-col gap-4">
+        <AmountInput
+          label={token0.symbol}
+          value={amount0}
+          onChange={setAmount0}
+          balance={balance0}
+          decimals={token0.decimals}
+          insufficient={insufficient0}
+          disabled={isBusy(status) || placeholderVault}
+        />
+        <AmountInput
+          label={token1.symbol}
+          value={amount1}
+          onChange={setAmount1}
+          balance={balance1}
+          decimals={token1.decimals}
+          insufficient={insufficient1}
+          disabled={isBusy(status) || placeholderVault}
+        />
+
+        <SlippageRow value={slippageBps} onChange={setSlippageBps} disabled={isBusy(status)} />
+
+        <button
+          type="button"
+          onClick={() => void onDeposit()}
+          disabled={submitDisabled}
+          className="rounded-lg bg-accent px-4 py-3 text-sm font-medium text-canvas transition-base
+                     hover:shadow-glow-violet disabled:cursor-not-allowed disabled:opacity-50
+                     disabled:hover:shadow-none"
+        >
+          {placeholderVault
+            ? "Vault not deployed"
+            : !account
+            ? "Connect wallet"
+            : insufficientBalance
+            ? "Insufficient balance"
+            : needsApproval0
+            ? `Approve ${token0.symbol}`
+            : needsApproval1
+            ? `Approve ${token1.symbol}`
+            : "Deposit"}
+        </button>
+
+        <StatusBanner status={status} />
+      </div>
+    </section>
+  );
+}
+
+function AmountInput({
+  label,
+  value,
+  onChange,
+  balance,
+  decimals,
+  insufficient,
+  disabled,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  balance: bigint;
+  decimals: number;
+  insufficient: boolean;
+  disabled?: boolean;
+}) {
+  const formattedBalance = formatUnits(balance, decimals);
+  return (
+    <label className="flex flex-col gap-1.5 text-sm">
+      <span className="flex items-baseline justify-between text-text-muted">
+        <span>{label}</span>
+        <button
+          type="button"
+          onClick={() => onChange(formattedBalance)}
+          disabled={disabled || balance === 0n}
+          className="font-mono text-xs text-text-faint hover:text-text disabled:cursor-not-allowed
+                     disabled:opacity-60"
+        >
+          balance {formattedBalance}
+        </button>
+      </span>
+      <input
+        type="text"
+        inputMode="decimal"
+        value={value}
+        onChange={(e) => onChange(sanitizeAmount(e.target.value))}
+        disabled={disabled}
+        placeholder="0.0"
+        className={`rounded-lg border bg-surface-raised px-3 py-2 font-mono text-base text-text
+                    outline-none transition-base disabled:cursor-not-allowed disabled:opacity-60
+                    ${insufficient ? "border-danger/60" : "border-border focus:border-border-strong"}`}
+      />
+      {insufficient ? (
+        <span className="text-xs text-danger">Exceeds balance.</span>
+      ) : null}
+    </label>
+  );
+}
+
+function SlippageRow({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: number;
+  onChange: (bps: number) => void;
+  disabled?: boolean;
+}) {
+  const presets = [10, 50, 100] as const; // 0.1%, 0.5%, 1%
+  return (
+    <div className="flex items-center justify-between text-sm">
+      <span className="text-text-muted">Max slippage</span>
+      <div className="flex gap-1">
+        {presets.map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => onChange(p)}
+            disabled={disabled}
+            className={`rounded-md border px-2 py-1 font-mono text-xs transition-base
+                        disabled:cursor-not-allowed disabled:opacity-60
+                        ${value === p ? "border-accent bg-accent/10 text-accent" : "border-border text-text-muted"}`}
+          >
+            {(p / 100).toFixed(2)}%
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StatusBanner({status}: {status: TxFlowStatus}) {
+  if (status.kind === "idle") return null;
+
+  const tone =
+    status.kind === "confirmed"
+      ? "border-success/40 bg-success/10 text-success"
+      : status.kind === "failed" || status.kind === "simulation-failed"
+      ? "border-danger/40 bg-danger/10 text-danger"
+      : "border-border bg-surface-raised text-text-muted";
+
+  const hash = "hash" in status ? status.hash : undefined;
+  return (
+    <div className={`rounded-lg border px-3 py-2 text-xs ${tone}`} role="status">
+      <p>{statusLabel(status)}</p>
+      {hash ? (
+        <p className="mt-1 font-mono text-[11px] text-text-faint">{shortHash(hash)}</p>
+      ) : null}
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+function sanitizeAmount(input: string): string {
+  // Allow only digits and a single decimal point.
+  const cleaned = input.replace(/[^0-9.]/g, "");
+  const firstDot = cleaned.indexOf(".");
+  if (firstDot === -1) return cleaned;
+  return cleaned.slice(0, firstDot + 1) + cleaned.slice(firstDot + 1).replace(/\./g, "");
+}
+
+function parseAmountSafe(value: string, decimals: number): bigint {
+  if (!value || value === ".") return 0n;
+  try {
+    return parseUnits(value, decimals);
+  } catch {
+    return 0n;
+  }
+}
+
+function applySlippage(amount: bigint, bps: number): bigint {
+  if (amount === 0n) return 0n;
+  // floor((amount * (10_000 - bps)) / 10_000)
+  return (amount * BigInt(10_000 - bps)) / 10_000n;
+}
+
+function shortHash(h: Hex): string {
+  return `${h.slice(0, 10)}…${h.slice(-8)}`;
+}

--- a/apps/web/components/PrismVisual.tsx
+++ b/apps/web/components/PrismVisual.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import {scaleLinear} from "d3-scale";
+import {useMemo} from "react";
+
+/// One tick-range position the vault holds, with the V4 liquidity it
+/// represents. Mirrors `Vault.Position` in the contracts package.
+export interface PrismPosition {
+  tickLower: number;
+  tickUpper: number;
+  liquidity: bigint;
+}
+
+interface PrismVisualProps {
+  /// Positions to render. Empty array → empty-state placeholder.
+  positions: PrismPosition[];
+  /// Current pool tick — drawn as a vertical guide line. Omit to skip.
+  currentTick?: number;
+  /// Tick spacing of the underlying pool. Used to widen the x-axis a
+  /// touch beyond the position extents so the side bars don't kiss the
+  /// chart edge.
+  tickSpacing: number;
+  /// Pixel height of the chart. Width is fluid (100%).
+  height?: number;
+  className?: string;
+}
+
+const SPECTRUM = [
+  "rgb(124 92 255)", // violet
+  "rgb(92 138 255)", // indigo
+  "rgb(62 220 255)", // teal
+  "rgb(62 255 155)", // mint
+  "rgb(255 209 102)", // amber
+  "rgb(255 92 138)", // rose
+] as const;
+
+/**
+ * Visualises the vault's prism — a layered set of tick-range positions —
+ * as a horizontal "spectrum" of liquidity blocks along the tick axis.
+ *
+ * Each block spans [`tickLower`, `tickUpper`] horizontally and has a
+ * height proportional to its share of total liquidity. Block colours
+ * cycle through the brand spectrum so adjacent positions stay visually
+ * distinct.
+ */
+export function PrismVisual({
+  positions,
+  currentTick,
+  tickSpacing,
+  height = 180,
+  className,
+}: PrismVisualProps) {
+  const empty = positions.length === 0;
+
+  const layout = useMemo(() => {
+    if (empty) return null;
+
+    const lows = positions.map((p) => p.tickLower);
+    const highs = positions.map((p) => p.tickUpper);
+    const minTick = Math.min(...lows) - tickSpacing;
+    const maxTick = Math.max(...highs) + tickSpacing;
+
+    // d3 linear scale on a 0..100 viewBox keeps the chart fluid — the
+    // SVG itself stretches to fit its container.
+    const x = scaleLinear().domain([minTick, maxTick]).range([0, 100]);
+
+    // Liquidity is bigint on the wire; convert to number for the
+    // height ratio. Loss of precision is acceptable for a *visual*
+    // ratio (we only care about the sort order, not the absolute
+    // value).
+    const maxLiquidity =
+      positions.reduce((acc, p) => (p.liquidity > acc ? p.liquidity : acc), 0n) || 1n;
+    const liquidityRatio = (l: bigint) => Number((l * 1000n) / maxLiquidity) / 1000;
+
+    return {
+      x,
+      minTick,
+      maxTick,
+      blocks: positions.map((p, i) => ({
+        x0: x(p.tickLower),
+        x1: x(p.tickUpper),
+        ratio: liquidityRatio(p.liquidity),
+        color: SPECTRUM[i % SPECTRUM.length],
+      })),
+    };
+  }, [positions, tickSpacing, empty]);
+
+  if (empty) {
+    return (
+      <section
+        className={`rounded-xl border border-border bg-surface p-5 shadow-card ${className ?? ""}`}
+        style={{minHeight: height}}
+      >
+        <h2 className="mb-4 text-base font-medium text-text">Prism</h2>
+        <div className="flex items-center justify-center" style={{height: height - 60}}>
+          <p className="text-sm text-text-muted">No positions deployed yet.</p>
+        </div>
+      </section>
+    );
+  }
+
+  // Non-null assertion — `empty === false` implies layout populated.
+  const {x, minTick, maxTick, blocks} = layout!;
+  const tickIndicatorX =
+    currentTick !== undefined && currentTick >= minTick && currentTick <= maxTick
+      ? x(currentTick)
+      : null;
+
+  return (
+    <section
+      className={`rounded-xl border border-border bg-surface p-5 shadow-card ${className ?? ""}`}
+      aria-label="Prism — vault liquidity distribution"
+    >
+      <header className="mb-4 flex items-baseline justify-between">
+        <h2 className="text-base font-medium text-text">Prism</h2>
+        <p className="text-xs text-text-faint">
+          {positions.length} {positions.length === 1 ? "position" : "positions"}
+        </p>
+      </header>
+
+      <svg
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        role="img"
+        aria-label="Liquidity distribution across tick ranges"
+        style={{width: "100%", height}}
+      >
+        {/* Floor — full-width hairline so empty corridors read clearly. */}
+        <line
+          x1={0}
+          y1={100}
+          x2={100}
+          y2={100}
+          stroke="rgb(var(--color-border-strong))"
+          strokeWidth={0.5}
+          vectorEffect="non-scaling-stroke"
+        />
+
+        {/* Position blocks — height proportional to liquidity. */}
+        {blocks.map((b, i) => {
+          const blockHeight = b.ratio * 90; // leave 10% headroom
+          return (
+            <rect
+              key={i}
+              x={b.x0}
+              y={100 - blockHeight}
+              width={Math.max(b.x1 - b.x0, 0.5)}
+              height={blockHeight}
+              fill={b.color}
+              fillOpacity={0.55}
+              stroke={b.color}
+              strokeWidth={0.5}
+              vectorEffect="non-scaling-stroke"
+              rx={0.5}
+            />
+          );
+        })}
+
+        {/* Current-tick indicator. */}
+        {tickIndicatorX !== null ? (
+          <g>
+            <line
+              x1={tickIndicatorX}
+              y1={0}
+              x2={tickIndicatorX}
+              y2={100}
+              stroke="rgb(var(--color-text))"
+              strokeWidth={0.75}
+              strokeDasharray="2 2"
+              vectorEffect="non-scaling-stroke"
+            />
+          </g>
+        ) : null}
+      </svg>
+
+      <footer className="mt-3 flex justify-between font-mono text-xs text-text-faint">
+        <span>tick {minTick}</span>
+        {currentTick !== undefined ? <span>now {currentTick}</span> : null}
+        <span>tick {maxTick}</span>
+      </footer>
+    </section>
+  );
+}

--- a/apps/web/lib/tx-status.ts
+++ b/apps/web/lib/tx-status.ts
@@ -1,0 +1,86 @@
+import type {Address, Hex} from "viem";
+
+/**
+ * Discriminated union covering the full deposit / withdraw transaction
+ * lifecycle. Each `kind` carries exactly the fields the UI needs at
+ * that step — no shared optional bag — so the renderer pattern-matches
+ * cleanly on `status.kind` without nullable-everything drift.
+ *
+ * Flow shape:
+ *
+ *   idle
+ *     ↓ (user clicks submit)
+ *   simulating              ← wagmi useSimulateContract
+ *     ↓ (sim ok)
+ *   awaiting-approval *     ← only if ERC-20 allowance < amount; one
+ *                             entry per token that needs approving.
+ *     ↓ (user signs)
+ *   approving *
+ *     ↓ (approval mined)
+ *   awaiting-submit
+ *     ↓ (user signs)
+ *   submitting
+ *     ↓ (tx broadcast)
+ *   pending
+ *     ↓ (receipt mined)
+ *   confirmed | failed
+ *
+ *   * Withdraw skips both approval steps (it burns shares the user
+ *     already owns).
+ */
+export type TxFlowStatus =
+  | {kind: "idle"}
+  | {kind: "simulating"}
+  | {kind: "simulation-failed"; reason: string}
+  | {kind: "awaiting-approval"; token: Address}
+  | {kind: "approving"; token: Address; hash: Hex}
+  | {kind: "awaiting-submit"}
+  | {kind: "submitting"}
+  | {kind: "pending"; hash: Hex}
+  | {kind: "confirmed"; hash: Hex}
+  | {kind: "failed"; reason: string; hash?: Hex};
+
+/// True when the user has work to do — wallet prompt open or the form
+/// should be locked because something is in flight.
+export function isBusy(s: TxFlowStatus): boolean {
+  switch (s.kind) {
+    case "simulating":
+    case "awaiting-approval":
+    case "approving":
+    case "awaiting-submit":
+    case "submitting":
+    case "pending":
+      return true;
+    case "idle":
+    case "simulation-failed":
+    case "confirmed":
+    case "failed":
+      return false;
+  }
+}
+
+/// Human-readable label for the status banner.
+export function statusLabel(s: TxFlowStatus): string {
+  switch (s.kind) {
+    case "idle":
+      return "Ready";
+    case "simulating":
+      return "Simulating…";
+    case "simulation-failed":
+      return `Simulation failed — ${s.reason}`;
+    case "awaiting-approval":
+      return "Waiting for approval signature…";
+    case "approving":
+      return "Approving token…";
+    case "awaiting-submit":
+      return "Waiting for transaction signature…";
+    case "submitting":
+      return "Submitting transaction…";
+    case "pending":
+      return "Transaction pending…";
+    case "confirmed":
+      return "Transaction confirmed";
+    case "failed":
+      return `Transaction failed — ${s.reason}`;
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@rainbow-me/rainbowkit": "^2.2.10",
     "@tanstack/react-query": "^5.100.6",
+    "d3-scale": "^4.0.2",
     "next": "14.2.18",
     "react": "18.3.1",
     "react-dom": "18.3.1",
@@ -21,6 +22,7 @@
     "wagmi": "^2.19.5"
   },
   "devDependencies": {
+    "@types/d3-scale": "^4.0.8",
     "@types/node": "20.16.10",
     "@types/react": "18.3.11",
     "@types/react-dom": "18.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.100.6
         version: 5.100.6(react@18.3.1)
+      d3-scale:
+        specifier: ^4.0.2
+        version: 4.0.2
       next:
         specifier: 14.2.18
         version: 14.2.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -42,6 +45,9 @@ importers:
         specifier: ^2.19.5
         version: 2.19.5(@tanstack/query-core@5.100.6)(@tanstack/react-query@5.100.6(react@18.3.1))(@types/react@18.3.11)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.6.3)(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
     devDependencies:
+      '@types/d3-scale':
+        specifier: ^4.0.8
+        version: 4.0.9
       '@types/node':
         specifier: 20.16.10
         version: 20.16.10
@@ -1061,6 +1067,12 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -1724,6 +1736,34 @@ packages:
       typescript:
         optional: true
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -2304,6 +2344,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -5175,6 +5219,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-time@3.0.4': {}
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -6339,6 +6389,34 @@ snapshots:
     optionalDependencies:
       typescript: 5.6.3
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -7088,6 +7166,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.3
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   iron-webcrypto@1.2.1: {}
 


### PR DESCRIPTION
## Summary

Dynamic route renders the vault detail layout. Real data wiring lands in M2 once #31 (VaultFactory) ships; this PR locks the layout so #51 (PrismVisual), #52 (deposit form), and #53 (withdraw form) have a place to land.

### Sections

- **Header** — token-pair hero (spectrum-arc glow chip), pair name + version Badge, monospace vault address. Bad addresses → \`notFound()\`
- **Metrics** — 3-card row: TVL / APR (24h) / Share price. Mono numerals, surface card chrome, stacked on mobile
- **Positions table** — empty-state copy when no positions (default pre-M2); otherwise scrollable table: range, liquidity, token0, token1. Mono throughout for tick comparison
- **Deposit panel** — placeholder pointing at #52

## Quality gates

- \`pnpm --filter @prism/web typecheck\` → pass
- \`pnpm --filter @prism/web build\` → pass (4 routes including dynamic \`/vaults/[address]\`)

## Test plan

- [x] typecheck + build green
- [x] bad addresses route to not-found
- [ ] real data wiring once #31 lands

## Dependencies

- Stacked on **#49 (frontend/49-vault-list)** — shares \`formatUsd\` / \`formatBps\` from \`lib/vault-list.ts\`
- Unblocks #51 (PrismVisual), #52 (deposit form), #53 (withdraw form)

Closes #50