### PR TITLE
feat(contracts): VaultFactory — CREATE2 + registry (#31)

### DIFF
--- a/packages/contracts/src/core/VaultFactory.sol
+++ b/packages/contracts/src/core/VaultFactory.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+
+import {IProtocolHook} from "../interfaces/IProtocolHook.sol";
+import {IStrategy} from "../interfaces/IStrategy.sol";
+import {Errors} from "../utils/Errors.sol";
+import {Vault} from "./Vault.sol";
+
+/// @title VaultFactory — CREATE2 vault deployer + registry
+/// @notice Deploys one `Vault` per `(PoolKey, IStrategy)` tuple via
+///         CREATE2 so the vault address is predictable off-chain. Maintains
+///         a registry of all deployed vaults indexed by the keccak256 of
+///         the (PoolKey, strategy) tuple.
+///
+/// @dev    Per ADR-006 the factory is itself immutable — no setters, no
+///         proxy. The hook + poolManager are pinned at construction so
+///         every vault deployed by this factory shares the same hook
+///         instance (singleton, ADR-002).
+///
+///         The factory is the only address authorised to call
+///         `IProtocolHook.registerVault` — see ProtocolHook constructor's
+///         `factory` immutable. Rotating the factory therefore requires
+///         redeploying both factory and hook.
+contract VaultFactory {
+    /// @notice Canonical V4 PoolManager.
+    IPoolManager public immutable poolManager;
+
+    /// @notice Singleton ProtocolHook every vault from this factory uses.
+    IProtocolHook public immutable hook;
+
+    /// @notice Multisig admin owner used as the initial owner for every
+    ///         vault deployed by this factory. Per-vault ownership can
+    ///         be transferred via `Vault.transferOwnership`.
+    address public immutable defaultOwner;
+
+    /// @notice keccak256(abi.encode(PoolKey, strategy)) → vault address.
+    ///         Zero means no vault has been deployed for that tuple.
+    mapping(bytes32 => address) public vaultByKey;
+
+    /// @notice Every vault address ever deployed by this factory, in
+    ///         deployment order. Off-chain consumers (the dApp, keeper)
+    ///         walk this to enumerate live vaults.
+    address[] internal _allVaults;
+
+    event VaultCreated(address indexed vault, address indexed strategy, bytes32 indexed registryKey, address creator);
+
+    constructor(IPoolManager poolManager_, IProtocolHook hook_, address defaultOwner_) {
+        if (address(poolManager_) == address(0)) revert Errors.ZeroAddress();
+        if (address(hook_) == address(0)) revert Errors.ZeroAddress();
+        if (defaultOwner_ == address(0)) revert Errors.ZeroAddress();
+
+        poolManager = poolManager_;
+        hook = hook_;
+        defaultOwner = defaultOwner_;
+    }
+
+    /// @notice Deploy a vault for `(poolKey, strategy)` if one does not
+    ///         already exist. Reverts if a vault is already registered
+    ///         for the tuple (prevents address collisions and accidental
+    ///         re-deployment over an active vault).
+    /// @param  poolKey       The Uniswap V4 pool the vault wraps.
+    /// @param  strategy      The IStrategy implementation the vault uses.
+    /// @param  tvlCap        Per-vault TVL cap in token0 notional units.
+    /// @param  name_         ERC-20 name of the share token.
+    /// @param  symbol_       ERC-20 symbol of the share token.
+    /// @param  salt          CREATE2 salt — caller-supplied so off-chain
+    ///                       tooling can mine vanity addresses if desired.
+    function create(
+        PoolKey calldata poolKey,
+        IStrategy strategy,
+        uint256 tvlCap,
+        string calldata name_,
+        string calldata symbol_,
+        bytes32 salt
+    )
+        external
+        returns (address vault)
+    {
+        if (address(strategy) == address(0)) revert Errors.ZeroAddress();
+
+        bytes32 registryKey = keccak256(abi.encode(poolKey, strategy));
+        if (vaultByKey[registryKey] != address(0)) revert Errors.OnlyOwner();
+
+        // CREATE2 deploy. The factory itself is the deployer so the
+        // address can be predicted off-chain via
+        //   keccak256(0xff, factory, salt, keccak256(creationCode + ctorArgs))[12:]
+        bytes memory creationCode = type(Vault).creationCode;
+        bytes memory ctorArgs = abi.encode(poolManager, poolKey, strategy, hook, defaultOwner, tvlCap, name_, symbol_);
+        bytes memory initCode = abi.encodePacked(creationCode, ctorArgs);
+
+        assembly {
+            vault := create2(0, add(initCode, 0x20), mload(initCode), salt)
+        }
+        if (vault == address(0)) revert Errors.UnknownOp();
+
+        vaultByKey[registryKey] = vault;
+        _allVaults.push(vault);
+
+        // Tell the hook about the new vault so afterSwap can attribute
+        // MEV observations. Reverts via OnlyOwner on the hook side if
+        // this factory wasn't the one set in the hook's `factory`
+        // immutable — that's the address-binding invariant from #34.
+        hook.registerVault(vault);
+
+        emit VaultCreated(vault, address(strategy), registryKey, msg.sender);
+    }
+
+    /// @notice Number of vaults this factory has deployed.
+    function allVaultsLength() external view returns (uint256) {
+        return _allVaults.length;
+    }
+
+    /// @notice Vault at index `i`. Reverts on out-of-bounds.
+    function allVaults(uint256 i) external view returns (address) {
+        return _allVaults[i];
+    }
+
+    /// @notice Predicted address for a CREATE2 deploy with the given
+    ///         args + salt. Lets off-chain tooling and the dApp render
+    ///         the future address before transaction submission.
+    function predictAddress(
+        PoolKey calldata poolKey,
+        IStrategy strategy,
+        uint256 tvlCap,
+        string calldata name_,
+        string calldata symbol_,
+        bytes32 salt
+    )
+        external
+        view
+        returns (address)
+    {
+        bytes memory creationCode = type(Vault).creationCode;
+        bytes memory ctorArgs = abi.encode(poolManager, poolKey, strategy, hook, defaultOwner, tvlCap, name_, symbol_);
+        bytes32 initCodeHash = keccak256(abi.encodePacked(creationCode, ctorArgs));
+        return address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), address(this), salt, initCodeHash)))));
+    }
+}

--- a/packages/contracts/test/core/VaultFactory.t.sol
+++ b/packages/contracts/test/core/VaultFactory.t.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {Currency} from "v4-core/types/Currency.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+
+import {VaultFactory} from "../../src/core/VaultFactory.sol";
+import {IProtocolHook} from "../../src/interfaces/IProtocolHook.sol";
+import {IStrategy} from "../../src/interfaces/IStrategy.sol";
+import {Errors} from "../../src/utils/Errors.sol";
+
+contract VaultFactoryTest is Test {
+    address constant POOL_MANAGER = address(0xCa11);
+    address constant HOOK = address(0xB00C);
+    address constant STRATEGY = address(0x5747);
+    address constant OWNER = address(0xACE);
+
+    VaultFactory factory;
+
+    function setUp() public {
+        factory = new VaultFactory(IPoolManager(POOL_MANAGER), IProtocolHook(HOOK), OWNER);
+        // Mock the hook.registerVault call so the factory's create()
+        // doesn't revert against a non-existent hook contract.
+        vm.mockCall(HOOK, abi.encodeWithSelector(IProtocolHook.registerVault.selector), abi.encode());
+    }
+
+    function _key() internal pure returns (PoolKey memory) {
+        return PoolKey({
+            currency0: Currency.wrap(address(0xa)),
+            currency1: Currency.wrap(address(0xb)),
+            fee: 0x800000,
+            tickSpacing: 60,
+            hooks: IHooks(HOOK)
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Construction
+    // -------------------------------------------------------------------------
+
+    function test_immutables() public view {
+        assertEq(address(factory.poolManager()), POOL_MANAGER);
+        assertEq(address(factory.hook()), HOOK);
+        assertEq(factory.defaultOwner(), OWNER);
+    }
+
+    function test_constructor_revertsOnZeroPoolManager() public {
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new VaultFactory(IPoolManager(address(0)), IProtocolHook(HOOK), OWNER);
+    }
+
+    function test_constructor_revertsOnZeroHook() public {
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new VaultFactory(IPoolManager(POOL_MANAGER), IProtocolHook(address(0)), OWNER);
+    }
+
+    function test_constructor_revertsOnZeroOwner() public {
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new VaultFactory(IPoolManager(POOL_MANAGER), IProtocolHook(HOOK), address(0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Registry
+    // -------------------------------------------------------------------------
+
+    function test_initialRegistryEmpty() public view {
+        assertEq(factory.allVaultsLength(), 0);
+    }
+
+    function test_create_revertsOnZeroStrategy() public {
+        PoolKey memory k = _key();
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        factory.create(k, IStrategy(address(0)), 1e18, "n", "s", bytes32(0));
+    }
+
+    function test_create_deploysVault() public {
+        PoolKey memory k = _key();
+        address vault = factory.create(k, IStrategy(STRATEGY), 1_000_000e18, "PRISM", "pTKN", bytes32(uint256(0x1234)));
+        assertTrue(vault != address(0));
+        assertEq(factory.allVaultsLength(), 1);
+        assertEq(factory.allVaults(0), vault);
+    }
+
+    function test_create_revertsOnDuplicate() public {
+        PoolKey memory k = _key();
+        factory.create(k, IStrategy(STRATEGY), 1e18, "n", "s", bytes32(uint256(1)));
+        vm.expectRevert(Errors.OnlyOwner.selector);
+        factory.create(k, IStrategy(STRATEGY), 1e18, "n", "s", bytes32(uint256(2)));
+    }
+
+    function test_predictAddress_matchesActualDeploy() public {
+        PoolKey memory k = _key();
+        bytes32 salt = bytes32(uint256(0xdead));
+        address predicted = factory.predictAddress(k, IStrategy(STRATEGY), 1e18, "n", "s", salt);
+        address actual = factory.create(k, IStrategy(STRATEGY), 1e18, "n", "s", salt);
+        assertEq(predicted, actual);
+    }
+}


### PR DESCRIPTION
## Summary

Deploys one Vault per \`(PoolKey, strategy)\` tuple via CREATE2 so the address is predictable off-chain. Maintains a registry indexed by \`keccak256(abi.encode(PoolKey, strategy))\`.

### Architecture (per ADR-002 + ADR-006)

- Factory is itself immutable — no setters, no proxy
- \`poolManager\` + \`hook\` + \`defaultOwner\` pinned at construction
- Singleton hook: every vault from this factory shares one hook instance
- Factory is the only address authorised to call \`hook.registerVault\` (enforced by the hook's \`factory\` immutable from #34)
- Caller-supplied salt for vanity addresses if desired

### Public surface

- \`create(poolKey, strategy, tvlCap, name, symbol, salt)\` — zero-strategy + duplicate-tuple guards, CREATE2, registry write, \`hook.registerVault\`, \`VaultCreated\` event
- \`allVaults(i)\` / \`allVaultsLength()\` — registry walker
- \`predictAddress(...)\` — off-chain helper, matches actual CREATE2 output

## Quality gates

- \`forge build\`: pass
- \`forge fmt\`: clean
- \`forge test test/core/VaultFactory.t.sol\`: **9/9 pass**

## Test plan

- [x] all 3 ctor reverts
- [x] initial registry empty
- [x] create deploys + indexes
- [x] duplicate tuple rejected
- [x] predictAddress == actual

## Dependencies

- Stacked on **#30 (contracts/30-vault-views)**
- Unblocks #64 (Deploy script wires factory + hook + everything)

Closes #31