### PR TITLE
test(contracts): expand BellStrategy fuzz invariants (#39)

### DIFF
--- a/packages/contracts/test/strategies/BellStrategy.t.sol
+++ b/packages/contracts/test/strategies/BellStrategy.t.sol
@@ -212,4 +212,64 @@ contract BellStrategyTest is Test {
         vm.warp(last + 6 hours);
         assertTrue(strat.shouldRebalance(0, 0, last));
     }
+
+    // -------------------------------------------------------------------------
+    // #39 — additional fuzz invariants
+    // -------------------------------------------------------------------------
+
+    /// @dev MAX_POSITIONS bound: returned positions never exceed the
+    ///      vault's hardcoded cap (invariant #3).
+    function testFuzz_neverExceedsMaxPositions(int24 tick, int8 spacingFactor) public view {
+        int24 spacing = int24(uint24(uint8(spacingFactor) | 1));
+        if (spacing <= 0) spacing = 1;
+        vm.assume(tick > -200_000 && tick < 200_000);
+
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(tick, spacing, 1, 1);
+        assertLe(ps.length, 7); // Vault.MAX_POSITIONS
+    }
+
+    /// @dev Tick-range bounds: every returned position has tickLower
+    ///      strictly less than tickUpper.
+    function testFuzz_tickRangeWellOrdered(int24 tick, int8 spacingFactor) public view {
+        int24 spacing = int24(uint24(uint8(spacingFactor) | 1));
+        if (spacing <= 0) spacing = 1;
+        vm.assume(tick > -200_000 && tick < 200_000);
+
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(tick, spacing, 1, 1);
+        for (uint256 i = 0; i < ps.length; i++) {
+            assertLt(ps[i].tickLower, ps[i].tickUpper);
+        }
+    }
+
+    /// @dev Tick alignment: every returned tick is divisible by spacing.
+    function testFuzz_ticksAlignedToSpacing(int24 tick, int8 spacingFactor) public view {
+        int24 spacing = int24(uint24(uint8(spacingFactor) | 1));
+        if (spacing <= 0) spacing = 1;
+        vm.assume(tick > -200_000 && tick < 200_000);
+
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(tick, spacing, 1, 1);
+        for (uint256 i = 0; i < ps.length; i++) {
+            assertEq(int256(ps[i].tickLower) % int256(spacing), 0);
+            assertEq(int256(ps[i].tickUpper) % int256(spacing), 0);
+        }
+    }
+
+    /// @dev shouldRebalance is monotonic in time: once it returns true
+    ///      for a given lastTimestamp, it stays true for any later
+    ///      block.timestamp at the same drift.
+    function testFuzz_shouldRebalanceMonotonicInTime(uint64 lastTs, uint64 dt) public {
+        vm.assume(lastTs > 0 && lastTs < type(uint32).max);
+        vm.assume(dt > 0 && dt < 365 days);
+
+        // Pick a calm tick (drift = 0). Time alone determines fire.
+        vm.warp(uint256(lastTs) + uint256(dt));
+
+        bool firstResult = strat.shouldRebalance(0, 0, lastTs);
+
+        // Warp further forward — should never flip from true → false.
+        vm.warp(uint256(lastTs) + uint256(dt) + 1);
+        bool secondResult = strat.shouldRebalance(0, 0, lastTs);
+
+        if (firstResult) assertTrue(secondResult);
+    }
 }


### PR DESCRIPTION
## Summary

4 fuzz invariants on top of the 21 from #32 + #33:

- \`testFuzz_neverExceedsMaxPositions\` — invariant #3 length cap
- \`testFuzz_tickRangeWellOrdered\` — \`tickLower < tickUpper\`
- \`testFuzz_ticksAlignedToSpacing\` — defence against off-by-spacing
- \`testFuzz_shouldRebalanceMonotonicInTime\` — gate is monotonic forward in time

Total: **25 tests**.

## Quality gates

- \`forge test test/strategies/BellStrategy.t.sol\`: 25/25 pass

## Dependencies

- Stacked on **#33 (contracts/33-bell-rebalance-gate)**

Closes #39