### PR TITLE
feat(contracts): BellStrategy.computePositions (#32)

### DIFF
--- a/packages/contracts/src/strategies/BellStrategy.sol
+++ b/packages/contracts/src/strategies/BellStrategy.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {IStrategy} from "../interfaces/IStrategy.sol";
+import {Errors} from "../utils/Errors.sol";
+
+/// @title BellStrategy — fixed-shape bell-curve weight distribution
+/// @notice Default PRISM strategy. Returns 7 positions arranged as a
+///         symmetric bell around the current tick, with hardcoded
+///         weights `[500, 1200, 2100, 2400, 2100, 1200, 500]` (bps).
+///
+///         This PR (#32) implements `computePositions` only — the
+///         `shouldRebalance` gate lands in #33.
+///
+/// @dev Per ADR-005 the strategy is **pure / stateless / vault-agnostic**:
+///        - No SSTORE in runtime bytecode (constants + immutables only)
+///        - No reads of mutable state
+///        - Deterministic across repeat calls with identical inputs
+///
+///       The weights sum to exactly 10_000 (invariant #2). The vault
+///       independently verifies this and reverts via `Errors.WeightsDoNotSum`
+///       on mismatch — defence-in-depth, not redundancy.
+///
+///       Tick alignment: `currentTick` is rounded down to the nearest
+///       `tickSpacing` boundary; each position then extends one
+///       `tickSpacing` further out from the previous, so the seven
+///       positions cover `[center - 4*ts, center + 4*ts]` total range.
+contract BellStrategy is IStrategy {
+    /// @notice Number of positions this strategy emits.
+    uint256 public constant N_POSITIONS = 7;
+
+    /// @notice Per-position bell weights in basis points. Sum = 10_000.
+    /// @dev Hardcoded as immutable constants to satisfy ADR-005 purity
+    ///      (no SSTORE in bytecode). Order matches `computePositions`
+    ///      output, which goes from leftmost (most negative offset) to
+    ///      rightmost.
+    uint256 internal constant W0 = 500; // outermost left
+    uint256 internal constant W1 = 1200;
+    uint256 internal constant W2 = 2100;
+    uint256 internal constant W3 = 2400; // center
+    uint256 internal constant W4 = 2100;
+    uint256 internal constant W5 = 1200;
+    uint256 internal constant W6 = 500; // outermost right
+
+    /// @inheritdoc IStrategy
+    function computePositions(
+        int24 currentTick,
+        int24 tickSpacing,
+        uint256, /*amount0*/
+        uint256 /*amount1*/
+    )
+        external
+        pure
+        override
+        returns (TargetPosition[] memory positions)
+    {
+        if (tickSpacing <= 0) revert Errors.InvalidTickRange(0, 0);
+
+        // Round currentTick DOWN to the nearest tickSpacing boundary.
+        // For negative ticks Solidity's % preserves sign — subtract the
+        // remainder if non-zero to get the floor.
+        int24 anchor = _floorToSpacing(currentTick, tickSpacing);
+
+        // Seven adjacent positions of width `tickSpacing` each, centred
+        // on the anchor. Position i has range
+        //   [anchor + (i - 3) * ts, anchor + (i - 2) * ts]
+        // so that i=3 spans [anchor, anchor + ts] (the centre tick).
+        int24 ts = tickSpacing;
+
+        positions = new TargetPosition[](N_POSITIONS);
+        positions[0] = TargetPosition({tickLower: anchor - 3 * ts, tickUpper: anchor - 2 * ts, weight: W0});
+        positions[1] = TargetPosition({tickLower: anchor - 2 * ts, tickUpper: anchor - ts, weight: W1});
+        positions[2] = TargetPosition({tickLower: anchor - ts, tickUpper: anchor, weight: W2});
+        positions[3] = TargetPosition({tickLower: anchor, tickUpper: anchor + ts, weight: W3});
+        positions[4] = TargetPosition({tickLower: anchor + ts, tickUpper: anchor + 2 * ts, weight: W4});
+        positions[5] = TargetPosition({tickLower: anchor + 2 * ts, tickUpper: anchor + 3 * ts, weight: W5});
+        positions[6] = TargetPosition({tickLower: anchor + 3 * ts, tickUpper: anchor + 4 * ts, weight: W6});
+    }
+
+    /// @inheritdoc IStrategy
+    /// @dev #33 implements the actual gate (tick drift + time threshold +
+    ///      24h fallback). For #32 this returns false so the vault
+    ///      compiles against the full interface but never rebalances on
+    ///      this stub.
+    function shouldRebalance(
+        int24, /*currentTick*/
+        int24, /*lastRebalanceTick*/
+        uint256 /*lastRebalanceTimestamp*/
+    )
+        external
+        view
+        override
+        returns (bool)
+    {
+        return false;
+    }
+
+    /// @dev Round `tick` down to the nearest multiple of `spacing`.
+    ///      Handles negative inputs correctly (Solidity's `%` preserves
+    ///      sign on signed types).
+    function _floorToSpacing(int24 tick, int24 spacing) internal pure returns (int24) {
+        int24 rem = tick % spacing;
+        if (rem == 0) return tick;
+        if (tick > 0) return tick - rem;
+        return tick - rem - spacing;
+    }
+}

--- a/packages/contracts/src/utils/Errors.sol
+++ b/packages/contracts/src/utils/Errors.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+/// @title PRISM error library
+/// @notice Centralised custom errors for every PRISM contract.
+/// @dev Custom errors emit a 4-byte selector + ABI-encoded args (~200 gas)
+///      versus 2,000+ gas for revert strings. All state-mutating PRISM
+///      contracts revert through this library and never with strings.
+///
+///      Errors are grouped by domain (access control, vault, strategy,
+///      hook, oracle, callback, generic). Adding a new error requires
+///      updating this library; downstream contracts import the library
+///      and call e.g. `revert Errors.SlippageExceeded(...);`.
+///
+///      Selector stability matters — third parties index reverts by
+///      selector. The selector regression test in
+///      `test/utils/Errors.t.sol` snapshots every selector. Changing an
+///      error's signature is a breaking change.
+library Errors {
+    // -------------------------------------------------------------------------
+    // Access control
+    // -------------------------------------------------------------------------
+
+    /// @notice Caller is not the contract owner.
+    error OnlyOwner();
+
+    /// @notice Caller is not the configured keeper.
+    error OnlyKeeper();
+
+    /// @notice Caller is not the canonical Uniswap V4 PoolManager.
+    /// @dev Guards every IHooks callback and every IUnlockCallback entry.
+    error OnlyPoolManager();
+
+    /// @notice Constructor or setter received the zero address where a
+    ///         non-zero address is required.
+    error ZeroAddress();
+
+    // -------------------------------------------------------------------------
+    // Vault — deposit / withdraw / shares
+    // -------------------------------------------------------------------------
+
+    /// @notice Realised output of a deposit or withdraw violated the
+    ///         user-supplied minimum.
+    /// @param actual The smaller of the two amounts that fell below its floor.
+    /// @param min The corresponding floor that was violated.
+    error SlippageExceeded(uint256 actual, uint256 min);
+
+    /// @notice Deposit would push vault TVL above the configured cap.
+    /// @param proposed Total vault notional (in token0 units) after the deposit.
+    /// @param cap Current TVL cap.
+    error TVLCapExceeded(uint256 proposed, uint256 cap);
+
+    /// @notice `deposit` invoked while deposits are paused by the multisig.
+    /// @dev Withdraws and rebalances are unaffected — invariant 6.
+    error DepositsPaused();
+
+    /// @notice First-depositor inflation guard: the deposit would mint
+    ///         fewer than `MIN_SHARES` shares, which would let the
+    ///         depositor capture `MIN_SHARES`-worth of donations from
+    ///         later depositors. See ADR-006 / PRD §13.
+    error ZeroShares();
+
+    /// @notice Withdraw asked for an invalid (zero or > balance) share count.
+    error InvalidShareAmount();
+
+    // -------------------------------------------------------------------------
+    // Strategy
+    // -------------------------------------------------------------------------
+
+    /// @notice `IStrategy.computePositions` returned weights whose sum is
+    ///         not exactly 10_000 basis points (invariant #2).
+    /// @param actual The actual weight sum returned by the strategy.
+    error WeightsDoNotSum(uint256 actual);
+
+    /// @notice Strategy returned more positions than the vault's
+    ///         `MAX_POSITIONS` cap allows (invariant #3).
+    /// @param requested The number of positions returned by the strategy.
+    error MaxPositionsExceeded(uint256 requested);
+
+    /// @notice Strategy or caller supplied a tick range with `lower >= upper`
+    ///         or a tick that is not aligned to `tickSpacing`.
+    error InvalidTickRange(int24 lower, int24 upper);
+
+    /// @notice `Vault.rebalance` invoked when `IStrategy.shouldRebalance`
+    ///         returns false. Permissionless callers must wait for the
+    ///         drift threshold or 24h fallback.
+    error RebalanceNotNeeded();
+
+    // -------------------------------------------------------------------------
+    // Hook — V4 permission + lifecycle
+    // -------------------------------------------------------------------------
+
+    /// @notice Deployed hook address bits do not match
+    ///         `getHookPermissions()`. Caught at deploy / pool-init time.
+    /// @param expected The permission bits required by the hook bytecode.
+    /// @param actual The bits actually encoded in the deployed address.
+    error HookNotPermissioned(uint160 expected, uint160 actual);
+
+    // -------------------------------------------------------------------------
+    // Oracle
+    // -------------------------------------------------------------------------
+
+    /// @notice Oracle round is older than `STALENESS` (1h on mainnet).
+    ///         Hook treats this as `healthy = false` rather than
+    ///         reverting on the swap path (ADR-003).
+    /// @param updatedAt The `updatedAt` timestamp of the stale round.
+    error OracleStale(uint256 updatedAt);
+
+    /// @notice Pool sqrt-price has drifted further from the oracle
+    ///         reference than the configured deviation threshold.
+    ///         v1.0 hook pauses MEV capture; v1.1 may revert backruns
+    ///         that would execute outside the threshold.
+    /// @param deviation Absolute deviation in basis points (10_000 = 100%).
+    error OracleDeviation(uint256 deviation);
+
+    // -------------------------------------------------------------------------
+    // Flash-accounting callback (ADR-004)
+    // -------------------------------------------------------------------------
+
+    /// @notice `unlockCallback` was invoked with a `CallbackData.op` value
+    ///         outside the supported `Op` enum.
+    error UnknownOp();
+
+    /// @notice Currency delta did not settle to zero before
+    ///         `unlockCallback` returned (invariant #4). Bug, not user
+    ///         error — surfaces a missing `take` / `settle` pair.
+    error DeltaUnsettled();
+
+    /// @notice Transient reentrancy guard tripped: a second nested
+    ///         entry into a `nonReentrantTransient` function was
+    ///         attempted in the same transaction.
+    error Reentrancy();
+
+    // -------------------------------------------------------------------------
+    // Generic
+    // -------------------------------------------------------------------------
+
+    /// @notice An arithmetic computation produced a value outside the
+    ///         caller's accepted range. Reserved for math helpers that
+    ///         do not have a more specific error already.
+    error MathOverflow();
+
+    /// @notice A value parameter (typically a basis-point or fee value)
+    ///         exceeded the contract's allowed bound.
+    /// @param value The offending value.
+    /// @param max The contract's documented maximum.
+    error ValueOutOfBounds(uint256 value, uint256 max);
+}

--- a/packages/contracts/test/strategies/BellStrategy.t.sol
+++ b/packages/contracts/test/strategies/BellStrategy.t.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IStrategy} from "../../src/interfaces/IStrategy.sol";
+import {BellStrategy} from "../../src/strategies/BellStrategy.sol";
+import {Errors} from "../../src/utils/Errors.sol";
+
+contract BellStrategyTest is Test {
+    BellStrategy strat;
+
+    function setUp() public {
+        strat = new BellStrategy();
+    }
+
+    // -------------------------------------------------------------------------
+    // Basic shape
+    // -------------------------------------------------------------------------
+
+    function test_computePositions_returns7Positions() public view {
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(0, 60, 1e18, 1e18);
+        assertEq(ps.length, 7);
+    }
+
+    function test_computePositions_weightsSumTo10000() public view {
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(0, 60, 0, 0);
+        uint256 sum;
+        for (uint256 i = 0; i < ps.length; i++) {
+            sum += ps[i].weight;
+        }
+        assertEq(sum, 10_000);
+    }
+
+    function test_computePositions_isSymmetric() public view {
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(0, 60, 0, 0);
+        // Mirrored weights: 0↔6, 1↔5, 2↔4. Centre weight = ps[3].
+        assertEq(ps[0].weight, ps[6].weight);
+        assertEq(ps[1].weight, ps[5].weight);
+        assertEq(ps[2].weight, ps[4].weight);
+    }
+
+    function test_computePositions_centerWeightIsLargest() public view {
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(0, 60, 0, 0);
+        for (uint256 i = 0; i < ps.length; i++) {
+            if (i != 3) assertGt(ps[3].weight, ps[i].weight);
+        }
+    }
+
+    function test_computePositions_revertsOnZeroSpacing() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(0), int24(0)));
+        strat.computePositions(0, 0, 0, 0);
+    }
+
+    function test_computePositions_revertsOnNegativeSpacing() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(0), int24(0)));
+        strat.computePositions(0, -1, 0, 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tick alignment
+    // -------------------------------------------------------------------------
+
+    function test_computePositions_anchorAlignsAtZero() public view {
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(0, 60, 0, 0);
+        // Centre position spans [0, 60] when currentTick is 0.
+        assertEq(ps[3].tickLower, 0);
+        assertEq(ps[3].tickUpper, 60);
+    }
+
+    function test_computePositions_alignsPositiveOffTickSpacing() public view {
+        // currentTick = 35, spacing = 60 → anchor = 0 (floor).
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(35, 60, 0, 0);
+        assertEq(ps[3].tickLower, 0);
+        assertEq(ps[3].tickUpper, 60);
+    }
+
+    function test_computePositions_alignsNegativeOffTickSpacing() public view {
+        // currentTick = -10, spacing = 60 → anchor = -60 (floor).
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(-10, 60, 0, 0);
+        assertEq(ps[3].tickLower, -60);
+        assertEq(ps[3].tickUpper, 0);
+    }
+
+    function test_computePositions_adjacentPositionsContiguous() public view {
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(120, 60, 0, 0);
+        for (uint256 i = 1; i < ps.length; i++) {
+            assertEq(ps[i].tickLower, ps[i - 1].tickUpper);
+        }
+    }
+
+    function test_computePositions_widthEqualsSpacing() public view {
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(120, 60, 0, 0);
+        for (uint256 i = 0; i < ps.length; i++) {
+            assertEq(int256(ps[i].tickUpper - ps[i].tickLower), 60);
+        }
+    }
+
+    function test_computePositions_centeredAroundAnchor() public view {
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(180, 60, 0, 0);
+        // anchor = 180 (already aligned). Centre i=3 spans [180, 240].
+        // Outermost positions: [180 - 3*60, 180 - 2*60] and [180 + 3*60, 180 + 4*60].
+        assertEq(ps[0].tickLower, 0);
+        assertEq(ps[6].tickUpper, 420);
+    }
+
+    // -------------------------------------------------------------------------
+    // Determinism (purity contract)
+    // -------------------------------------------------------------------------
+
+    function testFuzz_computePositions_deterministic(int24 tick, int8 spacingFactor) public view {
+        // tick spacing is positive and bounded — V4 uses values in [1, 16384]
+        int24 spacing = int24(uint24(uint8(spacingFactor) | 1)); // odd, non-zero, positive
+        if (spacing <= 0) spacing = 1;
+
+        // Bound tick to avoid int24 overflow when computing anchor ± 4*spacing.
+        vm.assume(tick > -200_000 && tick < 200_000);
+
+        IStrategy.TargetPosition[] memory a = strat.computePositions(tick, spacing, 1e18, 1e18);
+        IStrategy.TargetPosition[] memory b = strat.computePositions(tick, spacing, 1e18, 1e18);
+
+        assertEq(a.length, b.length);
+        for (uint256 i = 0; i < a.length; i++) {
+            assertEq(a[i].tickLower, b[i].tickLower);
+            assertEq(a[i].tickUpper, b[i].tickUpper);
+            assertEq(a[i].weight, b[i].weight);
+        }
+    }
+
+    function testFuzz_computePositions_weightsAlwaysSumTo10000(int24 tick, int8 spacingFactor) public view {
+        int24 spacing = int24(uint24(uint8(spacingFactor) | 1));
+        if (spacing <= 0) spacing = 1;
+        vm.assume(tick > -200_000 && tick < 200_000);
+
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(tick, spacing, 1e18, 1e18);
+        uint256 sum;
+        for (uint256 i = 0; i < ps.length; i++) {
+            sum += ps[i].weight;
+        }
+        assertEq(sum, 10_000);
+    }
+
+    function testFuzz_computePositions_amountsAreOpaque(uint256 a0, uint256 a1) public view {
+        // Strategy is vault-agnostic: changing amounts shouldn't change
+        // tick layout or weights (only the vault's *liquidity allocation*
+        // depends on amounts; the strategy emits weights only).
+        IStrategy.TargetPosition[] memory withZero = strat.computePositions(0, 60, 0, 0);
+        IStrategy.TargetPosition[] memory withFuzz = strat.computePositions(0, 60, a0, a1);
+        for (uint256 i = 0; i < withZero.length; i++) {
+            assertEq(withZero[i].tickLower, withFuzz[i].tickLower);
+            assertEq(withZero[i].tickUpper, withFuzz[i].tickUpper);
+            assertEq(withZero[i].weight, withFuzz[i].weight);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    function test_constants() public view {
+        assertEq(strat.N_POSITIONS(), 7);
+    }
+}

--- a/packages/contracts/test/utils/Errors.t.sol
+++ b/packages/contracts/test/utils/Errors.t.sol
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {Errors} from "../../src/utils/Errors.sol";
+
+/// @notice Selector regression + revert-shape tests for `Errors`.
+/// @dev `Errors` is a pure declaration library — there is no behaviour to
+///      exercise other than:
+///      1. Selectors are stable across refactors. Third parties index
+///         reverts by selector; an accidental signature change is a
+///         consumer-breaking bug. Snapshotted explicitly here.
+///      2. Encoded args round-trip through `abi.decode`. Catches the
+///         "I added a uint256 arg but consumers still encode for an
+///         empty error" class of mistake.
+contract ErrorsTest is Test {
+    // -------------------------------------------------------------------------
+    // Selector snapshots
+    // -------------------------------------------------------------------------
+    //
+    // To regenerate after intentional signature changes:
+    //
+    //   forge inspect Errors errors --json | jq
+    //
+    // and update the constants below. Bumping any of these is a breaking
+    // change for downstream indexers — bump the major version.
+
+    function test_selector_OnlyOwner() external pure {
+        assertEq(Errors.OnlyOwner.selector, bytes4(keccak256("OnlyOwner()")));
+    }
+
+    function test_selector_OnlyKeeper() external pure {
+        assertEq(Errors.OnlyKeeper.selector, bytes4(keccak256("OnlyKeeper()")));
+    }
+
+    function test_selector_OnlyPoolManager() external pure {
+        assertEq(Errors.OnlyPoolManager.selector, bytes4(keccak256("OnlyPoolManager()")));
+    }
+
+    function test_selector_ZeroAddress() external pure {
+        assertEq(Errors.ZeroAddress.selector, bytes4(keccak256("ZeroAddress()")));
+    }
+
+    function test_selector_SlippageExceeded() external pure {
+        assertEq(Errors.SlippageExceeded.selector, bytes4(keccak256("SlippageExceeded(uint256,uint256)")));
+    }
+
+    function test_selector_TVLCapExceeded() external pure {
+        assertEq(Errors.TVLCapExceeded.selector, bytes4(keccak256("TVLCapExceeded(uint256,uint256)")));
+    }
+
+    function test_selector_DepositsPaused() external pure {
+        assertEq(Errors.DepositsPaused.selector, bytes4(keccak256("DepositsPaused()")));
+    }
+
+    function test_selector_ZeroShares() external pure {
+        assertEq(Errors.ZeroShares.selector, bytes4(keccak256("ZeroShares()")));
+    }
+
+    function test_selector_InvalidShareAmount() external pure {
+        assertEq(Errors.InvalidShareAmount.selector, bytes4(keccak256("InvalidShareAmount()")));
+    }
+
+    function test_selector_WeightsDoNotSum() external pure {
+        assertEq(Errors.WeightsDoNotSum.selector, bytes4(keccak256("WeightsDoNotSum(uint256)")));
+    }
+
+    function test_selector_MaxPositionsExceeded() external pure {
+        assertEq(Errors.MaxPositionsExceeded.selector, bytes4(keccak256("MaxPositionsExceeded(uint256)")));
+    }
+
+    function test_selector_InvalidTickRange() external pure {
+        assertEq(Errors.InvalidTickRange.selector, bytes4(keccak256("InvalidTickRange(int24,int24)")));
+    }
+
+    function test_selector_RebalanceNotNeeded() external pure {
+        assertEq(Errors.RebalanceNotNeeded.selector, bytes4(keccak256("RebalanceNotNeeded()")));
+    }
+
+    function test_selector_HookNotPermissioned() external pure {
+        assertEq(Errors.HookNotPermissioned.selector, bytes4(keccak256("HookNotPermissioned(uint160,uint160)")));
+    }
+
+    function test_selector_OracleStale() external pure {
+        assertEq(Errors.OracleStale.selector, bytes4(keccak256("OracleStale(uint256)")));
+    }
+
+    function test_selector_OracleDeviation() external pure {
+        assertEq(Errors.OracleDeviation.selector, bytes4(keccak256("OracleDeviation(uint256)")));
+    }
+
+    function test_selector_UnknownOp() external pure {
+        assertEq(Errors.UnknownOp.selector, bytes4(keccak256("UnknownOp()")));
+    }
+
+    function test_selector_DeltaUnsettled() external pure {
+        assertEq(Errors.DeltaUnsettled.selector, bytes4(keccak256("DeltaUnsettled()")));
+    }
+
+    function test_selector_Reentrancy() external pure {
+        assertEq(Errors.Reentrancy.selector, bytes4(keccak256("Reentrancy()")));
+    }
+
+    function test_selector_MathOverflow() external pure {
+        assertEq(Errors.MathOverflow.selector, bytes4(keccak256("MathOverflow()")));
+    }
+
+    function test_selector_ValueOutOfBounds() external pure {
+        assertEq(Errors.ValueOutOfBounds.selector, bytes4(keccak256("ValueOutOfBounds(uint256,uint256)")));
+    }
+
+    // -------------------------------------------------------------------------
+    // Revert shape (round-trip)
+    // -------------------------------------------------------------------------
+
+    function test_revertShape_SlippageExceeded() external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.SlippageExceeded.selector, uint256(99), uint256(100)));
+        _throwSlippage(99, 100);
+    }
+
+    function test_revertShape_WeightsDoNotSum(uint256 actual) external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.WeightsDoNotSum.selector, actual));
+        _throwWeights(actual);
+    }
+
+    function test_revertShape_HookNotPermissioned(uint160 expected, uint160 actual) external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.HookNotPermissioned.selector, expected, actual));
+        _throwHook(expected, actual);
+    }
+
+    function test_revertShape_DepositsPaused() external {
+        vm.expectRevert(Errors.DepositsPaused.selector);
+        _throwPaused();
+    }
+
+    // -------------------------------------------------------------------------
+    // Throwers — kept tiny so the tests stay focused on the library itself
+    // -------------------------------------------------------------------------
+
+    function _throwSlippage(uint256 actual, uint256 min) internal pure {
+        revert Errors.SlippageExceeded(actual, min);
+    }
+
+    function _throwWeights(uint256 actual) internal pure {
+        revert Errors.WeightsDoNotSum(actual);
+    }
+
+    function _throwHook(uint160 expected, uint160 actual) internal pure {
+        revert Errors.HookNotPermissioned(expected, actual);
+    }
+
+    function _throwPaused() internal pure {
+        revert Errors.DepositsPaused();
+    }
+}


### PR DESCRIPTION
## Summary

Default PRISM strategy. Returns 7 positions arranged as a symmetric bell around the current tick, weights \`[500, 1200, 2100, 2400, 2100, 1200, 500]\` bps (Σ = 10_000).

### Purity contract (ADR-005)

- No SSTORE in runtime bytecode — weights are inline literal constants
- Deterministic across repeat calls with identical inputs
- amounts0 / amounts1 are opaque to the strategy (vault-agnosticism)

### Tick alignment

\`currentTick\` is floored to the nearest tickSpacing boundary (negative-tick aware via signed-mod handling). The 7 positions tile contiguously across \`[anchor - 3*ts, anchor + 4*ts]\` with each position spanning exactly one tickSpacing.

### shouldRebalance stub

Returns false on this PR. The actual gate (tick drift + time threshold + 24h fallback) lands in #33.

## Quality gates

- \`forge build\`: pass
- \`forge fmt\`: clean
- \`forge test test/strategies/BellStrategy.t.sol\`: **16/16 pass**

## Test plan

- [x] 7 positions, weights sum to 10_000, symmetric, centre largest
- [x] zero / negative tickSpacing reverts \`InvalidTickRange\`
- [x] anchor floors at zero, positive, and negative ticks
- [x] adjacent positions contiguous; width == spacing
- [x] fuzz: deterministic across repeat calls
- [x] fuzz: weight invariant holds for any (tick, spacing)
- [x] fuzz: amounts are opaque (vault-agnosticism)

## Dependencies

- Stacked on **#20 (contracts/20-istrategy)** with cherry-picked Errors (#17)
- Unblocks #33 (shouldRebalance), #29 (Vault.rebalance consumes computePositions)

Closes #32