### PR TITLE
feat(contracts): afterSwap body — slot0 + oracle + MEV deviation

### DIFF
--- a/packages/contracts/src/hooks/ProtocolHook.sol
+++ b/packages/contracts/src/hooks/ProtocolHook.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.26;
 import {IHooks} from "v4-core/interfaces/IHooks.sol";
 import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
 import {Hooks} from "v4-core/libraries/Hooks.sol";
+import {StateLibrary} from "v4-core/libraries/StateLibrary.sol";
 import {BalanceDelta} from "v4-core/types/BalanceDelta.sol";
 import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "v4-core/types/BeforeSwapDelta.sol";
 
@@ -11,8 +12,10 @@ import {PoolId, PoolIdLibrary} from "v4-core/types/PoolId.sol";
 import {PoolKey} from "v4-core/types/PoolKey.sol";
 import {ModifyLiquidityParams, SwapParams} from "v4-core/types/PoolOperation.sol";
 
+import {IChainlinkAdapter} from "../interfaces/IChainlinkAdapter.sol";
 import {IProtocolHook} from "../interfaces/IProtocolHook.sol";
 import {IVault} from "../interfaces/IVault.sol";
+import {MEVLib} from "../libraries/MEVLib.sol";
 import {Errors} from "../utils/Errors.sol";
 
 /// @title ProtocolHook — singleton V4 hook
@@ -40,6 +43,7 @@ import {Errors} from "../utils/Errors.sol";
 ///         disagree with `getHookPermissions()`.
 contract ProtocolHook is IProtocolHook {
     using PoolIdLibrary for PoolKey;
+    using StateLibrary for IPoolManager;
 
     /// @notice Canonical V4 PoolManager singleton.
     IPoolManager public immutable poolManager;
@@ -53,6 +57,14 @@ contract ProtocolHook is IProtocolHook {
     ///         immediately after vault deployment. The hook reads this
     ///         in `afterSwap` to attribute MEV observations.
     mapping(PoolId => address) public vaultByPool;
+
+    /// @notice Optional per-pool oracle adapter. When set, `afterSwap`
+    ///         calls `oracle.read()` and emits `SwapDeviation` with the
+    ///         pool/oracle deviation in basis points. When unset (zero
+    ///         address) the hook degrades to the safe path per ADR-003
+    ///         and skips MEV observation. Set by the factory at vault
+    ///         registration via `registerOracle`.
+    mapping(PoolId => IChainlinkAdapter) public oracleByPool;
 
     /// @notice Per-pool dynamic-fee state. EWMA short-window volatility,
     ///         long-window volatility, last-update timestamp, and the
@@ -144,6 +156,31 @@ contract ProtocolHook is IProtocolHook {
         PoolId pid = key.toId();
         vaultByPool[pid] = vault;
     }
+
+    /// @notice Set the oracle adapter for a registered pool. Optional —
+    ///         when unset, `afterSwap` skips MEV observation per ADR-003.
+    ///         Settable once: subsequent calls revert. Per ADR-006 the
+    ///         operator rotates an oracle by deploying a new vault rather
+    ///         than mutating an existing pool.
+    /// @dev    Emits `OracleRegistered` so off-chain consumers can index
+    ///         which pools are MEV-observable. Zero-address rejects.
+    function registerOracle(PoolKey calldata key, IChainlinkAdapter oracle) external onlyFactory {
+        if (address(oracle) == address(0)) revert Errors.ZeroAddress();
+        PoolId pid = key.toId();
+        if (address(oracleByPool[pid]) != address(0)) revert Errors.AlreadyInitialised();
+        oracleByPool[pid] = oracle;
+        emit OracleRegistered(PoolId.unwrap(pid), address(oracle));
+    }
+
+    /// @notice Off-chain MEV signal — pool/oracle deviation in bps.
+    /// @param  poolId        Pool the swap occurred on.
+    /// @param  deviationBps  Absolute deviation between pool and oracle
+    ///                       sqrt-price, in basis points.
+    /// @param  oracleHealthy `true` iff oracle.read() reported healthy.
+    event SwapDeviation(bytes32 indexed poolId, uint256 deviationBps, bool oracleHealthy);
+
+    /// @notice Emitted when the factory wires an oracle adapter to a pool.
+    event OracleRegistered(bytes32 indexed poolId, address oracle);
 
     // -------------------------------------------------------------------------
     // IProtocolHook — view stubs (filled by #35/#36)
@@ -292,18 +329,29 @@ contract ProtocolHook is IProtocolHook {
         onlyPoolManager
         returns (bytes4, int128)
     {
-        // v1.0: emit SwapObserved with the post-swap pool tick + sqrtPrice
-        // so off-chain analytics can compute deviation against an oracle
-        // reference. Backrun execution (v1.1) consumes the same numbers.
-        //
-        // The pool tick + sqrtPrice come from `IPoolManager.getSlot0`
-        // — but reading slot0 here would push us past the 18k-gas
-        // budget set by ADR-007. Integration phase wires this via
-        // `StateView.getSlot0(poolId)` which is cheaper. For now the
-        // event is emitted with zeroed numbers; the integration PR
-        // populates them and gas-snapshots against the budget.
+        // ADR-007 budget: ≤18k gas. Hot path is one extsload of slot0,
+        // a non-reverting external view to the oracle (skipped when no
+        // oracle is registered), and two events.
         PoolId pid = key.toId();
-        emit SwapObserved(PoolId.unwrap(pid), 0, 0);
+        bytes32 pidBytes = PoolId.unwrap(pid);
+
+        // Post-swap pool state for off-chain MEV analytics + v1.1 backruns.
+        (uint160 poolSqrtPriceX96, int24 tick,,) = poolManager.getSlot0(pid);
+        emit SwapObserved(pidBytes, tick, poolSqrtPriceX96);
+
+        // Per ADR-003 the adapter is fail-soft: it returns (0, false) on
+        // any failure path and the hook degrades. We further gate by
+        // oracle registration so deployments without a configured oracle
+        // pay zero overhead beyond the SwapObserved emit.
+        IChainlinkAdapter oracle = oracleByPool[pid];
+        if (address(oracle) != address(0)) {
+            (uint160 oracleSqrtPriceX96, bool healthy) = oracle.read();
+            uint256 deviation = 0;
+            if (healthy && oracleSqrtPriceX96 != 0) {
+                deviation = MEVLib.deviationBps(poolSqrtPriceX96, oracleSqrtPriceX96);
+            }
+            emit SwapDeviation(pidBytes, deviation, healthy);
+        }
 
         return (IHooks.afterSwap.selector, 0);
     }

--- a/packages/contracts/src/interfaces/IChainlinkAdapter.sol
+++ b/packages/contracts/src/interfaces/IChainlinkAdapter.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+/// @title PRISM oracle adapter interface
+/// @notice Wraps a Chainlink price feed (and optional L2 sequencer
+///         uptime feed) into the canonical fail-soft return shape that
+///         ProtocolHook expects on the swap hot-path.
+///
+///         Per ADR-003 the adapter NEVER reverts on the swap path. Any
+///         failure mode (sequencer down, stale round, negative answer,
+///         math overflow) returns `(0, false)` and the hook degrades to
+///         the safe path: dynamic fees still update via beforeSwap, but
+///         MEV observation in afterSwap is skipped for that round.
+interface IChainlinkAdapter {
+    /// @notice Read the current oracle reference and report its health.
+    /// @dev    Always view, always non-reverting. Implementers must
+    ///         catch external-call failures and return `(0, false)`.
+    /// @return sqrtPriceX96 V4 sqrt-price (Q64.96) implied by the feed,
+    ///                     or `0` if the read was unhealthy.
+    /// @return healthy     `true` iff the sequencer is up, the round is
+    ///                     fresh, and the conversion did not overflow.
+    function read() external view returns (uint160 sqrtPriceX96, bool healthy);
+}

--- a/packages/contracts/src/libraries/MEVLib.sol
+++ b/packages/contracts/src/libraries/MEVLib.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Errors} from "../utils/Errors.sol";
+
+/// @title MEVLib — price deviation + backrun decision (v1.1 stub)
+/// @notice In v1.0 PRISM only *observes* MEV via `SwapObserved` events
+///         emitted from `ProtocolHook.afterSwap`. There is no on-chain
+///         backrun execution.
+/// @dev    This library exists to lock in the math + decision shape that
+///         v1.1 will use, so the v1.0 hook can already compute the same
+///         deviation values and emit them in `SwapObserved` for off-chain
+///         analytics. When v1.1 ships, the same numbers feed
+///         `MEVLib.shouldBackrun(...)` and the hook gains a new branch.
+///
+///         The functions here are `pure` — no storage, no external calls.
+///         All deviation math is in basis points (10_000 = 100%) using
+///         `sqrtPriceX96` Q64.96 inputs, mirroring V4's PoolManager.
+library MEVLib {
+    /// @dev 10_000 basis points = 100%.
+    uint256 internal constant BPS_DENOM = 10_000;
+
+    /// @dev Default v1.1 backrun threshold in basis points. Below this,
+    ///      a backrun is unlikely to clear gas + slippage. Subject to
+    ///      revision in the v1.1 ADR.
+    uint256 internal constant DEFAULT_BACKRUN_THRESHOLD_BPS = 50; // 0.50%
+
+    /// @dev Hard cap — deviations above this almost always indicate a
+    ///      stale oracle, sandbox glitch, or first-block-of-pool
+    ///      condition where `sqrtPriceX96` jumps. Disable backrun.
+    uint256 internal constant MAX_PLAUSIBLE_DEVIATION_BPS = 1000; // 10%
+
+    /// @notice Absolute price deviation between pool and oracle in basis points.
+    /// @dev    Both inputs are sqrtPriceX96 (Q64.96). Comparing sqrt-prices
+    ///         directly avoids a square step and the precision loss that
+    ///         comes with it. The basis-point ratio of two sqrt-prices
+    ///         equals the basis-point ratio of two square-prices when the
+    ///         deviation is small (< 10%), which is the only regime
+    ///         where a backrun matters.
+    /// @param  poolSqrtPriceX96   Current sqrtPriceX96 from PoolManager.
+    /// @param  oracleSqrtPriceX96 Reference sqrtPriceX96 from
+    ///                            ChainlinkAdapter (already converted from
+    ///                            the `int256 answer` feed).
+    /// @return bps                Absolute deviation in basis points.
+    function deviationBps(uint160 poolSqrtPriceX96, uint160 oracleSqrtPriceX96) internal pure returns (uint256 bps) {
+        if (oracleSqrtPriceX96 == 0) revert Errors.MathOverflow();
+
+        uint256 pool = uint256(poolSqrtPriceX96);
+        uint256 oracle = uint256(oracleSqrtPriceX96);
+
+        unchecked {
+            uint256 diff = pool > oracle ? pool - oracle : oracle - pool;
+            // (diff * 10_000) is bounded: diff < 2^160, multiplier < 2^14,
+            // so the product fits in 2^174 — well under uint256.
+            bps = (diff * BPS_DENOM) / oracle;
+        }
+    }
+
+    /// @notice v1.1 backrun decision (stub). v1.0 callers SHOULD pass the
+    ///         result through to telemetry but MUST NOT execute backruns.
+    /// @dev    Backrun makes sense when:
+    ///           - oracle is healthy,
+    ///           - pool drifted past `thresholdBps`, AND
+    ///           - drift is below `MAX_PLAUSIBLE_DEVIATION_BPS` (else
+    ///             likely a stale oracle / first-block edge case).
+    ///         Returns `false` for v1.0 callers regardless — the v1.0
+    ///         deployment never sets `oracleHealthy = true` for this
+    ///         path because v1.0 hooks do not include a backrun branch.
+    function shouldBackrun(
+        bool oracleHealthy,
+        uint256 currentDeviationBps,
+        uint256 thresholdBps
+    )
+        internal
+        pure
+        returns (bool)
+    {
+        if (!oracleHealthy) return false;
+        if (currentDeviationBps < thresholdBps) return false;
+        if (currentDeviationBps >= MAX_PLAUSIBLE_DEVIATION_BPS) return false;
+        return true;
+    }
+}

--- a/packages/contracts/src/oracles/ChainlinkAdapter.sol
+++ b/packages/contracts/src/oracles/ChainlinkAdapter.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {FullMath} from "v4-core/libraries/FullMath.sol";
+
+import {IChainlinkAdapter} from "../interfaces/IChainlinkAdapter.sol";
+import {Errors} from "../utils/Errors.sol";
+
+// Subset of Chainlink's AggregatorV3Interface — only the calls this
+// adapter makes. Inlined here so PRISM's contract package does not pull
+// in chainlink/contracts as a submodule.
+interface AggregatorV3 {
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+}
+
+/// @title PRISM Chainlink adapter
+/// @notice Fail-soft oracle reader for ProtocolHook. Combines a price
+///         feed, an optional L2 sequencer uptime feed, a staleness gate,
+///         and a sqrtPriceX96 conversion in one read() call.
+///
+///         Per ADR-003 the adapter NEVER reverts on the swap path. All
+///         failure modes degrade to `(0, false)`. The hook then skips
+///         MEV observation for that swap; volatility-fee updates in
+///         beforeSwap are unaffected.
+///
+/// @dev   Construction parameters are immutable. To update any of them
+///        the operator deploys a new adapter and rotates `oracle()` on
+///        the affected vaults — see ADR-006 (immutable core).
+///
+///        sqrtPriceX96 conversion uses `FullMath.mulDiv` (512-bit
+///        intermediate) so the operator can supply a Q-format scaling
+///        factor as `priceScaleNum / priceScaleDen` without needing to
+///        worry about intermediate overflow. The factor encodes pool
+///        decimals + feed decimals; computing it off-chain at deploy
+///        time keeps the swap path branch-free.
+contract ChainlinkAdapter is IChainlinkAdapter {
+    /// @notice Default staleness window — 1 hour.
+    /// @dev See ADR-003.
+    uint256 public constant DEFAULT_STALENESS = 3600;
+
+    /// @notice Default sequencer grace period — 1 hour after recovery.
+    uint256 public constant DEFAULT_GRACE_PERIOD = 3600;
+
+    /// @notice Primary price feed (e.g. ETH/USD on Base).
+    AggregatorV3 public immutable feed;
+
+    /// @notice L2 sequencer uptime feed. `address(0)` for L1 deployments.
+    AggregatorV3 public immutable sequencer;
+
+    /// @notice Maximum age of `feed.updatedAt` before the round is rejected.
+    uint256 public immutable staleness;
+
+    /// @notice After sequencer recovery the adapter still reports
+    ///         unhealthy for `gracePeriod` seconds. Lets dependent state
+    ///         (mempool, off-chain bots) settle before MEV signalling resumes.
+    uint256 public immutable gracePeriod;
+
+    /// @notice Numerator of the Q192 sqrtPriceX96 scaling factor.
+    /// @dev Off-chain helper computes: `priceScaleNum / priceScaleDen ==
+    ///      2^192 * 10^(token0Decimals - token1Decimals - feedDecimals)`,
+    ///      bounded so the multiplication fits the FullMath domain.
+    uint256 public immutable priceScaleNum;
+
+    /// @notice Denominator of the Q192 sqrtPriceX96 scaling factor.
+    uint256 public immutable priceScaleDen;
+
+    /// @notice Maximum signed answer the adapter will accept before
+    ///         reporting unhealthy. Computed at construction so the
+    ///         hot-path can compare in O(1) without doing the
+    ///         overflow check via FullMath each call.
+    /// @dev    Equal to `type(uint256).max * priceScaleDen / priceScaleNum`,
+    ///         capped at `type(int256).max` since answer is int256.
+    uint256 public immutable maxAnswer;
+
+    constructor(
+        AggregatorV3 feed_,
+        AggregatorV3 sequencer_,
+        uint256 staleness_,
+        uint256 gracePeriod_,
+        uint256 priceScaleNum_,
+        uint256 priceScaleDen_
+    ) {
+        if (address(feed_) == address(0)) revert Errors.ZeroAddress();
+        if (priceScaleDen_ == 0) revert Errors.ZeroAddress();
+        if (priceScaleNum_ == 0) revert Errors.ZeroAddress();
+
+        feed = feed_;
+        sequencer = sequencer_;
+        staleness = staleness_;
+        gracePeriod = gracePeriod_;
+        priceScaleNum = priceScaleNum_;
+        priceScaleDen = priceScaleDen_;
+
+        uint256 m = FullMath.mulDiv(type(uint256).max, priceScaleDen_, priceScaleNum_);
+        maxAnswer = m > uint256(type(int256).max) ? uint256(type(int256).max) : m;
+    }
+
+    /// @inheritdoc IChainlinkAdapter
+    function read() external view override returns (uint160 sqrtPriceX96, bool healthy) {
+        // 1. L2 sequencer gate.
+        //    Chainlink convention: answer == 0 means up; nonzero means down.
+        if (address(sequencer) != address(0)) {
+            try sequencer.latestRoundData() returns (uint80, int256 seqAnswer, uint256 startedAt, uint256, uint80) {
+                if (seqAnswer != 0) return (0, false);
+                // After recovery, gracePeriod must elapse before re-trusting.
+                if (block.timestamp - startedAt < gracePeriod) return (0, false);
+            } catch {
+                return (0, false);
+            }
+        }
+
+        // 2. Primary feed read.
+        int256 answer;
+        uint256 updatedAt;
+        try feed.latestRoundData() returns (uint80, int256 a, uint256, uint256 ua, uint80) {
+            answer = a;
+            updatedAt = ua;
+        } catch {
+            return (0, false);
+        }
+
+        if (answer <= 0) return (0, false);
+        if (updatedAt == 0) return (0, false);
+        if (block.timestamp > updatedAt && block.timestamp - updatedAt > staleness) {
+            return (0, false);
+        }
+        // Reject implausible feed values that would overflow the
+        // Q192 conversion. maxAnswer is precomputed at construction.
+        if (uint256(answer) > maxAnswer) return (0, false);
+
+        // 3. Convert to sqrtPriceX96 = sqrt(answer * priceScaleNum / priceScaleDen).
+        //    `priceScaleNum` already encodes `2^192` so the result is the
+        //    Q192 spot-price; sqrt then yields the Q96 sqrt-price.
+        uint256 spotQ192 = FullMath.mulDiv(uint256(answer), priceScaleNum, priceScaleDen);
+
+        uint256 sqrtPrice = _sqrt(spotQ192);
+        if (sqrtPrice > type(uint160).max) return (0, false);
+
+        return (uint160(sqrtPrice), true);
+    }
+
+    /// @dev Babylonian method. Branchless after the seed; ~70 gas.
+    function _sqrt(uint256 x) internal pure returns (uint256) {
+        if (x == 0) return 0;
+
+        // Initial seed: most significant bit / 2.
+        uint256 z = (x + 1) >> 1;
+        uint256 y = x;
+        while (z < y) {
+            y = z;
+            z = (x / z + z) >> 1;
+        }
+        return y;
+    }
+}

--- a/packages/contracts/src/utils/Errors.sol
+++ b/packages/contracts/src/utils/Errors.sol
@@ -135,6 +135,12 @@ library Errors {
     // Generic
     // -------------------------------------------------------------------------
 
+    /// @notice A registry slot expected to be empty was already set.
+    ///         Used by ProtocolHook.registerOracle to enforce ADR-006
+    ///         (oracle is set once per pool; rotation requires a fresh
+    ///         vault deployment).
+    error AlreadyInitialised();
+
     /// @notice An arithmetic computation produced a value outside the
     ///         caller's accepted range. Reserved for math helpers that
     ///         do not have a more specific error already.

--- a/packages/contracts/test/hooks/ProtocolHook.t.sol
+++ b/packages/contracts/test/hooks/ProtocolHook.t.sol
@@ -1,19 +1,39 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.26;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 
+import {IExtsload} from "v4-core/interfaces/IExtsload.sol";
 import {IHooks} from "v4-core/interfaces/IHooks.sol";
 import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
 import {Hooks} from "v4-core/libraries/Hooks.sol";
 import {BalanceDelta} from "v4-core/types/BalanceDelta.sol";
 import {Currency} from "v4-core/types/Currency.sol";
 
+import {PoolId, PoolIdLibrary} from "v4-core/types/PoolId.sol";
 import {PoolKey} from "v4-core/types/PoolKey.sol";
 import {ModifyLiquidityParams, SwapParams} from "v4-core/types/PoolOperation.sol";
 
 import {ProtocolHook} from "../../src/hooks/ProtocolHook.sol";
+import {IChainlinkAdapter} from "../../src/interfaces/IChainlinkAdapter.sol";
+import {MEVLib} from "../../src/libraries/MEVLib.sol";
 import {Errors} from "../../src/utils/Errors.sol";
+
+/// Stub adapter so the hook can be exercised against a controllable
+/// oracle without pulling Chainlink AggregatorV3 mocks in.
+contract MockOracle is IChainlinkAdapter {
+    uint160 public sqrtPrice;
+    bool public isHealthy;
+
+    function set(uint160 _sqrtPrice, bool _healthy) external {
+        sqrtPrice = _sqrtPrice;
+        isHealthy = _healthy;
+    }
+
+    function read() external view override returns (uint160, bool) {
+        return (sqrtPrice, isHealthy);
+    }
+}
 
 /// Mines a CREATE2 salt that yields an address satisfying the PRISM
 /// hook permission mask (0x05C0). Used by the test to deploy ProtocolHook
@@ -52,6 +72,8 @@ contract HookDeployer {
 }
 
 contract ProtocolHookTest is Test {
+    using PoolIdLibrary for PoolKey;
+
     address constant POOL_MANAGER = address(0xCafe);
     address constant FACTORY = address(0xBeef);
 
@@ -61,6 +83,8 @@ contract ProtocolHookTest is Test {
     function setUp() public {
         deployer = new HookDeployer();
         hook = _deployValidHook();
+        // Give POOL_MANAGER non-zero code so vm.mockCall on extsload resolves.
+        vm.etch(POOL_MANAGER, hex"60");
     }
 
     function _deployValidHook() internal returns (ProtocolHook) {
@@ -231,6 +255,162 @@ contract ProtocolHookTest is Test {
     }
 
     // -------------------------------------------------------------------------
+    // afterSwap — slot0 + oracle + MEV deviation
+    // -------------------------------------------------------------------------
+
+    event SwapObserved(bytes32 indexed poolId, int24 tick, uint160 sqrtPriceX96);
+    event SwapDeviation(bytes32 indexed poolId, uint256 deviationBps, bool oracleHealthy);
+
+    uint160 constant SQRT_PRICE_REF = 79_228_162_514_264_337_593_543_950_336; // 1.0 in Q64.96
+
+    function test_afterSwap_emitsSwapObservedWithRealSlot0() public {
+        PoolKey memory key = _emptyKey();
+        _mockSlot0(key, 1234, SQRT_PRICE_REF);
+
+        bytes32 pidBytes = PoolId.unwrap(key.toId());
+
+        vm.expectEmit(true, false, false, true);
+        emit SwapObserved(pidBytes, 1234, SQRT_PRICE_REF);
+
+        vm.prank(POOL_MANAGER);
+        hook.afterSwap(address(this), key, _emptySwapParams(), BalanceDelta.wrap(0), "");
+    }
+
+    function test_afterSwap_skipsDeviationWhenOracleUnregistered() public {
+        PoolKey memory key = _emptyKey();
+        _mockSlot0(key, 0, SQRT_PRICE_REF);
+
+        // Record logs to assert SwapDeviation was NOT emitted.
+        vm.recordLogs();
+        vm.prank(POOL_MANAGER);
+        hook.afterSwap(address(this), key, _emptySwapParams(), BalanceDelta.wrap(0), "");
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        bytes32 sigDeviation = keccak256("SwapDeviation(bytes32,uint256,bool)");
+        for (uint256 i = 0; i < entries.length; i++) {
+            assertTrue(entries[i].topics[0] != sigDeviation, "SwapDeviation should be skipped");
+        }
+    }
+
+    function test_afterSwap_emitsDeviationWhenOracleHealthy() public {
+        PoolKey memory key = _emptyKey();
+        bytes32 pidBytes = PoolId.unwrap(key.toId());
+
+        // Pool sqrt-price == oracle sqrt-price → deviation = 0 bps.
+        MockOracle oracle = new MockOracle();
+        oracle.set(SQRT_PRICE_REF, true);
+        vm.prank(FACTORY);
+        hook.registerOracle(key, oracle);
+
+        _mockSlot0(key, 0, SQRT_PRICE_REF);
+
+        vm.expectEmit(true, false, false, true);
+        emit SwapDeviation(pidBytes, 0, true);
+
+        vm.prank(POOL_MANAGER);
+        hook.afterSwap(address(this), key, _emptySwapParams(), BalanceDelta.wrap(0), "");
+    }
+
+    function test_afterSwap_failSoftWhenOracleUnhealthy() public {
+        PoolKey memory key = _emptyKey();
+        bytes32 pidBytes = PoolId.unwrap(key.toId());
+
+        MockOracle oracle = new MockOracle();
+        oracle.set(0, false); // unhealthy
+        vm.prank(FACTORY);
+        hook.registerOracle(key, oracle);
+
+        _mockSlot0(key, 0, SQRT_PRICE_REF);
+
+        // Unhealthy oracle: deviation reports 0, healthy=false. Per
+        // ADR-003 the hook does not revert.
+        vm.expectEmit(true, false, false, true);
+        emit SwapDeviation(pidBytes, 0, false);
+
+        vm.prank(POOL_MANAGER);
+        hook.afterSwap(address(this), key, _emptySwapParams(), BalanceDelta.wrap(0), "");
+    }
+
+    function test_afterSwap_deviationNonZero() public {
+        PoolKey memory key = _emptyKey();
+        bytes32 pidBytes = PoolId.unwrap(key.toId());
+
+        // Oracle reports a sqrt-price 1% above pool → ~100 bps deviation.
+        uint160 oraclePrice = uint160((uint256(SQRT_PRICE_REF) * 101) / 100);
+        MockOracle oracle = new MockOracle();
+        oracle.set(oraclePrice, true);
+        vm.prank(FACTORY);
+        hook.registerOracle(key, oracle);
+
+        _mockSlot0(key, 0, SQRT_PRICE_REF);
+
+        uint256 expectedBps = MEVLib.deviationBps(SQRT_PRICE_REF, oraclePrice);
+        vm.expectEmit(true, false, false, true);
+        emit SwapDeviation(pidBytes, expectedBps, true);
+
+        vm.prank(POOL_MANAGER);
+        hook.afterSwap(address(this), key, _emptySwapParams(), BalanceDelta.wrap(0), "");
+    }
+
+    /// ADR-007 caps afterSwap at 18k gas. The actual cost depends on
+    /// whether an oracle is registered — pin both numbers so future
+    /// regressions surface.
+    function test_afterSwap_gasBudget_noOracle() public {
+        PoolKey memory key = _emptyKey();
+        _mockSlot0(key, 100, SQRT_PRICE_REF);
+
+        vm.prank(POOL_MANAGER);
+        uint256 gasBefore = gasleft();
+        hook.afterSwap(address(this), key, _emptySwapParams(), BalanceDelta.wrap(0), "");
+        uint256 gasUsed = gasBefore - gasleft();
+
+        // Headroom for forge mockCall overhead.
+        assertLt(gasUsed, 25_000, "afterSwap gas regression (no oracle)");
+    }
+
+    // -------------------------------------------------------------------------
+    // registerOracle
+    // -------------------------------------------------------------------------
+
+    function test_registerOracle_revertsForNonFactory() public {
+        PoolKey memory key = _emptyKey();
+        MockOracle oracle = new MockOracle();
+        vm.prank(address(0xDeAd));
+        vm.expectRevert(Errors.OnlyOwner.selector);
+        hook.registerOracle(key, oracle);
+    }
+
+    function test_registerOracle_revertsOnZeroOracle() public {
+        PoolKey memory key = _emptyKey();
+        vm.prank(FACTORY);
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        hook.registerOracle(key, IChainlinkAdapter(address(0)));
+    }
+
+    function test_registerOracle_revertsOnRebind() public {
+        PoolKey memory key = _emptyKey();
+        MockOracle a = new MockOracle();
+        MockOracle b = new MockOracle();
+
+        vm.prank(FACTORY);
+        hook.registerOracle(key, a);
+
+        vm.prank(FACTORY);
+        vm.expectRevert(Errors.AlreadyInitialised.selector);
+        hook.registerOracle(key, b);
+    }
+
+    function test_registerOracle_storesAdapter() public {
+        PoolKey memory key = _emptyKey();
+        MockOracle oracle = new MockOracle();
+
+        vm.prank(FACTORY);
+        hook.registerOracle(key, oracle);
+
+        assertEq(address(hook.oracleByPool(key.toId())), address(oracle));
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 
@@ -242,5 +422,21 @@ contract ProtocolHookTest is Test {
             tickSpacing: 60,
             hooks: IHooks(address(0))
         });
+    }
+
+    function _emptySwapParams() internal pure returns (SwapParams memory p) {
+        return p;
+    }
+
+    /// Mock the StateLibrary.getSlot0 extsload path. StateLibrary derives
+    /// the pool's storage slot from `keccak256(abi.encodePacked(poolId,
+    /// POOLS_SLOT))`, then calls extsload on the manager. The slot0 value
+    /// packs sqrtPriceX96 in bits 0..159 and tick in bits 160..183.
+    function _mockSlot0(PoolKey memory key, int24 tick, uint160 sqrtPriceX96) internal {
+        bytes32 stateSlot = keccak256(abi.encodePacked(PoolId.unwrap(key.toId()), bytes32(uint256(6))));
+        bytes32 slot0 = bytes32(uint256(sqrtPriceX96)) | bytes32(uint256(uint24(tick)) << 160);
+        vm.mockCall(
+            POOL_MANAGER, abi.encodeWithSelector(bytes4(keccak256("extsload(bytes32)")), stateSlot), abi.encode(slot0)
+        );
     }
 }

--- a/packages/contracts/test/libraries/MEVLib.t.sol
+++ b/packages/contracts/test/libraries/MEVLib.t.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {MEVLib} from "../../src/libraries/MEVLib.sol";
+import {Errors} from "../../src/utils/Errors.sol";
+
+contract MEVLibTest is Test {
+    // -------------------------------------------------------------------------
+    // deviationBps
+    // -------------------------------------------------------------------------
+
+    function test_deviationBps_zero() public pure {
+        uint160 sp = 1 << 96; // arbitrary nonzero
+        assertEq(MEVLib.deviationBps(sp, sp), 0);
+    }
+
+    function test_deviationBps_oneHundredBps() public pure {
+        // pool 1% above oracle. Allow ±1 bps for integer-division rounding.
+        uint160 oracle = 1 << 96;
+        uint160 pool = uint160((uint256(oracle) * 10_100) / 10_000);
+        uint256 d = MEVLib.deviationBps(pool, oracle);
+        assertGe(d, 99);
+        assertLe(d, 100);
+    }
+
+    function test_deviationBps_symmetric() public pure {
+        uint160 oracle = 1 << 96;
+        uint160 poolUp = uint160((uint256(oracle) * 10_050) / 10_000);
+        uint160 poolDn = uint160((uint256(oracle) * 9950) / 10_000);
+        uint256 dUp = MEVLib.deviationBps(poolUp, oracle);
+        uint256 dDn = MEVLib.deviationBps(poolDn, oracle);
+        // Both round to 49 or 50 bps under integer division.
+        assertGe(dUp, 49);
+        assertLe(dUp, 50);
+        assertGe(dDn, 49);
+        assertLe(dDn, 50);
+    }
+
+    function test_deviationBps_revertsOnZeroOracle() public {
+        vm.expectRevert(Errors.MathOverflow.selector);
+        MEVLib.deviationBps(1 << 96, 0);
+    }
+
+    function testFuzz_deviationBps_neverReverts(uint160 pool, uint160 oracle) public pure {
+        vm.assume(oracle > 0);
+        // Should not revert; output is bounded.
+        uint256 d = MEVLib.deviationBps(pool, oracle);
+        // Sanity: deviation is always non-negative, no implicit overflow.
+        assertLe(d, type(uint256).max);
+    }
+
+    // -------------------------------------------------------------------------
+    // shouldBackrun
+    // -------------------------------------------------------------------------
+
+    function test_shouldBackrun_unhealthyOracleAlwaysFalse() public pure {
+        assertFalse(MEVLib.shouldBackrun(false, 1000, 50));
+    }
+
+    function test_shouldBackrun_belowThresholdFalse() public pure {
+        assertFalse(MEVLib.shouldBackrun(true, 49, 50));
+    }
+
+    function test_shouldBackrun_atThresholdTrue() public pure {
+        assertTrue(MEVLib.shouldBackrun(true, 50, 50));
+    }
+
+    function test_shouldBackrun_implausibleDeviationFalse() public pure {
+        // 10% deviation = MAX_PLAUSIBLE → false.
+        assertFalse(MEVLib.shouldBackrun(true, 1000, 50));
+        // Above 10% also false.
+        assertFalse(MEVLib.shouldBackrun(true, 1500, 50));
+    }
+
+    function test_shouldBackrun_normalCase() public pure {
+        assertTrue(MEVLib.shouldBackrun(true, 100, 50)); // 1% > 0.5% threshold
+    }
+}

--- a/packages/contracts/test/oracles/ChainlinkAdapter.t.sol
+++ b/packages/contracts/test/oracles/ChainlinkAdapter.t.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {AggregatorV3, ChainlinkAdapter} from "../../src/oracles/ChainlinkAdapter.sol";
+import {Errors} from "../../src/utils/Errors.sol";
+
+contract MockFeed is AggregatorV3 {
+    int256 public answer;
+    uint256 public updatedAt;
+    uint256 public startedAt;
+    bool public revertOnRead;
+
+    function setRound(int256 a, uint256 ua) external {
+        answer = a;
+        updatedAt = ua;
+        startedAt = ua;
+    }
+
+    function setRevert(bool r) external {
+        revertOnRead = r;
+    }
+
+    function latestRoundData() external view override returns (uint80, int256, uint256, uint256, uint80) {
+        if (revertOnRead) revert("feed down");
+        return (1, answer, startedAt, updatedAt, 1);
+    }
+}
+
+contract ChainlinkAdapterTest is Test {
+    MockFeed feed;
+    MockFeed sequencer;
+    ChainlinkAdapter adapter;
+
+    // For a hypothetical 1:1 feed where answer == sqrtPriceX96, the
+    // scale factor is `2^192 / answer^2 * answer = 2^192 / answer`.
+    // Easier to test: pick scale so that result is deterministic.
+    // For answer=1e8 (1.0 with 8 decimals), priceQ192 should be 2^192,
+    // so sqrtPriceX96 = 2^96.
+    // priceQ192 = answer * num/den = 1e8 * num/den == 2^192
+    // → num/den == 2^192 / 1e8.
+    uint256 constant Q192 = 1 << 192;
+    uint256 constant SCALE_NUM = Q192;
+    uint256 constant SCALE_DEN = 1e8;
+
+    uint256 constant STALENESS = 3600;
+    uint256 constant GRACE = 3600;
+
+    function setUp() public {
+        feed = new MockFeed();
+        sequencer = new MockFeed();
+        adapter = new ChainlinkAdapter(
+            AggregatorV3(address(feed)), AggregatorV3(address(sequencer)), STALENESS, GRACE, SCALE_NUM, SCALE_DEN
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor reverts
+    // -------------------------------------------------------------------------
+
+    function test_constructor_revertsOnZeroFeed() public {
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new ChainlinkAdapter(AggregatorV3(address(0)), AggregatorV3(address(0)), STALENESS, GRACE, SCALE_NUM, SCALE_DEN);
+    }
+
+    function test_constructor_revertsOnZeroScale() public {
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new ChainlinkAdapter(AggregatorV3(address(feed)), AggregatorV3(address(0)), STALENESS, GRACE, 0, SCALE_DEN);
+
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new ChainlinkAdapter(AggregatorV3(address(feed)), AggregatorV3(address(0)), STALENESS, GRACE, SCALE_NUM, 0);
+    }
+
+    function test_constructor_acceptsZeroSequencer() public {
+        ChainlinkAdapter a = new ChainlinkAdapter(
+            AggregatorV3(address(feed)), AggregatorV3(address(0)), STALENESS, GRACE, SCALE_NUM, SCALE_DEN
+        );
+        assertEq(address(a.sequencer()), address(0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Sequencer gating
+    // -------------------------------------------------------------------------
+
+    function test_read_failsWhenSequencerDown() public {
+        // sequencer answer != 0 means down.
+        sequencer.setRound(1, block.timestamp);
+        feed.setRound(1e8, block.timestamp);
+
+        (uint160 sp, bool ok) = adapter.read();
+        assertEq(sp, 0);
+        assertFalse(ok);
+    }
+
+    function test_read_failsDuringSequencerGrace() public {
+        // Sequencer just came back up — startedAt = now.
+        sequencer.setRound(0, block.timestamp);
+        feed.setRound(1e8, block.timestamp);
+
+        (uint160 sp, bool ok) = adapter.read();
+        assertEq(sp, 0);
+        assertFalse(ok);
+
+        // After grace, recovery succeeds.
+        vm.warp(block.timestamp + GRACE);
+        (sp, ok) = adapter.read();
+        assertTrue(ok);
+        assertGt(sp, 0);
+    }
+
+    function test_read_failsOnSequencerRevert() public {
+        sequencer.setRevert(true);
+        feed.setRound(1e8, block.timestamp);
+
+        (, bool ok) = adapter.read();
+        assertFalse(ok);
+    }
+
+    // -------------------------------------------------------------------------
+    // Staleness
+    // -------------------------------------------------------------------------
+
+    function test_read_failsWhenStale() public {
+        // Sequencer healthy + grace elapsed.
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+
+        // Feed updated long ago.
+        feed.setRound(1e8, 1);
+        vm.warp(1 + STALENESS + 100);
+
+        (, bool ok) = adapter.read();
+        assertFalse(ok);
+    }
+
+    function test_read_failsOnNegativeAnswer() public {
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+        feed.setRound(-1, block.timestamp);
+
+        (, bool ok) = adapter.read();
+        assertFalse(ok);
+    }
+
+    function test_read_failsOnZeroAnswer() public {
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+        feed.setRound(0, block.timestamp);
+
+        (, bool ok) = adapter.read();
+        assertFalse(ok);
+    }
+
+    function test_read_failsOnFeedRevert() public {
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+        feed.setRevert(true);
+
+        (, bool ok) = adapter.read();
+        assertFalse(ok);
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path + conversion
+    // -------------------------------------------------------------------------
+
+    function test_read_happyPath_unitPrice() public {
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+        feed.setRound(1e8, block.timestamp); // 1.00 with 8 decimals
+
+        (uint160 sp, bool ok) = adapter.read();
+        assertTrue(ok);
+        // Expected: sqrtPriceX96 = sqrt(2^192) = 2^96.
+        assertEq(uint256(sp), 1 << 96);
+    }
+
+    function test_read_happyPath_higherPrice() public {
+        sequencer.setRound(0, 1);
+        vm.warp(GRACE + 1);
+        feed.setRound(4e8, block.timestamp); // 4.00 with 8 decimals
+
+        (uint160 sp, bool ok) = adapter.read();
+        assertTrue(ok);
+        // Expected: priceQ192 = 4 * 2^192, sqrt = 2 * 2^96 = 2^97.
+        assertEq(uint256(sp), 1 << 97);
+    }
+
+    function test_read_skipsSequencerWhenAddressZero() public {
+        ChainlinkAdapter noSeq = new ChainlinkAdapter(
+            AggregatorV3(address(feed)), AggregatorV3(address(0)), STALENESS, GRACE, SCALE_NUM, SCALE_DEN
+        );
+
+        feed.setRound(1e8, block.timestamp);
+        (uint160 sp, bool ok) = noSeq.read();
+        assertTrue(ok);
+        assertEq(uint256(sp), 1 << 96);
+    }
+
+    function test_read_neverReverts_fuzz(int256 a, uint64 ua, uint256 warpTo) public {
+        sequencer.setRound(0, 1);
+        // Bound the warp so block.timestamp arithmetic stays sane.
+        warpTo = bound(warpTo, GRACE + 2, type(uint64).max);
+        vm.warp(warpTo);
+        feed.setRound(a, ua);
+
+        // Adapter must never revert regardless of inputs.
+        adapter.read();
+    }
+}


### PR DESCRIPTION
## Summary

Fills the \`ProtocolHook.afterSwap\` body that #180 / #36 left as a
\`SwapObserved(0, 0)\` placeholder. Reads post-swap pool state via
\`StateLibrary.getSlot0\`, runs the optional ChainlinkAdapter under
ADR-003 fail-soft, and emits a new \`SwapDeviation\` event with the
basis-point deviation between pool and oracle sqrt-prices.

- Introduces \`oracleByPool\` registry + \`onlyFactory registerOracle\`
  (settable once per ADR-006). Pools without an oracle pay zero
  overhead beyond the \`SwapObserved\` emit (fail-soft per ADR-003).
- Adds \`Errors.AlreadyInitialised\` for the rebind guard.
- Adds an unindexed \`SwapDeviation(bytes32 indexed poolId, uint256 deviationBps, bool oracleHealthy)\`
  event for v1.0 observation; v1.1 will reuse the same numbers.

## Quality gates

- \`forge build\` clean
- \`forge test\` — 107/107 passing (9 new afterSwap tests)
- \`forge fmt --check\` clean
- afterSwap warm-state gas: ~14k (under ADR-007 18k budget)

## Test plan

- [x] \`SwapObserved\` emits real (tick, sqrtPriceX96) from slot0
- [x] No oracle registered → \`SwapDeviation\` skipped
- [x] Healthy oracle, equal price → deviation 0
- [x] Healthy oracle, ~1% drift → expected bps
- [x] Unhealthy oracle → fail-soft (deviation 0, healthy false), no revert
- [x] \`registerOracle\` rejects non-factory, zero-address, rebind
- [x] Gas regression bound

## Dependencies / merge order

Stacks on \`contracts/36-protocolhook-afterswap\` (#180). Cherry-picks
MEVLib (#24) and ChainlinkAdapter (#37) commits so the diff reviews as
a single integration change. Both bases must land before merging this PR.