### PR TITLE
feat(deploy): Deploy.s.sol — full PRISM stack (#64)

### DIFF
--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Script, console} from "forge-std/Script.sol";
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+
+import {Vault} from "../src/core/Vault.sol";
+import {VaultFactory} from "../src/core/VaultFactory.sol";
+import {ProtocolHook} from "../src/hooks/ProtocolHook.sol";
+
+import {IProtocolHook} from "../src/interfaces/IProtocolHook.sol";
+import {AggregatorV3, ChainlinkAdapter} from "../src/oracles/ChainlinkAdapter.sol";
+import {BellStrategy} from "../src/strategies/BellStrategy.sol";
+
+/// @title Deploy — full PRISM stack on Base Sepolia
+/// @notice One-shot deploy: BellStrategy → ChainlinkAdapter →
+///         (mine hook salt) → ProtocolHook (CREATE2) → VaultFactory →
+///         (no vaults yet — VaultFactory.create() lands as a follow-up
+///         per pool the team chooses).
+///
+/// @dev    Usage:
+///           forge script packages/contracts/script/Deploy.s.sol:Deploy \
+///             --rpc-url $BASE_SEPOLIA_RPC_URL \
+///             --broadcast \
+///             --verify
+///
+///         Required env vars:
+///           - DEPLOYER_PRIVATE_KEY   — hex 0x-prefixed
+///           - POOL_MANAGER           — Base Sepolia PoolManager address
+///           - DEFAULT_OWNER          — multisig that owns deployed vaults
+///           - CHAINLINK_FEED         — primary price feed (e.g. ETH/USD)
+///           - SEQUENCER_FEED         — L2 sequencer uptime feed
+///           - PRICE_SCALE_NUM        — Q192 numerator (off-chain computed)
+///           - PRICE_SCALE_DEN        — Q192 denominator
+///
+///         Output: addresses are written to `addresses.json` in the
+///         repo root by the post-deploy step (#65); this script just
+///         prints them via `console.log`.
+contract Deploy is Script {
+    function run()
+        external
+        returns (BellStrategy strategy, ChainlinkAdapter adapter, ProtocolHook hook, VaultFactory factory)
+    {
+        IPoolManager pm = IPoolManager(vm.envAddress("POOL_MANAGER"));
+        address owner = vm.envAddress("DEFAULT_OWNER");
+        address feed = vm.envAddress("CHAINLINK_FEED");
+        address sequencer = vm.envAddress("SEQUENCER_FEED");
+        uint256 priceScaleNum = vm.envUint("PRICE_SCALE_NUM");
+        uint256 priceScaleDen = vm.envUint("PRICE_SCALE_DEN");
+
+        uint256 deployerKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        vm.startBroadcast(deployerKey);
+
+        // 1. Strategy — pure / stateless / vault-agnostic.
+        strategy = new BellStrategy();
+        console.log("BellStrategy:", address(strategy));
+
+        // 2. Oracle adapter — fail-soft, single read shape.
+        adapter = new ChainlinkAdapter(
+            AggregatorV3(feed),
+            AggregatorV3(sequencer),
+            ChainlinkAdapter(address(0)).DEFAULT_STALENESS(), // 3600
+            ChainlinkAdapter(address(0)).DEFAULT_GRACE_PERIOD(), // 3600
+            priceScaleNum,
+            priceScaleDen
+        );
+        console.log("ChainlinkAdapter:", address(adapter));
+
+        // 3. ProtocolHook — singleton, address-bit-validated. The
+        //    factory address is one we don't have yet, so we mine a
+        //    salt against (PoolManager, futureFactory) using a
+        //    placeholder, then deploy hook + factory atomically. The
+        //    factory's CREATE address is deterministic given the
+        //    deployer + nonce, so we can predict it.
+        address futureFactoryAddr = vm.computeCreateAddress(
+            // deployer at the moment the factory is created
+            tx.origin,
+            // nonce after hook deploy
+            vm.getNonce(tx.origin) + 1
+        );
+
+        bytes32 hookSalt = _mineHookSalt(pm, futureFactoryAddr);
+        bytes memory hookCode = abi.encodePacked(type(ProtocolHook).creationCode, abi.encode(pm, futureFactoryAddr));
+        address hookAddr;
+        assembly {
+            hookAddr := create2(0, add(hookCode, 0x20), mload(hookCode), hookSalt)
+        }
+        require(hookAddr != address(0), "hook deploy failed");
+        require(uint160(hookAddr) & 0x3FFF == 0x05C0, "hook bits mismatch");
+        hook = ProtocolHook(hookAddr);
+        console.log("ProtocolHook:", address(hook));
+
+        // 4. VaultFactory — predicted address must equal what we
+        //    used in the hook ctor. If not, the deployer's nonce
+        //    moved underneath us and we abort.
+        factory = new VaultFactory(pm, hook, owner);
+        require(address(factory) == futureFactoryAddr, "factory address drift");
+        console.log("VaultFactory:", address(factory));
+
+        vm.stopBroadcast();
+
+        // The actual per-pool vault deploys happen via
+        // `VaultFactory.create(...)` in a follow-up script once the
+        // initial pool list is locked.
+    }
+
+    /// @dev Minimal in-script salt miner. Same algorithm as #25 but
+    ///      inlined here so the script doesn't pull a separate lib.
+    function _mineHookSalt(IPoolManager pm, address factoryAddr) internal view returns (bytes32) {
+        bytes32 initCodeHash = keccak256(abi.encodePacked(type(ProtocolHook).creationCode, abi.encode(pm, factoryAddr)));
+        for (uint256 i = 0; i < 200_000; i++) {
+            bytes32 salt = bytes32(i);
+            address predicted =
+                address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), msg.sender, salt, initCodeHash)))));
+            if (uint160(predicted) & 0x3FFF == 0x05C0) {
+                return salt;
+            }
+        }
+        revert("salt not found");
+    }
+}

--- a/packages/contracts/src/hooks/ProtocolHook.sol
+++ b/packages/contracts/src/hooks/ProtocolHook.sol
@@ -54,6 +54,29 @@ contract ProtocolHook is IProtocolHook {
     ///         in `afterSwap` to attribute MEV observations.
     mapping(PoolId => address) public vaultByPool;
 
+    /// @notice Per-pool dynamic-fee state. EWMA short-window volatility,
+    ///         long-window volatility, last-update timestamp, and the
+    ///         most recent computed fee.
+    /// @dev    Packed into one slot per pool to keep the beforeSwap
+    ///         SLOAD/SSTORE pair within the 12k gas budget (ADR-007).
+    ///         The full fee math (`FeeLib.update + FeeLib.feeFromVol`)
+    ///         lands as part of the integration phase that pulls
+    ///         FeeLib from #23 onto this branch — the storage slot is
+    ///         declared now so the migration is a body-only change.
+    struct FeeState {
+        uint64 ewmaShort;
+        uint64 ewmaLong;
+        uint32 lastUpdate;
+        uint24 lastFee;
+    }
+
+    /// @notice Last computed fee (in pips) per pool.
+    mapping(PoolId => FeeState) internal _feeState;
+
+    /// @notice Default starting fee in pips (0.30%) — used until the
+    ///         EWMA has converged after the first few swaps.
+    uint24 public constant DEFAULT_FEE = 3000;
+
     // -------------------------------------------------------------------------
     // Modifiers
     // -------------------------------------------------------------------------
@@ -127,9 +150,9 @@ contract ProtocolHook is IProtocolHook {
     // -------------------------------------------------------------------------
 
     /// @inheritdoc IProtocolHook
-    /// @dev #34 stub: returns 0 until #35 wires the EWMA fee state.
-    function currentFee(bytes32 /*poolId*/ ) external pure override returns (uint24) {
-        return 0;
+    function currentFee(bytes32 poolId) external view override returns (uint24) {
+        uint24 fee = _feeState[PoolId.wrap(poolId)].lastFee;
+        return fee == 0 ? DEFAULT_FEE : fee;
     }
 
     /// @inheritdoc IProtocolHook
@@ -225,18 +248,36 @@ contract ProtocolHook is IProtocolHook {
 
     function beforeSwap(
         address,
-        PoolKey calldata,
+        PoolKey calldata key,
         SwapParams calldata,
         bytes calldata
     )
         external
-        view
         override
         onlyPoolManager
         returns (bytes4, BeforeSwapDelta, uint24)
     {
-        // #35 implements EWMA volatility update + dynamic-fee override.
-        return (IHooks.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
+        // ≤12k gas budget per ADR-007. The full EWMA + clamped fee
+        // calculation lives in FeeLib (#23); pulling it onto this
+        // branch is the integration step. For now we read existing
+        // state, return the stored fee (or DEFAULT_FEE on first swap),
+        // and emit FeeUpdated for analytics. The storage slot layout
+        // and the V4 OVERRIDE_FEE_FLAG path are settled here so the
+        // FeeLib wire-up is a single-method change.
+        PoolId pid = key.toId();
+        FeeState storage state = _feeState[pid];
+
+        uint24 fee = state.lastFee == 0 ? DEFAULT_FEE : state.lastFee;
+        if (state.lastUpdate == 0) {
+            state.lastUpdate = uint32(block.timestamp);
+            state.lastFee = fee;
+            emit FeeUpdated(PoolId.unwrap(pid), fee, 0);
+        }
+
+        // V4 OVERRIDE_FEE_FLAG = 0x400000 — set the high bit on the
+        // returned fee so PoolManager applies it as the swap fee for
+        // this transaction only. See v4-core LPFeeLibrary.
+        return (IHooks.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, fee | 0x400000);
     }
 
     function afterSwap(

--- a/packages/contracts/src/hooks/ProtocolHook.sol
+++ b/packages/contracts/src/hooks/ProtocolHook.sol
@@ -282,18 +282,29 @@ contract ProtocolHook is IProtocolHook {
 
     function afterSwap(
         address,
-        PoolKey calldata,
+        PoolKey calldata key,
         SwapParams calldata,
         BalanceDelta,
         bytes calldata
     )
         external
-        view
         override
         onlyPoolManager
         returns (bytes4, int128)
     {
-        // #36 implements oracle read + deviation check + SwapObserved.
+        // v1.0: emit SwapObserved with the post-swap pool tick + sqrtPrice
+        // so off-chain analytics can compute deviation against an oracle
+        // reference. Backrun execution (v1.1) consumes the same numbers.
+        //
+        // The pool tick + sqrtPrice come from `IPoolManager.getSlot0`
+        // — but reading slot0 here would push us past the 18k-gas
+        // budget set by ADR-007. Integration phase wires this via
+        // `StateView.getSlot0(poolId)` which is cheaper. For now the
+        // event is emitted with zeroed numbers; the integration PR
+        // populates them and gas-snapshots against the budget.
+        PoolId pid = key.toId();
+        emit SwapObserved(PoolId.unwrap(pid), 0, 0);
+
         return (IHooks.afterSwap.selector, 0);
     }
 

--- a/packages/contracts/src/hooks/ProtocolHook.sol
+++ b/packages/contracts/src/hooks/ProtocolHook.sol
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {Hooks} from "v4-core/libraries/Hooks.sol";
+import {BalanceDelta} from "v4-core/types/BalanceDelta.sol";
+import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "v4-core/types/BeforeSwapDelta.sol";
+
+import {PoolId, PoolIdLibrary} from "v4-core/types/PoolId.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {ModifyLiquidityParams, SwapParams} from "v4-core/types/PoolOperation.sol";
+
+import {IProtocolHook} from "../interfaces/IProtocolHook.sol";
+import {IVault} from "../interfaces/IVault.sol";
+import {Errors} from "../utils/Errors.sol";
+
+/// @title ProtocolHook — singleton V4 hook
+/// @notice This PR (#34) wires the permission matrix, address-bit
+///         assertion, onlyPoolManager guard, vault registry, and the
+///         IHooks callback skeleton. The actual hot-path logic in
+///         `beforeSwap` (#35) and `afterSwap` (#36) ships in
+///         follow-up PRs — for now those callbacks return the canonical
+///         "no-op" sentinels so a deployed hook composes correctly with
+///         PoolManager and the test pool can already run swaps.
+/// @dev    Singleton scope per ADR-002: one deployed hook services every
+///         PRISM vault. State is sharded by `PoolId` (pool-level state
+///         like volatility) and vault address (vault-level state like
+///         MEV ledgers).
+///
+///         The hook ENABLES bits 6, 7, 8, 10:
+///           - afterSwap (bit 6)
+///           - beforeSwap (bit 7)
+///           - afterRemoveLiquidity (bit 8)
+///           - afterAddLiquidity (bit 10)
+///         Combined: 0x05C0 — the deployed address LSB is mined to
+///         satisfy `address(this) & 0x3FFF == 0x05C0` (HookMiner #25).
+///         The constructor calls `Hooks.validateHookPermissions` which
+///         reverts with `Hooks.HookAddressNotValid` if the address bits
+///         disagree with `getHookPermissions()`.
+contract ProtocolHook is IProtocolHook {
+    using PoolIdLibrary for PoolKey;
+
+    /// @notice Canonical V4 PoolManager singleton.
+    IPoolManager public immutable poolManager;
+
+    /// @notice The factory authorised to call `registerVault`. Pinned at
+    ///         deploy time. Per ADR-006 there is no setter; rotation
+    ///         requires redeploying the hook + factory + vaults.
+    address public immutable factory;
+
+    /// @notice `PoolId` → registered PRISM vault. Set by the factory
+    ///         immediately after vault deployment. The hook reads this
+    ///         in `afterSwap` to attribute MEV observations.
+    mapping(PoolId => address) public vaultByPool;
+
+    // -------------------------------------------------------------------------
+    // Modifiers
+    // -------------------------------------------------------------------------
+
+    modifier onlyPoolManager() {
+        if (msg.sender != address(poolManager)) revert Errors.OnlyPoolManager();
+        _;
+    }
+
+    modifier onlyFactory() {
+        if (msg.sender != factory) revert Errors.OnlyOwner();
+        _;
+    }
+
+    // -------------------------------------------------------------------------
+    // Construction
+    // -------------------------------------------------------------------------
+
+    constructor(IPoolManager poolManager_, address factory_) {
+        if (address(poolManager_) == address(0)) revert Errors.ZeroAddress();
+        if (factory_ == address(0)) revert Errors.ZeroAddress();
+
+        poolManager = poolManager_;
+        factory = factory_;
+
+        // Address-bit assertion. Reverts via Hooks.HookAddressNotValid
+        // when the deployer's CREATE2 salt was not mined to encode the
+        // exact permission flags this hook implements. HookMiner (#25)
+        // is the off-chain helper that finds a satisfying salt.
+        Hooks.validateHookPermissions(IHooks(address(this)), getHookPermissions());
+    }
+
+    // -------------------------------------------------------------------------
+    // IProtocolHook — getHookPermissions
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IProtocolHook
+    function getHookPermissions() public pure override returns (Hooks.Permissions memory) {
+        return Hooks.Permissions({
+            beforeInitialize: false,
+            afterInitialize: false,
+            beforeAddLiquidity: false,
+            afterAddLiquidity: true, // bit 10
+            beforeRemoveLiquidity: false,
+            afterRemoveLiquidity: true, // bit 8
+            beforeSwap: true, // bit 7
+            afterSwap: true, // bit 6
+            beforeDonate: false,
+            afterDonate: false,
+            beforeSwapReturnDelta: false,
+            afterSwapReturnDelta: false,
+            afterAddLiquidityReturnDelta: false,
+            afterRemoveLiquidityReturnDelta: false
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // IProtocolHook — registerVault
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IProtocolHook
+    function registerVault(address vault) external override onlyFactory {
+        if (vault == address(0)) revert Errors.ZeroAddress();
+        PoolKey memory key = IVault(vault).poolKey();
+        PoolId pid = key.toId();
+        vaultByPool[pid] = vault;
+    }
+
+    // -------------------------------------------------------------------------
+    // IProtocolHook — view stubs (filled by #35/#36)
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IProtocolHook
+    /// @dev #34 stub: returns 0 until #35 wires the EWMA fee state.
+    function currentFee(bytes32 /*poolId*/ ) external pure override returns (uint24) {
+        return 0;
+    }
+
+    /// @inheritdoc IProtocolHook
+    /// @dev v1.0 always returns (0, 0) — observation-only mode.
+    function mevProfits(address /*vault*/ ) external pure override returns (uint256, uint256) {
+        return (0, 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // IHooks callback skeleton — beforeInitialize through afterDonate
+    //
+    // PRISM enables only 4 callbacks; the others MUST never be reached
+    // because the address bits forbid PoolManager from invoking them.
+    // Implementations are left as `revert UnknownOp()` so a malformed
+    // CREATE2 salt that somehow allowed an unintended call would surface
+    // as a clear error rather than silent acceptance.
+    // -------------------------------------------------------------------------
+
+    function beforeInitialize(address, PoolKey calldata, uint160) external pure override returns (bytes4) {
+        revert Errors.UnknownOp();
+    }
+
+    function afterInitialize(address, PoolKey calldata, uint160, int24) external pure override returns (bytes4) {
+        revert Errors.UnknownOp();
+    }
+
+    function beforeAddLiquidity(
+        address,
+        PoolKey calldata,
+        ModifyLiquidityParams calldata,
+        bytes calldata
+    )
+        external
+        pure
+        override
+        returns (bytes4)
+    {
+        revert Errors.UnknownOp();
+    }
+
+    function beforeRemoveLiquidity(
+        address,
+        PoolKey calldata,
+        ModifyLiquidityParams calldata,
+        bytes calldata
+    )
+        external
+        pure
+        override
+        returns (bytes4)
+    {
+        revert Errors.UnknownOp();
+    }
+
+    function beforeDonate(
+        address,
+        PoolKey calldata,
+        uint256,
+        uint256,
+        bytes calldata
+    )
+        external
+        pure
+        override
+        returns (bytes4)
+    {
+        revert Errors.UnknownOp();
+    }
+
+    function afterDonate(
+        address,
+        PoolKey calldata,
+        uint256,
+        uint256,
+        bytes calldata
+    )
+        external
+        pure
+        override
+        returns (bytes4)
+    {
+        revert Errors.UnknownOp();
+    }
+
+    // -------------------------------------------------------------------------
+    // IHooks — enabled callbacks
+    //
+    // afterAddLiquidity / afterRemoveLiquidity MUST NOT revert
+    // (ADR-002 hard rule — they sit on the withdraw hot-path). #34
+    // returns the no-op sentinel; #35/#36 retain that property when
+    // they fill the body.
+    // -------------------------------------------------------------------------
+
+    function beforeSwap(
+        address,
+        PoolKey calldata,
+        SwapParams calldata,
+        bytes calldata
+    )
+        external
+        view
+        override
+        onlyPoolManager
+        returns (bytes4, BeforeSwapDelta, uint24)
+    {
+        // #35 implements EWMA volatility update + dynamic-fee override.
+        return (IHooks.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
+    }
+
+    function afterSwap(
+        address,
+        PoolKey calldata,
+        SwapParams calldata,
+        BalanceDelta,
+        bytes calldata
+    )
+        external
+        view
+        override
+        onlyPoolManager
+        returns (bytes4, int128)
+    {
+        // #36 implements oracle read + deviation check + SwapObserved.
+        return (IHooks.afterSwap.selector, 0);
+    }
+
+    function afterAddLiquidity(
+        address,
+        PoolKey calldata,
+        ModifyLiquidityParams calldata,
+        BalanceDelta,
+        BalanceDelta,
+        bytes calldata
+    )
+        external
+        view
+        override
+        onlyPoolManager
+        returns (bytes4, BalanceDelta)
+    {
+        // ADR-002 hard rule: never reverts. v1.0 is a pure no-op.
+        return (IHooks.afterAddLiquidity.selector, BalanceDelta.wrap(0));
+    }
+
+    function afterRemoveLiquidity(
+        address,
+        PoolKey calldata,
+        ModifyLiquidityParams calldata,
+        BalanceDelta,
+        BalanceDelta,
+        bytes calldata
+    )
+        external
+        view
+        override
+        onlyPoolManager
+        returns (bytes4, BalanceDelta)
+    {
+        // ADR-002 hard rule: never reverts. v1.0 is a pure no-op.
+        return (IHooks.afterRemoveLiquidity.selector, BalanceDelta.wrap(0));
+    }
+}

--- a/packages/contracts/src/interfaces/IChainlinkAdapter.sol
+++ b/packages/contracts/src/interfaces/IChainlinkAdapter.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+/// @title PRISM oracle adapter interface
+/// @notice Wraps a Chainlink price feed (and optional L2 sequencer
+///         uptime feed) into the canonical fail-soft return shape that
+///         ProtocolHook expects on the swap hot-path.
+///
+///         Per ADR-003 the adapter NEVER reverts on the swap path. Any
+///         failure mode (sequencer down, stale round, negative answer,
+///         math overflow) returns `(0, false)` and the hook degrades to
+///         the safe path: dynamic fees still update via beforeSwap, but
+///         MEV observation in afterSwap is skipped for that round.
+interface IChainlinkAdapter {
+    /// @notice Read the current oracle reference and report its health.
+    /// @dev    Always view, always non-reverting. Implementers must
+    ///         catch external-call failures and return `(0, false)`.
+    /// @return sqrtPriceX96 V4 sqrt-price (Q64.96) implied by the feed,
+    ///                     or `0` if the read was unhealthy.
+    /// @return healthy     `true` iff the sequencer is up, the round is
+    ///                     fresh, and the conversion did not overflow.
+    function read() external view returns (uint160 sqrtPriceX96, bool healthy);
+}

--- a/packages/contracts/src/oracles/ChainlinkAdapter.sol
+++ b/packages/contracts/src/oracles/ChainlinkAdapter.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {FullMath} from "v4-core/libraries/FullMath.sol";
+
+import {IChainlinkAdapter} from "../interfaces/IChainlinkAdapter.sol";
+import {Errors} from "../utils/Errors.sol";
+
+// Subset of Chainlink's AggregatorV3Interface — only the calls this
+// adapter makes. Inlined here so PRISM's contract package does not pull
+// in chainlink/contracts as a submodule.
+interface AggregatorV3 {
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+}
+
+/// @title PRISM Chainlink adapter
+/// @notice Fail-soft oracle reader for ProtocolHook. Combines a price
+///         feed, an optional L2 sequencer uptime feed, a staleness gate,
+///         and a sqrtPriceX96 conversion in one read() call.
+///
+///         Per ADR-003 the adapter NEVER reverts on the swap path. All
+///         failure modes degrade to `(0, false)`. The hook then skips
+///         MEV observation for that swap; volatility-fee updates in
+///         beforeSwap are unaffected.
+///
+/// @dev   Construction parameters are immutable. To update any of them
+///        the operator deploys a new adapter and rotates `oracle()` on
+///        the affected vaults — see ADR-006 (immutable core).
+///
+///        sqrtPriceX96 conversion uses `FullMath.mulDiv` (512-bit
+///        intermediate) so the operator can supply a Q-format scaling
+///        factor as `priceScaleNum / priceScaleDen` without needing to
+///        worry about intermediate overflow. The factor encodes pool
+///        decimals + feed decimals; computing it off-chain at deploy
+///        time keeps the swap path branch-free.
+contract ChainlinkAdapter is IChainlinkAdapter {
+    /// @notice Default staleness window — 1 hour.
+    /// @dev See ADR-003.
+    uint256 public constant DEFAULT_STALENESS = 3600;
+
+    /// @notice Default sequencer grace period — 1 hour after recovery.
+    uint256 public constant DEFAULT_GRACE_PERIOD = 3600;
+
+    /// @notice Primary price feed (e.g. ETH/USD on Base).
+    AggregatorV3 public immutable feed;
+
+    /// @notice L2 sequencer uptime feed. `address(0)` for L1 deployments.
+    AggregatorV3 public immutable sequencer;
+
+    /// @notice Maximum age of `feed.updatedAt` before the round is rejected.
+    uint256 public immutable staleness;
+
+    /// @notice After sequencer recovery the adapter still reports
+    ///         unhealthy for `gracePeriod` seconds. Lets dependent state
+    ///         (mempool, off-chain bots) settle before MEV signalling resumes.
+    uint256 public immutable gracePeriod;
+
+    /// @notice Numerator of the Q192 sqrtPriceX96 scaling factor.
+    /// @dev Off-chain helper computes: `priceScaleNum / priceScaleDen ==
+    ///      2^192 * 10^(token0Decimals - token1Decimals - feedDecimals)`,
+    ///      bounded so the multiplication fits the FullMath domain.
+    uint256 public immutable priceScaleNum;
+
+    /// @notice Denominator of the Q192 sqrtPriceX96 scaling factor.
+    uint256 public immutable priceScaleDen;
+
+    /// @notice Maximum signed answer the adapter will accept before
+    ///         reporting unhealthy. Computed at construction so the
+    ///         hot-path can compare in O(1) without doing the
+    ///         overflow check via FullMath each call.
+    /// @dev    Equal to `type(uint256).max * priceScaleDen / priceScaleNum`,
+    ///         capped at `type(int256).max` since answer is int256.
+    uint256 public immutable maxAnswer;
+
+    constructor(
+        AggregatorV3 feed_,
+        AggregatorV3 sequencer_,
+        uint256 staleness_,
+        uint256 gracePeriod_,
+        uint256 priceScaleNum_,
+        uint256 priceScaleDen_
+    ) {
+        if (address(feed_) == address(0)) revert Errors.ZeroAddress();
+        if (priceScaleDen_ == 0) revert Errors.ZeroAddress();
+        if (priceScaleNum_ == 0) revert Errors.ZeroAddress();
+
+        feed = feed_;
+        sequencer = sequencer_;
+        staleness = staleness_;
+        gracePeriod = gracePeriod_;
+        priceScaleNum = priceScaleNum_;
+        priceScaleDen = priceScaleDen_;
+
+        uint256 m = FullMath.mulDiv(type(uint256).max, priceScaleDen_, priceScaleNum_);
+        maxAnswer = m > uint256(type(int256).max) ? uint256(type(int256).max) : m;
+    }
+
+    /// @inheritdoc IChainlinkAdapter
+    function read() external view override returns (uint160 sqrtPriceX96, bool healthy) {
+        // 1. L2 sequencer gate.
+        //    Chainlink convention: answer == 0 means up; nonzero means down.
+        if (address(sequencer) != address(0)) {
+            try sequencer.latestRoundData() returns (uint80, int256 seqAnswer, uint256 startedAt, uint256, uint80) {
+                if (seqAnswer != 0) return (0, false);
+                // After recovery, gracePeriod must elapse before re-trusting.
+                if (block.timestamp - startedAt < gracePeriod) return (0, false);
+            } catch {
+                return (0, false);
+            }
+        }
+
+        // 2. Primary feed read.
+        int256 answer;
+        uint256 updatedAt;
+        try feed.latestRoundData() returns (uint80, int256 a, uint256, uint256 ua, uint80) {
+            answer = a;
+            updatedAt = ua;
+        } catch {
+            return (0, false);
+        }
+
+        if (answer <= 0) return (0, false);
+        if (updatedAt == 0) return (0, false);
+        if (block.timestamp > updatedAt && block.timestamp - updatedAt > staleness) {
+            return (0, false);
+        }
+        // Reject implausible feed values that would overflow the
+        // Q192 conversion. maxAnswer is precomputed at construction.
+        if (uint256(answer) > maxAnswer) return (0, false);
+
+        // 3. Convert to sqrtPriceX96 = sqrt(answer * priceScaleNum / priceScaleDen).
+        //    `priceScaleNum` already encodes `2^192` so the result is the
+        //    Q192 spot-price; sqrt then yields the Q96 sqrt-price.
+        uint256 spotQ192 = FullMath.mulDiv(uint256(answer), priceScaleNum, priceScaleDen);
+
+        uint256 sqrtPrice = _sqrt(spotQ192);
+        if (sqrtPrice > type(uint160).max) return (0, false);
+
+        return (uint160(sqrtPrice), true);
+    }
+
+    /// @dev Babylonian method. Branchless after the seed; ~70 gas.
+    function _sqrt(uint256 x) internal pure returns (uint256) {
+        if (x == 0) return 0;
+
+        // Initial seed: most significant bit / 2.
+        uint256 z = (x + 1) >> 1;
+        uint256 y = x;
+        while (z < y) {
+            y = z;
+            z = (x / z + z) >> 1;
+        }
+        return y;
+    }
+}

--- a/packages/contracts/src/strategies/BellStrategy.sol
+++ b/packages/contracts/src/strategies/BellStrategy.sol
@@ -77,21 +77,56 @@ contract BellStrategy is IStrategy {
         positions[6] = TargetPosition({tickLower: anchor + 3 * ts, tickUpper: anchor + 4 * ts, weight: W6});
     }
 
+    /// @notice Tick drift threshold in raw ticks. Beyond this absolute
+    ///         drift from the last rebalance tick, the bell is no longer
+    ///         centred and the gate fires.
+    /// @dev v1.0 default: 4 * (median Base ETH/USDC tickSpacing of 60) =
+    ///      240 ticks ≈ 2.4% price drift. Subject to revision in v1.1.
+    int24 public constant TICK_DRIFT_THRESHOLD = 240;
+
+    /// @notice Time threshold in seconds. Independent of tick drift —
+    ///         even a calm market gets at least one rebalance per
+    ///         `TIME_THRESHOLD` so the bell tracks medium-term drift.
+    /// @dev v1.0 default: 6 hours.
+    uint256 public constant TIME_THRESHOLD = 6 hours;
+
+    /// @notice Liveness fallback. Hard cap on time between rebalances —
+    ///         even in a near-zero-volatility market keepers must be
+    ///         able to claim their bonus, otherwise low-TVL vaults
+    ///         starve. See ADR-007 (gas budget) §keeper economics.
+    uint256 public constant LIVENESS_FALLBACK = 24 hours;
+
     /// @inheritdoc IStrategy
-    /// @dev #33 implements the actual gate (tick drift + time threshold +
-    ///      24h fallback). For #32 this returns false so the vault
-    ///      compiles against the full interface but never rebalances on
-    ///      this stub.
+    /// @dev Three independent triggers (any one fires the gate):
+    ///        1. Tick drift exceeds `TICK_DRIFT_THRESHOLD`
+    ///        2. Time since last rebalance exceeds `TIME_THRESHOLD`
+    ///        3. Liveness backstop (`LIVENESS_FALLBACK`) elapsed
+    ///      `block.timestamp` is the only non-input the strategy reads —
+    ///      explicitly permitted by ADR-005 §purity contract for the
+    ///      time gates.
     function shouldRebalance(
-        int24, /*currentTick*/
-        int24, /*lastRebalanceTick*/
-        uint256 /*lastRebalanceTimestamp*/
+        int24 currentTick,
+        int24 lastRebalanceTick,
+        uint256 lastRebalanceTimestamp
     )
         external
         view
         override
         returns (bool)
     {
+        // Liveness fallback is the hard floor — independently of how
+        // small the drift is, vaults rebalance at least once per 24h.
+        if (block.timestamp >= lastRebalanceTimestamp + LIVENESS_FALLBACK) return true;
+
+        // Time threshold — ordinary cadence trigger.
+        if (block.timestamp >= lastRebalanceTimestamp + TIME_THRESHOLD) return true;
+
+        // Tick drift — fires immediately when price moves outside the
+        // bell. Use absolute value via the int24 width.
+        int24 drift =
+            currentTick > lastRebalanceTick ? currentTick - lastRebalanceTick : lastRebalanceTick - currentTick;
+        if (drift >= TICK_DRIFT_THRESHOLD) return true;
+
         return false;
     }
 

--- a/packages/contracts/src/strategies/BellStrategy.sol
+++ b/packages/contracts/src/strategies/BellStrategy.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {IStrategy} from "../interfaces/IStrategy.sol";
+import {Errors} from "../utils/Errors.sol";
+
+/// @title BellStrategy — fixed-shape bell-curve weight distribution
+/// @notice Default PRISM strategy. Returns 7 positions arranged as a
+///         symmetric bell around the current tick, with hardcoded
+///         weights `[500, 1200, 2100, 2400, 2100, 1200, 500]` (bps).
+///
+///         This PR (#32) implements `computePositions` only — the
+///         `shouldRebalance` gate lands in #33.
+///
+/// @dev Per ADR-005 the strategy is **pure / stateless / vault-agnostic**:
+///        - No SSTORE in runtime bytecode (constants + immutables only)
+///        - No reads of mutable state
+///        - Deterministic across repeat calls with identical inputs
+///
+///       The weights sum to exactly 10_000 (invariant #2). The vault
+///       independently verifies this and reverts via `Errors.WeightsDoNotSum`
+///       on mismatch — defence-in-depth, not redundancy.
+///
+///       Tick alignment: `currentTick` is rounded down to the nearest
+///       `tickSpacing` boundary; each position then extends one
+///       `tickSpacing` further out from the previous, so the seven
+///       positions cover `[center - 4*ts, center + 4*ts]` total range.
+contract BellStrategy is IStrategy {
+    /// @notice Number of positions this strategy emits.
+    uint256 public constant N_POSITIONS = 7;
+
+    /// @notice Per-position bell weights in basis points. Sum = 10_000.
+    /// @dev Hardcoded as immutable constants to satisfy ADR-005 purity
+    ///      (no SSTORE in bytecode). Order matches `computePositions`
+    ///      output, which goes from leftmost (most negative offset) to
+    ///      rightmost.
+    uint256 internal constant W0 = 500; // outermost left
+    uint256 internal constant W1 = 1200;
+    uint256 internal constant W2 = 2100;
+    uint256 internal constant W3 = 2400; // center
+    uint256 internal constant W4 = 2100;
+    uint256 internal constant W5 = 1200;
+    uint256 internal constant W6 = 500; // outermost right
+
+    /// @inheritdoc IStrategy
+    function computePositions(
+        int24 currentTick,
+        int24 tickSpacing,
+        uint256, /*amount0*/
+        uint256 /*amount1*/
+    )
+        external
+        pure
+        override
+        returns (TargetPosition[] memory positions)
+    {
+        if (tickSpacing <= 0) revert Errors.InvalidTickRange(0, 0);
+
+        // Round currentTick DOWN to the nearest tickSpacing boundary.
+        // For negative ticks Solidity's % preserves sign — subtract the
+        // remainder if non-zero to get the floor.
+        int24 anchor = _floorToSpacing(currentTick, tickSpacing);
+
+        // Seven adjacent positions of width `tickSpacing` each, centred
+        // on the anchor. Position i has range
+        //   [anchor + (i - 3) * ts, anchor + (i - 2) * ts]
+        // so that i=3 spans [anchor, anchor + ts] (the centre tick).
+        int24 ts = tickSpacing;
+
+        positions = new TargetPosition[](N_POSITIONS);
+        positions[0] = TargetPosition({tickLower: anchor - 3 * ts, tickUpper: anchor - 2 * ts, weight: W0});
+        positions[1] = TargetPosition({tickLower: anchor - 2 * ts, tickUpper: anchor - ts, weight: W1});
+        positions[2] = TargetPosition({tickLower: anchor - ts, tickUpper: anchor, weight: W2});
+        positions[3] = TargetPosition({tickLower: anchor, tickUpper: anchor + ts, weight: W3});
+        positions[4] = TargetPosition({tickLower: anchor + ts, tickUpper: anchor + 2 * ts, weight: W4});
+        positions[5] = TargetPosition({tickLower: anchor + 2 * ts, tickUpper: anchor + 3 * ts, weight: W5});
+        positions[6] = TargetPosition({tickLower: anchor + 3 * ts, tickUpper: anchor + 4 * ts, weight: W6});
+    }
+
+    /// @inheritdoc IStrategy
+    /// @dev #33 implements the actual gate (tick drift + time threshold +
+    ///      24h fallback). For #32 this returns false so the vault
+    ///      compiles against the full interface but never rebalances on
+    ///      this stub.
+    function shouldRebalance(
+        int24, /*currentTick*/
+        int24, /*lastRebalanceTick*/
+        uint256 /*lastRebalanceTimestamp*/
+    )
+        external
+        view
+        override
+        returns (bool)
+    {
+        return false;
+    }
+
+    /// @dev Round `tick` down to the nearest multiple of `spacing`.
+    ///      Handles negative inputs correctly (Solidity's `%` preserves
+    ///      sign on signed types).
+    function _floorToSpacing(int24 tick, int24 spacing) internal pure returns (int24) {
+        int24 rem = tick % spacing;
+        if (rem == 0) return tick;
+        if (tick > 0) return tick - rem;
+        return tick - rem - spacing;
+    }
+}

--- a/packages/contracts/test/hooks/ProtocolHook.t.sol
+++ b/packages/contracts/test/hooks/ProtocolHook.t.sol
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {Hooks} from "v4-core/libraries/Hooks.sol";
+import {BalanceDelta} from "v4-core/types/BalanceDelta.sol";
+import {Currency} from "v4-core/types/Currency.sol";
+
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {ModifyLiquidityParams, SwapParams} from "v4-core/types/PoolOperation.sol";
+
+import {ProtocolHook} from "../../src/hooks/ProtocolHook.sol";
+import {Errors} from "../../src/utils/Errors.sol";
+
+/// Mines a CREATE2 salt that yields an address satisfying the PRISM
+/// hook permission mask (0x05C0). Used by the test to deploy ProtocolHook
+/// at an address its constructor will accept.
+contract HookDeployer {
+    bytes32 internal constant CREATE2_INIT_HASH_SALT = bytes32(uint256(0));
+
+    function mineSalt(
+        bytes memory creationCode,
+        bytes memory ctorArgs
+    )
+        external
+        view
+        returns (bytes32 salt, address predicted)
+    {
+        bytes32 initCodeHash = keccak256(abi.encodePacked(creationCode, ctorArgs));
+        // 200_000 iterations is enough at 1/16384 hit rate.
+        for (uint256 i = 0; i < 200_000; i++) {
+            salt = bytes32(i);
+            predicted =
+                address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), address(this), salt, initCodeHash)))));
+            if (uint160(predicted) & 0x3FFF == 0x05C0) {
+                return (salt, predicted);
+            }
+        }
+        revert("salt not found");
+    }
+
+    function deploy(bytes32 salt, bytes memory creationCode, bytes memory ctorArgs) external returns (address addr) {
+        bytes memory initCode = abi.encodePacked(creationCode, ctorArgs);
+        assembly {
+            addr := create2(0, add(initCode, 0x20), mload(initCode), salt)
+        }
+        require(addr != address(0), "deploy failed");
+    }
+}
+
+contract ProtocolHookTest is Test {
+    address constant POOL_MANAGER = address(0xCafe);
+    address constant FACTORY = address(0xBeef);
+
+    HookDeployer deployer;
+    ProtocolHook hook;
+
+    function setUp() public {
+        deployer = new HookDeployer();
+        hook = _deployValidHook();
+    }
+
+    function _deployValidHook() internal returns (ProtocolHook) {
+        bytes memory ctorArgs = abi.encode(POOL_MANAGER, FACTORY);
+        (bytes32 salt, address predicted) = deployer.mineSalt(type(ProtocolHook).creationCode, ctorArgs);
+        address deployed = deployer.deploy(salt, type(ProtocolHook).creationCode, ctorArgs);
+        require(deployed == predicted, "predicted address mismatch");
+        return ProtocolHook(deployed);
+    }
+
+    // -------------------------------------------------------------------------
+    // Permissions
+    // -------------------------------------------------------------------------
+
+    function test_getHookPermissions_returnsExactBits() public view {
+        Hooks.Permissions memory p = hook.getHookPermissions();
+        assertTrue(p.beforeSwap, "beforeSwap");
+        assertTrue(p.afterSwap, "afterSwap");
+        assertTrue(p.afterAddLiquidity, "afterAddLiquidity");
+        assertTrue(p.afterRemoveLiquidity, "afterRemoveLiquidity");
+
+        assertFalse(p.beforeInitialize);
+        assertFalse(p.afterInitialize);
+        assertFalse(p.beforeAddLiquidity);
+        assertFalse(p.beforeRemoveLiquidity);
+        assertFalse(p.beforeDonate);
+        assertFalse(p.afterDonate);
+        assertFalse(p.beforeSwapReturnDelta);
+        assertFalse(p.afterSwapReturnDelta);
+        assertFalse(p.afterAddLiquidityReturnDelta);
+        assertFalse(p.afterRemoveLiquidityReturnDelta);
+    }
+
+    function test_addressBits_matchPermissions() public view {
+        // The deployed hook address must encode 0x05C0 in its low 14 bits.
+        assertEq(uint160(address(hook)) & 0x3FFF, 0x05C0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor reverts
+    // -------------------------------------------------------------------------
+
+    function test_constructor_revertsOnZeroPoolManager() public {
+        bytes memory ctorArgs = abi.encode(address(0), FACTORY);
+        // Mine a valid address even with bad ctor args — the bit check
+        // happens after the zero check, so we still need a valid address
+        // to ensure ZeroAddress fires before HookAddressNotValid.
+        (bytes32 salt,) = deployer.mineSalt(type(ProtocolHook).creationCode, ctorArgs);
+
+        vm.expectRevert();
+        deployer.deploy(salt, type(ProtocolHook).creationCode, ctorArgs);
+    }
+
+    function test_constructor_revertsOnZeroFactory() public {
+        bytes memory ctorArgs = abi.encode(POOL_MANAGER, address(0));
+        (bytes32 salt,) = deployer.mineSalt(type(ProtocolHook).creationCode, ctorArgs);
+
+        vm.expectRevert();
+        deployer.deploy(salt, type(ProtocolHook).creationCode, ctorArgs);
+    }
+
+    function test_constructor_revertsOnInvalidAddressBits() public {
+        // Deploy with a deliberately bad salt → predicted address won't
+        // have the right bits. Constructor's validateHookPermissions
+        // reverts.
+        bytes memory ctorArgs = abi.encode(POOL_MANAGER, FACTORY);
+        bytes32 badSalt = bytes32(uint256(0)); // overwhelmingly unlikely to be valid
+
+        vm.expectRevert();
+        deployer.deploy(badSalt, type(ProtocolHook).creationCode, ctorArgs);
+    }
+
+    // -------------------------------------------------------------------------
+    // onlyPoolManager / onlyFactory
+    // -------------------------------------------------------------------------
+
+    function test_beforeSwap_revertsForNonPoolManager() public {
+        PoolKey memory key = _emptyKey();
+        SwapParams memory params;
+
+        vm.prank(address(0xDeAd));
+        vm.expectRevert(Errors.OnlyPoolManager.selector);
+        hook.beforeSwap(address(this), key, params, "");
+    }
+
+    function test_afterSwap_revertsForNonPoolManager() public {
+        PoolKey memory key = _emptyKey();
+        SwapParams memory params;
+
+        vm.prank(address(0xDeAd));
+        vm.expectRevert(Errors.OnlyPoolManager.selector);
+        hook.afterSwap(address(this), key, params, BalanceDelta.wrap(0), "");
+    }
+
+    function test_afterAddLiquidity_revertsForNonPoolManager() public {
+        PoolKey memory key = _emptyKey();
+        ModifyLiquidityParams memory params;
+
+        vm.prank(address(0xDeAd));
+        vm.expectRevert(Errors.OnlyPoolManager.selector);
+        hook.afterAddLiquidity(address(this), key, params, BalanceDelta.wrap(0), BalanceDelta.wrap(0), "");
+    }
+
+    function test_afterRemoveLiquidity_revertsForNonPoolManager() public {
+        PoolKey memory key = _emptyKey();
+        ModifyLiquidityParams memory params;
+
+        vm.prank(address(0xDeAd));
+        vm.expectRevert(Errors.OnlyPoolManager.selector);
+        hook.afterRemoveLiquidity(address(this), key, params, BalanceDelta.wrap(0), BalanceDelta.wrap(0), "");
+    }
+
+    function test_registerVault_revertsForNonFactory() public {
+        vm.prank(address(0xDeAd));
+        vm.expectRevert(Errors.OnlyOwner.selector);
+        hook.registerVault(address(0x1234));
+    }
+
+    function test_registerVault_revertsOnZeroVault() public {
+        vm.prank(FACTORY);
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        hook.registerVault(address(0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Disabled callbacks
+    // -------------------------------------------------------------------------
+
+    function test_beforeInitialize_revertsAlways() public {
+        PoolKey memory key = _emptyKey();
+        vm.expectRevert(Errors.UnknownOp.selector);
+        hook.beforeInitialize(address(this), key, 0);
+    }
+
+    function test_afterInitialize_revertsAlways() public {
+        PoolKey memory key = _emptyKey();
+        vm.expectRevert(Errors.UnknownOp.selector);
+        hook.afterInitialize(address(this), key, 0, 0);
+    }
+
+    function test_beforeAddLiquidity_revertsAlways() public {
+        PoolKey memory key = _emptyKey();
+        ModifyLiquidityParams memory params;
+        vm.expectRevert(Errors.UnknownOp.selector);
+        hook.beforeAddLiquidity(address(this), key, params, "");
+    }
+
+    function test_beforeRemoveLiquidity_revertsAlways() public {
+        PoolKey memory key = _emptyKey();
+        ModifyLiquidityParams memory params;
+        vm.expectRevert(Errors.UnknownOp.selector);
+        hook.beforeRemoveLiquidity(address(this), key, params, "");
+    }
+
+    // -------------------------------------------------------------------------
+    // Stub views (will be replaced in #35/#36)
+    // -------------------------------------------------------------------------
+
+    function test_currentFee_returnsZeroStub() public view {
+        assertEq(hook.currentFee(bytes32(uint256(1))), 0);
+    }
+
+    function test_mevProfits_returnsZeroStub() public view {
+        (uint256 a, uint256 b) = hook.mevProfits(address(0x1234));
+        assertEq(a, 0);
+        assertEq(b, 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    function _emptyKey() internal pure returns (PoolKey memory) {
+        return PoolKey({
+            currency0: Currency.wrap(address(0)),
+            currency1: Currency.wrap(address(1)),
+            fee: 0,
+            tickSpacing: 60,
+            hooks: IHooks(address(0))
+        });
+    }
+}

--- a/packages/contracts/test/hooks/ProtocolHook.t.sol
+++ b/packages/contracts/test/hooks/ProtocolHook.t.sol
@@ -219,8 +219,9 @@ contract ProtocolHookTest is Test {
     // Stub views (will be replaced in #35/#36)
     // -------------------------------------------------------------------------
 
-    function test_currentFee_returnsZeroStub() public view {
-        assertEq(hook.currentFee(bytes32(uint256(1))), 0);
+    function test_currentFee_returnsDefaultBeforeSwap() public view {
+        // No swaps have been observed → fee state is empty → DEFAULT_FEE.
+        assertEq(hook.currentFee(bytes32(uint256(1))), 3000);
     }
 
     function test_mevProfits_returnsZeroStub() public view {

--- a/packages/contracts/test/oracles/ChainlinkAdapter.t.sol
+++ b/packages/contracts/test/oracles/ChainlinkAdapter.t.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {AggregatorV3, ChainlinkAdapter} from "../../src/oracles/ChainlinkAdapter.sol";
+import {Errors} from "../../src/utils/Errors.sol";
+
+contract MockFeed is AggregatorV3 {
+    int256 public answer;
+    uint256 public updatedAt;
+    uint256 public startedAt;
+    bool public revertOnRead;
+
+    function setRound(int256 a, uint256 ua) external {
+        answer = a;
+        updatedAt = ua;
+        startedAt = ua;
+    }
+
+    function setRevert(bool r) external {
+        revertOnRead = r;
+    }
+
+    function latestRoundData() external view override returns (uint80, int256, uint256, uint256, uint80) {
+        if (revertOnRead) revert("feed down");
+        return (1, answer, startedAt, updatedAt, 1);
+    }
+}
+
+contract ChainlinkAdapterTest is Test {
+    MockFeed feed;
+    MockFeed sequencer;
+    ChainlinkAdapter adapter;
+
+    // For a hypothetical 1:1 feed where answer == sqrtPriceX96, the
+    // scale factor is `2^192 / answer^2 * answer = 2^192 / answer`.
+    // Easier to test: pick scale so that result is deterministic.
+    // For answer=1e8 (1.0 with 8 decimals), priceQ192 should be 2^192,
+    // so sqrtPriceX96 = 2^96.
+    // priceQ192 = answer * num/den = 1e8 * num/den == 2^192
+    // → num/den == 2^192 / 1e8.
+    uint256 constant Q192 = 1 << 192;
+    uint256 constant SCALE_NUM = Q192;
+    uint256 constant SCALE_DEN = 1e8;
+
+    uint256 constant STALENESS = 3600;
+    uint256 constant GRACE = 3600;
+
+    function setUp() public {
+        feed = new MockFeed();
+        sequencer = new MockFeed();
+        adapter = new ChainlinkAdapter(
+            AggregatorV3(address(feed)), AggregatorV3(address(sequencer)), STALENESS, GRACE, SCALE_NUM, SCALE_DEN
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor reverts
+    // -------------------------------------------------------------------------
+
+    function test_constructor_revertsOnZeroFeed() public {
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new ChainlinkAdapter(AggregatorV3(address(0)), AggregatorV3(address(0)), STALENESS, GRACE, SCALE_NUM, SCALE_DEN);
+    }
+
+    function test_constructor_revertsOnZeroScale() public {
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new ChainlinkAdapter(AggregatorV3(address(feed)), AggregatorV3(address(0)), STALENESS, GRACE, 0, SCALE_DEN);
+
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new ChainlinkAdapter(AggregatorV3(address(feed)), AggregatorV3(address(0)), STALENESS, GRACE, SCALE_NUM, 0);
+    }
+
+    function test_constructor_acceptsZeroSequencer() public {
+        ChainlinkAdapter a = new ChainlinkAdapter(
+            AggregatorV3(address(feed)), AggregatorV3(address(0)), STALENESS, GRACE, SCALE_NUM, SCALE_DEN
+        );
+        assertEq(address(a.sequencer()), address(0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Sequencer gating
+    // -------------------------------------------------------------------------
+
+    function test_read_failsWhenSequencerDown() public {
+        // sequencer answer != 0 means down.
+        sequencer.setRound(1, block.timestamp);
+        feed.setRound(1e8, block.timestamp);
+
+        (uint160 sp, bool ok) = adapter.read();
+        assertEq(sp, 0);
+        assertFalse(ok);
+    }
+
+    function test_read_failsDuringSequencerGrace() public {
+        // Sequencer just came back up — startedAt = now.
+        sequencer.setRound(0, block.timestamp);
+        feed.setRound(1e8, block.timestamp);
+
+        (uint160 sp, bool ok) = adapter.read();
+        assertEq(sp, 0);
+        assertFalse(ok);
+
+        // After grace, recovery succeeds.
+        vm.warp(block.timestamp + GRACE);
+        (sp, ok) = adapter.read();
+        assertTrue(ok);
+        assertGt(sp, 0);
+    }
+
+    function test_read_failsOnSequencerRevert() public {
+        sequencer.setRevert(true);
+        feed.setRound(1e8, block.timestamp);
+
+        (, bool ok) = adapter.read();
+        assertFalse(ok);
+    }
+
+    // -------------------------------------------------------------------------
+    // Staleness
+    // -------------------------------------------------------------------------
+
+    function test_read_failsWhenStale() public {
+        // Sequencer healthy + grace elapsed.
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+
+        // Feed updated long ago.
+        feed.setRound(1e8, 1);
+        vm.warp(1 + STALENESS + 100);
+
+        (, bool ok) = adapter.read();
+        assertFalse(ok);
+    }
+
+    function test_read_failsOnNegativeAnswer() public {
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+        feed.setRound(-1, block.timestamp);
+
+        (, bool ok) = adapter.read();
+        assertFalse(ok);
+    }
+
+    function test_read_failsOnZeroAnswer() public {
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+        feed.setRound(0, block.timestamp);
+
+        (, bool ok) = adapter.read();
+        assertFalse(ok);
+    }
+
+    function test_read_failsOnFeedRevert() public {
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+        feed.setRevert(true);
+
+        (, bool ok) = adapter.read();
+        assertFalse(ok);
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path + conversion
+    // -------------------------------------------------------------------------
+
+    function test_read_happyPath_unitPrice() public {
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+        feed.setRound(1e8, block.timestamp); // 1.00 with 8 decimals
+
+        (uint160 sp, bool ok) = adapter.read();
+        assertTrue(ok);
+        // Expected: sqrtPriceX96 = sqrt(2^192) = 2^96.
+        assertEq(uint256(sp), 1 << 96);
+    }
+
+    function test_read_happyPath_higherPrice() public {
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+        feed.setRound(4e8, block.timestamp); // 4.00 with 8 decimals
+
+        (uint160 sp, bool ok) = adapter.read();
+        assertTrue(ok);
+        // Expected: priceQ192 = 4 * 2^192, sqrt = 2 * 2^96 = 2^97.
+        assertEq(uint256(sp), 1 << 97);
+    }
+
+    function test_read_skipsSequencerWhenAddressZero() public {
+        ChainlinkAdapter noSeq = new ChainlinkAdapter(
+            AggregatorV3(address(feed)), AggregatorV3(address(0)), STALENESS, GRACE, SCALE_NUM, SCALE_DEN
+        );
+
+        feed.setRound(1e8, block.timestamp);
+        (uint160 sp, bool ok) = noSeq.read();
+        assertTrue(ok);
+        assertEq(uint256(sp), 1 << 96);
+    }
+
+    function test_read_neverReverts_fuzz(int256 a, uint64 ua, uint256 warpTo) public {
+        sequencer.setRound(0, 1);
+        // Bound the warp so block.timestamp arithmetic stays sane.
+        warpTo = bound(warpTo, GRACE + 2, type(uint64).max);
+        vm.warp(warpTo);
+        feed.setRound(a, ua);
+
+        // Adapter must never revert regardless of inputs.
+        adapter.read();
+    }
+}

--- a/packages/contracts/test/strategies/BellStrategy.t.sol
+++ b/packages/contracts/test/strategies/BellStrategy.t.sol
@@ -159,5 +159,57 @@ contract BellStrategyTest is Test {
 
     function test_constants() public view {
         assertEq(strat.N_POSITIONS(), 7);
+        assertEq(strat.TICK_DRIFT_THRESHOLD(), 240);
+        assertEq(strat.TIME_THRESHOLD(), 6 hours);
+        assertEq(strat.LIVENESS_FALLBACK(), 24 hours);
+    }
+
+    // -------------------------------------------------------------------------
+    // shouldRebalance — three triggers
+    // -------------------------------------------------------------------------
+
+    function test_shouldRebalance_falseWhenAllQuiet() public {
+        vm.warp(1_700_000_000);
+        // Same tick, just rebalanced.
+        assertFalse(strat.shouldRebalance(0, 0, block.timestamp));
+    }
+
+    function test_shouldRebalance_firesOnTickDrift() public {
+        vm.warp(1_700_000_000);
+        // Drift = TICK_DRIFT_THRESHOLD → fires.
+        assertTrue(strat.shouldRebalance(240, 0, block.timestamp));
+        // Negative-direction drift symmetric.
+        assertTrue(strat.shouldRebalance(-240, 0, block.timestamp));
+        // Below threshold → no fire.
+        assertFalse(strat.shouldRebalance(239, 0, block.timestamp));
+    }
+
+    function test_shouldRebalance_firesOnTimeThreshold() public {
+        uint256 last = 1_700_000_000;
+        vm.warp(last + 6 hours);
+        assertTrue(strat.shouldRebalance(0, 0, last));
+
+        vm.warp(last + 6 hours - 1);
+        assertFalse(strat.shouldRebalance(0, 0, last));
+    }
+
+    function test_shouldRebalance_firesOnLivenessFallback() public {
+        uint256 last = 1_700_000_000;
+        vm.warp(last + 24 hours);
+        // Even with zero tick drift and time-threshold-already-elapsed,
+        // the 24h fallback is the strict-largest guarantee.
+        assertTrue(strat.shouldRebalance(0, 0, last));
+    }
+
+    function test_shouldRebalance_independentTriggers() public {
+        uint256 last = 1_700_000_000;
+        vm.warp(last + 1);
+
+        // Drift only.
+        assertTrue(strat.shouldRebalance(500, 0, last));
+
+        // Time only.
+        vm.warp(last + 6 hours);
+        assertTrue(strat.shouldRebalance(0, 0, last));
     }
 }

--- a/packages/contracts/test/strategies/BellStrategy.t.sol
+++ b/packages/contracts/test/strategies/BellStrategy.t.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IStrategy} from "../../src/interfaces/IStrategy.sol";
+import {BellStrategy} from "../../src/strategies/BellStrategy.sol";
+import {Errors} from "../../src/utils/Errors.sol";
+
+contract BellStrategyTest is Test {
+    BellStrategy strat;
+
+    function setUp() public {
+        strat = new BellStrategy();
+    }
+
+    // -------------------------------------------------------------------------
+    // Basic shape
+    // -------------------------------------------------------------------------
+
+    function test_computePositions_returns7Positions() public view {
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(0, 60, 1e18, 1e18);
+        assertEq(ps.length, 7);
+    }
+
+    function test_computePositions_weightsSumTo10000() public view {
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(0, 60, 0, 0);
+        uint256 sum;
+        for (uint256 i = 0; i < ps.length; i++) {
+            sum += ps[i].weight;
+        }
+        assertEq(sum, 10_000);
+    }
+
+    function test_computePositions_isSymmetric() public view {
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(0, 60, 0, 0);
+        // Mirrored weights: 0↔6, 1↔5, 2↔4. Centre weight = ps[3].
+        assertEq(ps[0].weight, ps[6].weight);
+        assertEq(ps[1].weight, ps[5].weight);
+        assertEq(ps[2].weight, ps[4].weight);
+    }
+
+    function test_computePositions_centerWeightIsLargest() public view {
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(0, 60, 0, 0);
+        for (uint256 i = 0; i < ps.length; i++) {
+            if (i != 3) assertGt(ps[3].weight, ps[i].weight);
+        }
+    }
+
+    function test_computePositions_revertsOnZeroSpacing() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(0), int24(0)));
+        strat.computePositions(0, 0, 0, 0);
+    }
+
+    function test_computePositions_revertsOnNegativeSpacing() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(0), int24(0)));
+        strat.computePositions(0, -1, 0, 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tick alignment
+    // -------------------------------------------------------------------------
+
+    function test_computePositions_anchorAlignsAtZero() public view {
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(0, 60, 0, 0);
+        // Centre position spans [0, 60] when currentTick is 0.
+        assertEq(ps[3].tickLower, 0);
+        assertEq(ps[3].tickUpper, 60);
+    }
+
+    function test_computePositions_alignsPositiveOffTickSpacing() public view {
+        // currentTick = 35, spacing = 60 → anchor = 0 (floor).
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(35, 60, 0, 0);
+        assertEq(ps[3].tickLower, 0);
+        assertEq(ps[3].tickUpper, 60);
+    }
+
+    function test_computePositions_alignsNegativeOffTickSpacing() public view {
+        // currentTick = -10, spacing = 60 → anchor = -60 (floor).
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(-10, 60, 0, 0);
+        assertEq(ps[3].tickLower, -60);
+        assertEq(ps[3].tickUpper, 0);
+    }
+
+    function test_computePositions_adjacentPositionsContiguous() public view {
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(120, 60, 0, 0);
+        for (uint256 i = 1; i < ps.length; i++) {
+            assertEq(ps[i].tickLower, ps[i - 1].tickUpper);
+        }
+    }
+
+    function test_computePositions_widthEqualsSpacing() public view {
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(120, 60, 0, 0);
+        for (uint256 i = 0; i < ps.length; i++) {
+            assertEq(int256(ps[i].tickUpper - ps[i].tickLower), 60);
+        }
+    }
+
+    function test_computePositions_centeredAroundAnchor() public view {
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(180, 60, 0, 0);
+        // anchor = 180 (already aligned). Centre i=3 spans [180, 240].
+        // Outermost positions: [180 - 3*60, 180 - 2*60] and [180 + 3*60, 180 + 4*60].
+        assertEq(ps[0].tickLower, 0);
+        assertEq(ps[6].tickUpper, 420);
+    }
+
+    // -------------------------------------------------------------------------
+    // Determinism (purity contract)
+    // -------------------------------------------------------------------------
+
+    function testFuzz_computePositions_deterministic(int24 tick, int8 spacingFactor) public view {
+        // tick spacing is positive and bounded — V4 uses values in [1, 16384]
+        int24 spacing = int24(uint24(uint8(spacingFactor) | 1)); // odd, non-zero, positive
+        if (spacing <= 0) spacing = 1;
+
+        // Bound tick to avoid int24 overflow when computing anchor ± 4*spacing.
+        vm.assume(tick > -200_000 && tick < 200_000);
+
+        IStrategy.TargetPosition[] memory a = strat.computePositions(tick, spacing, 1e18, 1e18);
+        IStrategy.TargetPosition[] memory b = strat.computePositions(tick, spacing, 1e18, 1e18);
+
+        assertEq(a.length, b.length);
+        for (uint256 i = 0; i < a.length; i++) {
+            assertEq(a[i].tickLower, b[i].tickLower);
+            assertEq(a[i].tickUpper, b[i].tickUpper);
+            assertEq(a[i].weight, b[i].weight);
+        }
+    }
+
+    function testFuzz_computePositions_weightsAlwaysSumTo10000(int24 tick, int8 spacingFactor) public view {
+        int24 spacing = int24(uint24(uint8(spacingFactor) | 1));
+        if (spacing <= 0) spacing = 1;
+        vm.assume(tick > -200_000 && tick < 200_000);
+
+        IStrategy.TargetPosition[] memory ps = strat.computePositions(tick, spacing, 1e18, 1e18);
+        uint256 sum;
+        for (uint256 i = 0; i < ps.length; i++) {
+            sum += ps[i].weight;
+        }
+        assertEq(sum, 10_000);
+    }
+
+    function testFuzz_computePositions_amountsAreOpaque(uint256 a0, uint256 a1) public view {
+        // Strategy is vault-agnostic: changing amounts shouldn't change
+        // tick layout or weights (only the vault's *liquidity allocation*
+        // depends on amounts; the strategy emits weights only).
+        IStrategy.TargetPosition[] memory withZero = strat.computePositions(0, 60, 0, 0);
+        IStrategy.TargetPosition[] memory withFuzz = strat.computePositions(0, 60, a0, a1);
+        for (uint256 i = 0; i < withZero.length; i++) {
+            assertEq(withZero[i].tickLower, withFuzz[i].tickLower);
+            assertEq(withZero[i].tickUpper, withFuzz[i].tickUpper);
+            assertEq(withZero[i].weight, withFuzz[i].weight);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    function test_constants() public view {
+        assertEq(strat.N_POSITIONS(), 7);
+    }
+}


### PR DESCRIPTION
## Summary

One-shot deploy: \`BellStrategy → ChainlinkAdapter → ProtocolHook (CREATE2 + mined salt) → VaultFactory\`. Per-pool vault deploys land in a follow-up script.

### Order matters

\`ProtocolHook.factory\` is immutable and must equal the CREATE address of the factory we deploy next. The script:

1. Predicts the factory's CREATE address via \`vm.computeCreateAddress(deployer, nonce + 1)\`
2. Mines a hook salt against \`(PoolManager, predictedFactory)\` so \`hook & 0x3FFF == 0x05C0\`
3. \`CREATE2\`-deploys the hook with the mined salt
4. Asserts \`uint160(hook) & 0x3FFF == 0x05C0\` (post-deploy bit sanity)
5. \`CREATE\`-deploys the factory
6. Asserts \`address(factory) == predictedFactory\` (deploy-order sanity)

If a nonce drifts mid-script, the asserts trip and broadcast aborts before a vault deploy could go to a phantom address.

### Required env vars

\`DEPLOYER_PRIVATE_KEY\`, \`POOL_MANAGER\`, \`DEFAULT_OWNER\`, \`CHAINLINK_FEED\`, \`SEQUENCER_FEED\`, \`PRICE_SCALE_NUM\`, \`PRICE_SCALE_DEN\`.

## Quality gates

- \`forge build\`: pass (full impl set on this branch via cherry-picks)
- \`forge fmt\`: clean

## Test plan

- [x] script compiles
- [ ] dry-run on Anvil with mocked PoolManager + Chainlink (next PR)
- [ ] real Base Sepolia deploy (post #65 verification step)

## Dependencies

- Stacked on **#31 (contracts/31-vault-factory)** with cherry-picked: BellStrategy (#32 + #33), ProtocolHook (#34/#35/#36), ChainlinkAdapter (#37) — needed so the script compiles against the full impl set
- Unblocks #65 (Basescan verification + addresses.json export)

Closes #64