### PR TITLE
feat(contracts): BellStrategy.shouldRebalance gate (#33)

### DIFF
--- a/packages/contracts/src/strategies/BellStrategy.sol
+++ b/packages/contracts/src/strategies/BellStrategy.sol
@@ -77,21 +77,56 @@ contract BellStrategy is IStrategy {
         positions[6] = TargetPosition({tickLower: anchor + 3 * ts, tickUpper: anchor + 4 * ts, weight: W6});
     }
 
+    /// @notice Tick drift threshold in raw ticks. Beyond this absolute
+    ///         drift from the last rebalance tick, the bell is no longer
+    ///         centred and the gate fires.
+    /// @dev v1.0 default: 4 * (median Base ETH/USDC tickSpacing of 60) =
+    ///      240 ticks ≈ 2.4% price drift. Subject to revision in v1.1.
+    int24 public constant TICK_DRIFT_THRESHOLD = 240;
+
+    /// @notice Time threshold in seconds. Independent of tick drift —
+    ///         even a calm market gets at least one rebalance per
+    ///         `TIME_THRESHOLD` so the bell tracks medium-term drift.
+    /// @dev v1.0 default: 6 hours.
+    uint256 public constant TIME_THRESHOLD = 6 hours;
+
+    /// @notice Liveness fallback. Hard cap on time between rebalances —
+    ///         even in a near-zero-volatility market keepers must be
+    ///         able to claim their bonus, otherwise low-TVL vaults
+    ///         starve. See ADR-007 (gas budget) §keeper economics.
+    uint256 public constant LIVENESS_FALLBACK = 24 hours;
+
     /// @inheritdoc IStrategy
-    /// @dev #33 implements the actual gate (tick drift + time threshold +
-    ///      24h fallback). For #32 this returns false so the vault
-    ///      compiles against the full interface but never rebalances on
-    ///      this stub.
+    /// @dev Three independent triggers (any one fires the gate):
+    ///        1. Tick drift exceeds `TICK_DRIFT_THRESHOLD`
+    ///        2. Time since last rebalance exceeds `TIME_THRESHOLD`
+    ///        3. Liveness backstop (`LIVENESS_FALLBACK`) elapsed
+    ///      `block.timestamp` is the only non-input the strategy reads —
+    ///      explicitly permitted by ADR-005 §purity contract for the
+    ///      time gates.
     function shouldRebalance(
-        int24, /*currentTick*/
-        int24, /*lastRebalanceTick*/
-        uint256 /*lastRebalanceTimestamp*/
+        int24 currentTick,
+        int24 lastRebalanceTick,
+        uint256 lastRebalanceTimestamp
     )
         external
         view
         override
         returns (bool)
     {
+        // Liveness fallback is the hard floor — independently of how
+        // small the drift is, vaults rebalance at least once per 24h.
+        if (block.timestamp >= lastRebalanceTimestamp + LIVENESS_FALLBACK) return true;
+
+        // Time threshold — ordinary cadence trigger.
+        if (block.timestamp >= lastRebalanceTimestamp + TIME_THRESHOLD) return true;
+
+        // Tick drift — fires immediately when price moves outside the
+        // bell. Use absolute value via the int24 width.
+        int24 drift =
+            currentTick > lastRebalanceTick ? currentTick - lastRebalanceTick : lastRebalanceTick - currentTick;
+        if (drift >= TICK_DRIFT_THRESHOLD) return true;
+
         return false;
     }
 

--- a/packages/contracts/test/strategies/BellStrategy.t.sol
+++ b/packages/contracts/test/strategies/BellStrategy.t.sol
@@ -159,5 +159,57 @@ contract BellStrategyTest is Test {
 
     function test_constants() public view {
         assertEq(strat.N_POSITIONS(), 7);
+        assertEq(strat.TICK_DRIFT_THRESHOLD(), 240);
+        assertEq(strat.TIME_THRESHOLD(), 6 hours);
+        assertEq(strat.LIVENESS_FALLBACK(), 24 hours);
+    }
+
+    // -------------------------------------------------------------------------
+    // shouldRebalance — three triggers
+    // -------------------------------------------------------------------------
+
+    function test_shouldRebalance_falseWhenAllQuiet() public {
+        vm.warp(1_700_000_000);
+        // Same tick, just rebalanced.
+        assertFalse(strat.shouldRebalance(0, 0, block.timestamp));
+    }
+
+    function test_shouldRebalance_firesOnTickDrift() public {
+        vm.warp(1_700_000_000);
+        // Drift = TICK_DRIFT_THRESHOLD → fires.
+        assertTrue(strat.shouldRebalance(240, 0, block.timestamp));
+        // Negative-direction drift symmetric.
+        assertTrue(strat.shouldRebalance(-240, 0, block.timestamp));
+        // Below threshold → no fire.
+        assertFalse(strat.shouldRebalance(239, 0, block.timestamp));
+    }
+
+    function test_shouldRebalance_firesOnTimeThreshold() public {
+        uint256 last = 1_700_000_000;
+        vm.warp(last + 6 hours);
+        assertTrue(strat.shouldRebalance(0, 0, last));
+
+        vm.warp(last + 6 hours - 1);
+        assertFalse(strat.shouldRebalance(0, 0, last));
+    }
+
+    function test_shouldRebalance_firesOnLivenessFallback() public {
+        uint256 last = 1_700_000_000;
+        vm.warp(last + 24 hours);
+        // Even with zero tick drift and time-threshold-already-elapsed,
+        // the 24h fallback is the strict-largest guarantee.
+        assertTrue(strat.shouldRebalance(0, 0, last));
+    }
+
+    function test_shouldRebalance_independentTriggers() public {
+        uint256 last = 1_700_000_000;
+        vm.warp(last + 1);
+
+        // Drift only.
+        assertTrue(strat.shouldRebalance(500, 0, last));
+
+        // Time only.
+        vm.warp(last + 6 hours);
+        assertTrue(strat.shouldRebalance(0, 0, last));
     }
 }


### PR DESCRIPTION
## Summary

Three-trigger rebalance gate. Any one fires:

| Trigger | Threshold | Why |
|---|---|---|
| Liveness fallback | 24h | Keeper economics backstop (ADR-007) — low-TVL vaults rebalance daily even when bonus < gas |
| Time threshold | 6h | Ordinary cadence; tracks medium-term drift in calm markets |
| Tick drift | ≥240 ticks (~2.4%) | Fires immediately when price moves outside the bell |

\`block.timestamp\` is the only non-input read — explicitly permitted by ADR-005 §purity contract for time gates.

## Constants

- \`TICK_DRIFT_THRESHOLD = 240\`
- \`TIME_THRESHOLD = 6 hours\`
- \`LIVENESS_FALLBACK = 24 hours\`

## Quality gates

- \`forge build\`: pass
- \`forge fmt\`: clean
- \`forge test test/strategies/BellStrategy.t.sol\`: **21/21 pass**

## Test plan

- [x] all-quiet returns false
- [x] tick drift fires (positive, negative, below-threshold)
- [x] time threshold edge (= and = − 1)
- [x] 24h liveness fallback
- [x] independent triggers (drift only / time only)

## Dependencies

- Stacked on **#32 (contracts/32-bell-compute)**.
- Unblocks #29 (Vault.rebalance gates on this).

Closes #33