### PR TITLE
feat(contracts): Vault._handleDeposit body — multi-position deploy + share mint

### DIFF
--- a/packages/contracts/src/core/Vault.sol
+++ b/packages/contracts/src/core/Vault.sol
@@ -4,15 +4,21 @@ pragma solidity 0.8.26;
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
 import {IUnlockCallback} from "v4-core/interfaces/callback/IUnlockCallback.sol";
+import {StateLibrary} from "v4-core/libraries/StateLibrary.sol";
+import {BalanceDelta, BalanceDeltaLibrary} from "v4-core/types/BalanceDelta.sol";
 import {Currency} from "v4-core/types/Currency.sol";
+import {PoolId, PoolIdLibrary} from "v4-core/types/PoolId.sol";
 import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {ModifyLiquidityParams} from "v4-core/types/PoolOperation.sol";
 
 import {IProtocolHook} from "../interfaces/IProtocolHook.sol";
 import {IStrategy} from "../interfaces/IStrategy.sol";
 import {IVault} from "../interfaces/IVault.sol";
+import {PositionLib} from "../libraries/PositionLib.sol";
 import {Errors} from "../utils/Errors.sol";
 
 /// @title PRISM Vault — multi-position LP aggregator on Uniswap V4
@@ -48,6 +54,9 @@ import {Errors} from "../utils/Errors.sol";
 ///      mitigates the first-depositor inflation attack (PRD §13).
 contract Vault is IVault, ERC20, IUnlockCallback {
     using SafeERC20 for IERC20;
+    using StateLibrary for IPoolManager;
+    using PoolIdLibrary for PoolKey;
+    using BalanceDeltaLibrary for BalanceDelta;
 
     /// @dev Tagged operations for `unlockCallback`. Each entry point
     ///      (deposit / withdraw / rebalance) calls `poolManager.unlock`
@@ -286,11 +295,140 @@ contract Vault is IVault, ERC20, IUnlockCallback {
         revert Errors.UnknownOp();
     }
 
-    /// @dev Stub: real implementation pulls tokens via permit2, calls
-    ///      `poolManager.modifyLiquidity` per target position, settles
-    ///      deltas, and refunds any unused desired amount.
-    function _handleDeposit(DepositPayload memory /*payload*/ ) internal pure returns (bytes memory) {
-        revert Errors.UnknownOp();
+    /// @dev Multi-position deploy + share mint inside the V4 flash-accounting
+    ///      unlock callback. Steps:
+    ///        1. Read currentTick + sqrtPriceX96 via StateLibrary.getSlot0.
+    ///        2. Ask the strategy for the target shape across the desired amounts.
+    ///        3. Reject malformed shapes (weight sum, position count).
+    ///        4. For each target position, compute liquidity from the weighted
+    ///           share of the desired amounts and call modifyLiquidity. The
+    ///           returned BalanceDelta is the negative-signed amount the vault
+    ///           owes the pool (callerDelta is the vault's net delta).
+    ///        5. Settle the aggregate negative delta — sync, transfer the
+    ///           deposit tokens to the manager, settle.
+    ///        6. Refund the unused portion of `amountXDesired` to the payer.
+    ///        7. Compute and mint shares: first depositor mints sqrt(a0*a1) and
+    ///           burns MIN_SHARES to DEAD (PRD §13 inflation guard); subsequent
+    ///           depositors mint pro-rata against existing totalSupply.
+    function _handleDeposit(DepositPayload memory payload) internal returns (bytes memory) {
+        // 1. Read the pool state.
+        PoolId pid = _poolKey.toId();
+        (uint160 sqrtPriceX96, int24 currentTick,,) = poolManager.getSlot0(pid);
+
+        // 2. Strategy decides the target shape against the deposit budget.
+        IStrategy.TargetPosition[] memory targets =
+            strategy.computePositions(currentTick, tickSpacing, payload.amount0Desired, payload.amount1Desired);
+
+        // 3. Validate the strategy output (invariants #2 and #3).
+        if (targets.length == 0 || targets.length > MAX_POSITIONS) {
+            revert Errors.MaxPositionsExceeded(targets.length);
+        }
+        uint256 weightSum;
+        for (uint256 i = 0; i < targets.length; i++) {
+            weightSum += targets[i].weight;
+        }
+        if (weightSum != 10_000) revert Errors.WeightsDoNotSum(weightSum);
+
+        // 4. Deploy each target. Track aggregate consumed amounts via the
+        // returned BalanceDelta. callerDelta < 0 means the vault owes.
+        uint256 amount0Used;
+        uint256 amount1Used;
+        delete _positions; // first deposit only — subsequent rebalance manages this
+
+        for (uint256 i = 0; i < targets.length; i++) {
+            IStrategy.TargetPosition memory t = targets[i];
+
+            // Allocate this position's share of the budget by weight.
+            uint256 share0 = (payload.amount0Desired * t.weight) / 10_000;
+            uint256 share1 = (payload.amount1Desired * t.weight) / 10_000;
+
+            uint128 liquidity =
+                PositionLib.liquidityForAmounts(sqrtPriceX96, t.tickLower, t.tickUpper, tickSpacing, share0, share1);
+            if (liquidity == 0) continue; // skip degenerate positions
+
+            (BalanceDelta delta,) = poolManager.modifyLiquidity(
+                _poolKey,
+                ModifyLiquidityParams({
+                    tickLower: t.tickLower,
+                    tickUpper: t.tickUpper,
+                    liquidityDelta: int256(uint256(liquidity)),
+                    salt: bytes32(uint256(i))
+                }),
+                ""
+            );
+
+            int128 d0 = delta.amount0();
+            int128 d1 = delta.amount1();
+            if (d0 < 0) amount0Used += uint128(-d0);
+            if (d1 < 0) amount1Used += uint128(-d1);
+
+            _positions.push(Position({tickLower: t.tickLower, tickUpper: t.tickUpper, liquidity: liquidity}));
+        }
+
+        // 5. Slippage gate.
+        if (amount0Used < payload.amount0Min) revert Errors.SlippageExceeded(amount0Used, payload.amount0Min);
+        if (amount1Used < payload.amount1Min) revert Errors.SlippageExceeded(amount1Used, payload.amount1Min);
+
+        // 6. Settle deltas. The vault holds `amountXDesired` from the entry
+        // point's transferFrom. Anything not consumed by modifyLiquidity is
+        // refunded to the payer; the rest is paid to the PoolManager.
+        if (amount0Used > 0) {
+            poolManager.sync(_poolKey.currency0);
+            token0.safeTransfer(address(poolManager), amount0Used);
+            poolManager.settle();
+        }
+        if (amount1Used > 0) {
+            poolManager.sync(_poolKey.currency1);
+            token1.safeTransfer(address(poolManager), amount1Used);
+            poolManager.settle();
+        }
+
+        uint256 refund0 = payload.amount0Desired - amount0Used;
+        uint256 refund1 = payload.amount1Desired - amount1Used;
+        if (refund0 > 0) token0.safeTransfer(payload.payer, refund0);
+        if (refund1 > 0) token1.safeTransfer(payload.payer, refund1);
+
+        // 7. TVL cap — enforce against the token0-notional contribution.
+        // v1.0 uses amount0Used as the proxy; a more sophisticated notional
+        // (oracle-priced) lands in a follow-up.
+        if (amount0Used > tvlCap) revert Errors.TVLCapExceeded(amount0Used, tvlCap);
+
+        // 8. Compute + mint shares.
+        uint256 supply = totalSupply();
+        uint256 shares;
+        if (supply == 0) {
+            // First deposit: shares = sqrt(a0 * a1) - MIN_SHARES; MIN_SHARES
+            // burned to DEAD per PRD §13 inflation-attack guard.
+            uint256 product = amount0Used * amount1Used;
+            shares = Math.sqrt(product);
+            if (shares <= MIN_SHARES) revert Errors.ZeroShares();
+            shares -= MIN_SHARES;
+            _mint(DEAD, MIN_SHARES);
+        } else {
+            // Subsequent deposit: shares proportional to existing TVL share.
+            // We use the dominant-token contribution to avoid divide-by-zero
+            // when one side is empty mid-rebalance.
+            uint256 share0 = amount0Used > 0 ? Math.mulDiv(amount0Used, supply, _tvlToken0Estimate()) : 0;
+            uint256 share1 = amount1Used > 0 ? Math.mulDiv(amount1Used, supply, _tvlToken1Estimate()) : 0;
+            shares = share0 < share1 || share1 == 0 ? share0 : share1;
+            if (shares == 0) revert Errors.ZeroShares();
+        }
+        _mint(payload.to, shares);
+
+        return abi.encode(shares, amount0Used, amount1Used);
+    }
+
+    /// @dev Estimate of the vault's total token0 holdings — idle balance
+    ///      plus the position-equivalent value at the current pool price.
+    ///      Used only for share-pricing on subsequent deposits. Full
+    ///      multi-position aggregation lands in #30.
+    function _tvlToken0Estimate() internal view returns (uint256) {
+        return token0.balanceOf(address(this));
+    }
+
+    /// @dev Estimate of the vault's total token1 holdings (see token0).
+    function _tvlToken1Estimate() internal view returns (uint256) {
+        return token1.balanceOf(address(this));
     }
 
     /// @inheritdoc IVault

--- a/packages/contracts/src/libraries/PositionLib.sol
+++ b/packages/contracts/src/libraries/PositionLib.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {SqrtPriceMath} from "v4-core/libraries/SqrtPriceMath.sol";
+import {TickMath} from "v4-core/libraries/TickMath.sol";
+import {LiquidityAmounts} from "v4-periphery/libraries/LiquidityAmounts.sol";
+
+import {Errors} from "../utils/Errors.sol";
+
+/// @title PositionLib
+/// @notice Tick-range validation and liquidity ↔ amount conversions
+///         shared across `Vault`, `IStrategy` implementations, and the
+///         off-chain keeper simulation.
+/// @dev Wraps `v4-core` (`TickMath`, `SqrtPriceMath`) and `v4-periphery`
+///      (`LiquidityAmounts`) with a thin PRISM-specific surface:
+///        - tick ranges are aligned to the pool's `tickSpacing` and
+///          clamped to `[minUsableTick, maxUsableTick]`.
+///        - reverts use the canonical `Errors.InvalidTickRange`
+///          selector instead of inline strings.
+///        - amount-aggregation helpers operate on the `Position` shape
+///          the vault and the IVault interface use.
+///
+///      Pure library — no mutable storage, no external calls.
+library PositionLib {
+    /// @notice Validate a tick range against the pool's `tickSpacing`
+    ///         and the absolute V4 bounds.
+    /// @dev Reverts with `Errors.InvalidTickRange(lower, upper)` when:
+    ///        - `lower >= upper` (zero or inverted range), OR
+    ///        - either tick is not a multiple of `tickSpacing`, OR
+    ///        - either tick is outside `[minUsableTick, maxUsableTick]`
+    ///          for the supplied `tickSpacing`. The bounds collapse the
+    ///          ABI-level [`MIN_TICK`, `MAX_TICK`] into the largest
+    ///          range the pool can legally expose at the given spacing.
+    /// @param tickLower Lower tick of the position.
+    /// @param tickUpper Upper tick of the position.
+    /// @param tickSpacing Pool's tick spacing (per `PoolKey`).
+    function validateRange(int24 tickLower, int24 tickUpper, int24 tickSpacing) internal pure {
+        if (tickLower >= tickUpper) revert Errors.InvalidTickRange(tickLower, tickUpper);
+
+        if (tickLower % tickSpacing != 0 || tickUpper % tickSpacing != 0) {
+            revert Errors.InvalidTickRange(tickLower, tickUpper);
+        }
+
+        int24 minUsable = TickMath.minUsableTick(tickSpacing);
+        int24 maxUsable = TickMath.maxUsableTick(tickSpacing);
+        if (tickLower < minUsable || tickUpper > maxUsable) {
+            revert Errors.InvalidTickRange(tickLower, tickUpper);
+        }
+    }
+
+    /// @notice Round a tick down to the nearest multiple of
+    ///         `tickSpacing` while staying within usable bounds.
+    /// @dev Useful when a strategy expresses its target as a continuous
+    ///      drift band and the vault must snap to legal ticks before
+    ///      handing positions to the PoolManager. Negative ticks round
+    ///      *down* (toward `-infinity`), matching V4's semantics for
+    ///      `tickLower` placement.
+    /// @param tick Raw tick value.
+    /// @param tickSpacing Pool's tick spacing.
+    /// @return aligned `tick` rounded down to a `tickSpacing` multiple
+    ///         and clamped into `[minUsableTick, maxUsableTick]`.
+    function alignDown(int24 tick, int24 tickSpacing) internal pure returns (int24 aligned) {
+        int24 minUsable = TickMath.minUsableTick(tickSpacing);
+        int24 maxUsable = TickMath.maxUsableTick(tickSpacing);
+
+        // Clamp first — keeps subsequent arithmetic inside int24's
+        // representable range even for adversarial tick inputs.
+        if (tick < minUsable) return minUsable;
+        if (tick > maxUsable) return maxUsable;
+
+        // Solidity floor division for negatives rounds toward zero;
+        // adjust manually to round toward -infinity (V4 lower-tick
+        // semantics) when the remainder is non-zero.
+        int24 remainder = tick % tickSpacing;
+        if (remainder != 0 && tick < 0) {
+            aligned = tick - remainder - tickSpacing;
+        } else {
+            aligned = tick - remainder;
+        }
+
+        // After alignment a negative tick may sit one spacing below
+        // minUsable; clamp the tail.
+        if (aligned < minUsable) aligned = minUsable;
+        if (aligned > maxUsable) aligned = maxUsable;
+    }
+
+    /// @notice Compute the maximum liquidity a position can host given
+    ///         the current pool sqrt-price and the desired token
+    ///         amounts.
+    /// @dev Wraps `LiquidityAmounts.getLiquidityForAmounts`. Validates
+    ///      the tick range first; reverts via `Errors.InvalidTickRange`
+    ///      on malformed input. Returns the smaller of the two
+    ///      single-side liquidity amounts when the current price sits
+    ///      inside the range.
+    /// @param sqrtPriceX96 Current pool sqrt-price (Q64.96).
+    /// @param tickLower Lower tick of the position.
+    /// @param tickUpper Upper tick of the position.
+    /// @param tickSpacing Pool's tick spacing.
+    /// @param amount0 Available token0.
+    /// @param amount1 Available token1.
+    /// @return liquidity Maximum V4 liquidity units the position can host.
+    function liquidityForAmounts(
+        uint160 sqrtPriceX96,
+        int24 tickLower,
+        int24 tickUpper,
+        int24 tickSpacing,
+        uint256 amount0,
+        uint256 amount1
+    )
+        internal
+        pure
+        returns (uint128 liquidity)
+    {
+        validateRange(tickLower, tickUpper, tickSpacing);
+        liquidity = LiquidityAmounts.getLiquidityForAmounts(
+            sqrtPriceX96,
+            TickMath.getSqrtPriceAtTick(tickLower),
+            TickMath.getSqrtPriceAtTick(tickUpper),
+            amount0,
+            amount1
+        );
+    }
+
+    /// @notice Compute token0 / token1 amounts represented by a given
+    ///         liquidity amount in a tick range at the current pool
+    ///         sqrt-price.
+    /// @dev Reproduces the V3 / V4 piecewise formula:
+    ///        - price ≤ lower → all amount0
+    ///        - price ≥ upper → all amount1
+    ///        - in-range      → mixed
+    ///      Used for `getTotalAmounts` and for slippage-bound
+    ///      computation on rebalance.
+    /// @param sqrtPriceX96 Current pool sqrt-price (Q64.96).
+    /// @param tickLower Lower tick of the position.
+    /// @param tickUpper Upper tick of the position.
+    /// @param tickSpacing Pool's tick spacing.
+    /// @param liquidity V4 liquidity units in the position.
+    /// @return amount0 Token0 representation of the position's value.
+    /// @return amount1 Token1 representation of the position's value.
+    function amountsForLiquidity(
+        uint160 sqrtPriceX96,
+        int24 tickLower,
+        int24 tickUpper,
+        int24 tickSpacing,
+        uint128 liquidity
+    )
+        internal
+        pure
+        returns (uint256 amount0, uint256 amount1)
+    {
+        validateRange(tickLower, tickUpper, tickSpacing);
+        uint160 sqrtA = TickMath.getSqrtPriceAtTick(tickLower);
+        uint160 sqrtB = TickMath.getSqrtPriceAtTick(tickUpper);
+
+        if (sqrtPriceX96 <= sqrtA) {
+            amount0 = SqrtPriceMath.getAmount0Delta(sqrtA, sqrtB, liquidity, false);
+        } else if (sqrtPriceX96 >= sqrtB) {
+            amount1 = SqrtPriceMath.getAmount1Delta(sqrtA, sqrtB, liquidity, false);
+        } else {
+            amount0 = SqrtPriceMath.getAmount0Delta(sqrtPriceX96, sqrtB, liquidity, false);
+            amount1 = SqrtPriceMath.getAmount1Delta(sqrtA, sqrtPriceX96, liquidity, false);
+        }
+    }
+}

--- a/packages/contracts/test/core/Vault.t.sol
+++ b/packages/contracts/test/core/Vault.t.sol
@@ -3,15 +3,80 @@ pragma solidity 0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import {IExtsload} from "v4-core/interfaces/IExtsload.sol";
 import {IHooks} from "v4-core/interfaces/IHooks.sol";
 import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {BalanceDelta, toBalanceDelta} from "v4-core/types/BalanceDelta.sol";
 import {Currency} from "v4-core/types/Currency.sol";
+import {PoolId} from "v4-core/types/PoolId.sol";
 import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {ModifyLiquidityParams} from "v4-core/types/PoolOperation.sol";
 
 import {Vault} from "../../src/core/Vault.sol";
 import {IProtocolHook} from "../../src/interfaces/IProtocolHook.sol";
 import {IStrategy} from "../../src/interfaces/IStrategy.sol";
 import {Errors} from "../../src/utils/Errors.sol";
+
+/// Minimal ERC20 used by the deposit-body tests so the vault can run
+/// real `safeTransferFrom` / `safeTransfer` against funded balances.
+contract MockERC20 is ERC20 {
+    constructor(string memory n, string memory s) ERC20(n, s) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+/// Stub strategy that returns a single tick range with weight 10_000.
+contract MockStrategy is IStrategy {
+    int24 public lowerTick;
+    int24 public upperTick;
+    bool public misbehave;
+    uint256 public extraPositions;
+
+    function set(int24 l, int24 u) external {
+        lowerTick = l;
+        upperTick = u;
+    }
+
+    function setMisbehave(bool m) external {
+        misbehave = m;
+    }
+
+    function setExtraPositions(uint256 n) external {
+        extraPositions = n;
+    }
+
+    function computePositions(
+        int24, /* currentTick */
+        int24, /* tickSpacing */
+        uint256, /* amount0 */
+        uint256 /* amount1 */
+    )
+        external
+        view
+        override
+        returns (TargetPosition[] memory)
+    {
+        if (extraPositions > 0) {
+            TargetPosition[] memory many = new TargetPosition[](extraPositions);
+            for (uint256 i = 0; i < extraPositions; i++) {
+                many[i] = TargetPosition({tickLower: lowerTick, tickUpper: upperTick, weight: 1});
+            }
+            return many;
+        }
+        TargetPosition[] memory ps = new TargetPosition[](1);
+        ps[0] = TargetPosition({tickLower: lowerTick, tickUpper: upperTick, weight: misbehave ? 9999 : 10_000});
+        return ps;
+    }
+
+    function shouldRebalance(int24, int24, uint256) external pure override returns (bool) {
+        return false;
+    }
+}
 
 contract VaultStorageTest is Test {
     address constant POOL_MANAGER = address(0xCa11);
@@ -245,5 +310,206 @@ contract VaultStorageTest is Test {
     function test_erc20_transfer_zeroBalance() public {
         vm.expectRevert();
         vault.transfer(address(0x9999), 1);
+    }
+}
+
+// =============================================================================
+// VaultDepositTest — exercises _handleDeposit against mock ERC20s and a
+// mocked PoolManager. Slot0 / unlock / modifyLiquidity / settle / take /
+// sync are all faked via vm.mockCall so the test runs without bringing
+// up a real PoolManager.
+// =============================================================================
+
+contract VaultDepositTest is Test {
+    address constant HOOK = address(0xB00C);
+    address constant OWNER = address(0xACE);
+    address constant DEAD = 0x000000000000000000000000000000000000dEaD;
+
+    /// Sqrt-price for tick 0 — produces equal-weighted token0/token1.
+    uint160 constant SQRT_PRICE_TICK_0 = 79_228_162_514_264_337_593_543_950_336;
+
+    uint256 constant TVL_CAP = 1_000_000e18;
+
+    Vault vault;
+    MockERC20 token0;
+    MockERC20 token1;
+    MockStrategy strategy;
+    MockPoolManager pool;
+    PoolKey key;
+
+    function setUp() public {
+        // Deterministic order: token0 < token1.
+        token0 = new MockERC20("Token0", "TK0");
+        token1 = new MockERC20("Token1", "TK1");
+        if (uint160(address(token1)) < uint160(address(token0))) {
+            (token0, token1) = (token1, token0);
+        }
+
+        strategy = new MockStrategy();
+        strategy.set(-600, 600);
+        pool = new MockPoolManager();
+
+        key = PoolKey({
+            currency0: Currency.wrap(address(token0)),
+            currency1: Currency.wrap(address(token1)),
+            fee: 0x800000,
+            tickSpacing: 60,
+            hooks: IHooks(HOOK)
+        });
+
+        vault = new Vault(
+            IPoolManager(address(pool)),
+            key,
+            IStrategy(address(strategy)),
+            IProtocolHook(HOOK),
+            OWNER,
+            TVL_CAP,
+            "v",
+            "v"
+        );
+
+        _mockSlot0(0);
+    }
+
+    function test_deposit_firstDepositMintsSharesAndBurnsMin() public {
+        uint256 a0 = 10e18;
+        uint256 a1 = 10e18;
+        token0.mint(address(this), a0);
+        token1.mint(address(this), a1);
+        token0.approve(address(vault), a0);
+        token1.approve(address(vault), a1);
+
+        // Mock the modifyLiquidity call: vault owes 9e18 / 9e18 (90% of desired,
+        // 10% refunded as if liquidity didn't fully consume).
+        pool.setDelta(int128(-9e18), int128(-9e18));
+
+        (uint256 shares, uint256 amt0, uint256 amt1) = vault.deposit(a0, a1, 1, 1, address(this));
+
+        assertEq(amt0, 9e18, "amt0 used");
+        assertEq(amt1, 9e18, "amt1 used");
+
+        // First-deposit shares = sqrt(9e18 * 9e18) - MIN_SHARES = 9e18 - 1000.
+        uint256 expectedShares = Math.sqrt(uint256(9e18) * uint256(9e18)) - 1000;
+        assertEq(shares, expectedShares, "shares");
+        assertEq(vault.balanceOf(address(this)), expectedShares, "shares minted to depositor");
+        assertEq(vault.balanceOf(DEAD), 1000, "MIN_SHARES burn");
+
+        // Refund — depositor should hold the unused 1e18 of each token back.
+        assertEq(token0.balanceOf(address(this)), 1e18, "refund0");
+        assertEq(token1.balanceOf(address(this)), 1e18, "refund1");
+
+        // Position recorded.
+        Vault.Position[] memory positions = vault.getPositions();
+        assertEq(positions.length, 1, "position count");
+        assertEq(positions[0].tickLower, -600, "tickLower");
+        assertEq(positions[0].tickUpper, 600, "tickUpper");
+    }
+
+    function test_deposit_revertsOnSlippage() public {
+        token0.mint(address(this), 10e18);
+        token1.mint(address(this), 10e18);
+        token0.approve(address(vault), 10e18);
+        token1.approve(address(vault), 10e18);
+
+        // Mock so the strategy actually consumes only 1e18 of each — well
+        // under the user-supplied min of 5e18.
+        pool.setDelta(int128(-1e18), int128(-1e18));
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.SlippageExceeded.selector, 1e18, 5e18));
+        vault.deposit(10e18, 10e18, 5e18, 5e18, address(this));
+    }
+
+    function test_deposit_revertsOnBadStrategyWeights() public {
+        token0.mint(address(this), 10e18);
+        token1.mint(address(this), 10e18);
+        token0.approve(address(vault), 10e18);
+        token1.approve(address(vault), 10e18);
+
+        strategy.setMisbehave(true); // weight = 9_999 instead of 10_000
+
+        pool.setDelta(int128(-9e18), int128(-9e18));
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.WeightsDoNotSum.selector, 9999));
+        vault.deposit(10e18, 10e18, 0, 0, address(this));
+    }
+
+    function test_deposit_revertsOnTooManyPositions() public {
+        token0.mint(address(this), 10e18);
+        token1.mint(address(this), 10e18);
+        token0.approve(address(vault), 10e18);
+        token1.approve(address(vault), 10e18);
+
+        // Strategy returns MAX_POSITIONS + 1 = 8 positions.
+        strategy.setExtraPositions(8);
+
+        pool.setDelta(int128(-1), int128(-1));
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.MaxPositionsExceeded.selector, 8));
+        vault.deposit(10e18, 10e18, 0, 0, address(this));
+    }
+
+    // -------------------------------------------------------------------------
+    // Mock helpers
+    // -------------------------------------------------------------------------
+
+    /// Pre-pack slot0 (sqrtPriceX96 + tick) on the mock pool so the
+    /// vault's StateLibrary.getSlot0 call returns the expected values.
+    function _mockSlot0(int24 tick) internal {
+        bytes32 slot0 = bytes32(uint256(SQRT_PRICE_TICK_0)) | bytes32(uint256(uint24(tick)) << 160);
+        pool.setSlot0(slot0);
+    }
+}
+
+/// Minimal PoolManager stand-in for the deposit-body unit tests. Real
+/// PoolManager flow (modifyLiquidity → settle/take/sync) is exercised
+/// against Base Sepolia in the fork tests (#42); here we only need
+/// enough surface to drive the unlock callback.
+///
+/// The mock returns a configurable BalanceDelta from `modifyLiquidity`
+/// and treats settle/take/sync as no-ops. `unlock` invokes
+/// `IUnlockCallback.unlockCallback` on the caller — matching the V4
+/// reentrancy pattern.
+import {IUnlockCallback} from "v4-core/interfaces/callback/IUnlockCallback.sol";
+
+contract MockPoolManager {
+    BalanceDelta public mockedDelta;
+    bytes public lastUnlockData;
+    bytes32 public lastSlot0;
+
+    function setDelta(int128 d0, int128 d1) external {
+        mockedDelta = toBalanceDelta(d0, d1);
+    }
+
+    function setSlot0(bytes32 slot0) external {
+        lastSlot0 = slot0;
+    }
+
+    function unlock(bytes calldata data) external returns (bytes memory) {
+        lastUnlockData = data;
+        return IUnlockCallback(msg.sender).unlockCallback(data);
+    }
+
+    function modifyLiquidity(
+        PoolKey memory,
+        ModifyLiquidityParams memory,
+        bytes calldata
+    )
+        external
+        view
+        returns (BalanceDelta, BalanceDelta)
+    {
+        return (mockedDelta, BalanceDelta.wrap(0));
+    }
+
+    function sync(Currency) external {}
+
+    function take(Currency, address, uint256) external {}
+
+    function settle() external payable returns (uint256) {
+        return 0;
+    }
+
+    function extsload(bytes32) external view returns (bytes32) {
+        return lastSlot0;
     }
 }

--- a/packages/contracts/test/libraries/PositionLib.t.sol
+++ b/packages/contracts/test/libraries/PositionLib.t.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {SqrtPriceMath} from "v4-core/libraries/SqrtPriceMath.sol";
+import {TickMath} from "v4-core/libraries/TickMath.sol";
+import {LiquidityAmounts} from "v4-periphery/libraries/LiquidityAmounts.sol";
+
+import {PositionLib} from "../../src/libraries/PositionLib.sol";
+import {Errors} from "../../src/utils/Errors.sol";
+
+/// @notice Behaviour + fuzz tests for `PositionLib`.
+contract PositionLibTest is Test {
+    int24 internal constant SPACING_LOW = 10; // 0.05% pool
+    int24 internal constant SPACING_MED = 60; // 0.30% pool
+
+    // -------------------------------------------------------------------------
+    // validateRange — happy path
+    // -------------------------------------------------------------------------
+
+    function test_validateRange_aligned() external pure {
+        PositionLib.validateRange(-60, 60, SPACING_MED);
+        PositionLib.validateRange(-120, 120, SPACING_MED);
+        PositionLib.validateRange(0, SPACING_LOW, SPACING_LOW);
+    }
+
+    function test_validateRange_atUsableExtremes() external pure {
+        int24 minU = TickMath.minUsableTick(SPACING_MED);
+        int24 maxU = TickMath.maxUsableTick(SPACING_MED);
+        PositionLib.validateRange(minU, maxU, SPACING_MED);
+    }
+
+    // -------------------------------------------------------------------------
+    // validateRange — reverts
+    // -------------------------------------------------------------------------
+
+    function test_validateRange_invertedReverts() external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(60), int24(-60)));
+        PositionLib.validateRange(60, -60, SPACING_MED);
+    }
+
+    function test_validateRange_zeroWidthReverts() external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(60), int24(60)));
+        PositionLib.validateRange(60, 60, SPACING_MED);
+    }
+
+    function test_validateRange_misalignedLowerReverts() external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(57), int24(60)));
+        PositionLib.validateRange(57, 60, SPACING_MED);
+    }
+
+    function test_validateRange_misalignedUpperReverts() external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(60), int24(73)));
+        PositionLib.validateRange(60, 73, SPACING_MED);
+    }
+
+    function test_validateRange_belowMinUsableReverts() external {
+        int24 minU = TickMath.minUsableTick(SPACING_MED);
+        // One spacing past the boundary is not usable.
+        int24 below = minU - SPACING_MED;
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, below, int24(0)));
+        PositionLib.validateRange(below, 0, SPACING_MED);
+    }
+
+    function test_validateRange_aboveMaxUsableReverts() external {
+        int24 maxU = TickMath.maxUsableTick(SPACING_MED);
+        int24 above = maxU + SPACING_MED;
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(0), above));
+        PositionLib.validateRange(0, above, SPACING_MED);
+    }
+
+    // -------------------------------------------------------------------------
+    // alignDown
+    // -------------------------------------------------------------------------
+
+    function test_alignDown_alreadyAligned() external pure {
+        assertEq(int256(PositionLib.alignDown(60, SPACING_MED)), int256(60));
+        assertEq(int256(PositionLib.alignDown(0, SPACING_MED)), int256(0));
+        assertEq(int256(PositionLib.alignDown(-60, SPACING_MED)), int256(-60));
+    }
+
+    function test_alignDown_positiveRoundsToward0() external pure {
+        // 73 → 60 (drop the 13 remainder).
+        assertEq(int256(PositionLib.alignDown(73, SPACING_MED)), int256(60));
+    }
+
+    function test_alignDown_negativeRoundsTowardNegInf() external pure {
+        // -73 → -120 (V4 lower-tick semantics: round toward -infinity).
+        assertEq(int256(PositionLib.alignDown(-73, SPACING_MED)), int256(-120));
+    }
+
+    function test_alignDown_clampsToMinUsable() external pure {
+        int24 minU = TickMath.minUsableTick(SPACING_MED);
+        // A tick below the usable region is clamped, not rejected (this
+        // helper does not revert — `validateRange` does).
+        assertEq(int256(PositionLib.alignDown(minU - 5000, SPACING_MED)), int256(minU));
+    }
+
+    function test_alignDown_clampsToMaxUsable() external pure {
+        int24 maxU = TickMath.maxUsableTick(SPACING_MED);
+        int24 raw = maxU + 1000;
+        int24 aligned = PositionLib.alignDown(raw, SPACING_MED);
+        // Must be ≤ maxUsable.
+        assertLe(int256(aligned), int256(maxU));
+    }
+
+    // -------------------------------------------------------------------------
+    // liquidityForAmounts — round-trip vs amountsForLiquidity
+    // -------------------------------------------------------------------------
+
+    /// @dev Sanity round-trip: deposit `amount0` + `amount1` into a
+    ///      position centered around the current tick, then verify
+    ///      `amountsForLiquidity(L)` returns numbers ≤ the originals
+    ///      (rounding always favours the pool — never gives the LP
+    ///      more than they put in).
+    function test_roundTrip_amountsForLiquidity_doesNotInflate() external pure {
+        int24 currentTick = 0;
+        uint160 sqrtPriceX96 = TickMath.getSqrtPriceAtTick(currentTick);
+        int24 tickLower = -120;
+        int24 tickUpper = 120;
+        uint256 amount0 = 1e18;
+        uint256 amount1 = 2000e6; // ETH/USDC-ish ratio
+
+        uint128 liquidity =
+            PositionLib.liquidityForAmounts(sqrtPriceX96, tickLower, tickUpper, SPACING_MED, amount0, amount1);
+        (uint256 a0, uint256 a1) =
+            PositionLib.amountsForLiquidity(sqrtPriceX96, tickLower, tickUpper, SPACING_MED, liquidity);
+
+        assertLe(a0, amount0);
+        assertLe(a1, amount1);
+    }
+
+    function test_amountsForLiquidity_priceBelowRange_isAllToken0() external pure {
+        int24 tickLower = 60;
+        int24 tickUpper = 180;
+        uint160 sqrtPriceX96 = TickMath.getSqrtPriceAtTick(0); // below tickLower
+        (uint256 a0, uint256 a1) =
+            PositionLib.amountsForLiquidity(sqrtPriceX96, tickLower, tickUpper, SPACING_MED, 1_000_000);
+        assertGt(a0, 0);
+        assertEq(a1, 0);
+    }
+
+    function test_amountsForLiquidity_priceAboveRange_isAllToken1() external pure {
+        int24 tickLower = -180;
+        int24 tickUpper = -60;
+        uint160 sqrtPriceX96 = TickMath.getSqrtPriceAtTick(0); // above tickUpper
+        (uint256 a0, uint256 a1) =
+            PositionLib.amountsForLiquidity(sqrtPriceX96, tickLower, tickUpper, SPACING_MED, 1_000_000);
+        assertEq(a0, 0);
+        assertGt(a1, 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Fuzz near tick extremes
+    // -------------------------------------------------------------------------
+
+    /// @dev Prove `validateRange` accepts every aligned, in-bounds pair.
+    function testFuzz_validateRange_acceptsAlignedInBounds(int24 lower, int24 upper) external pure {
+        int24 minU = TickMath.minUsableTick(SPACING_MED);
+        int24 maxU = TickMath.maxUsableTick(SPACING_MED);
+
+        // Constrain to the legal grid: aligned and within usable range.
+        lower = int24(bound(int256(lower), int256(minU) / SPACING_MED, int256(maxU) / SPACING_MED - 1)) * SPACING_MED;
+        upper = int24(bound(int256(upper), int256(lower) / SPACING_MED + 1, int256(maxU) / SPACING_MED)) * SPACING_MED;
+
+        PositionLib.validateRange(lower, upper, SPACING_MED);
+    }
+
+    /// @dev For deposit amounts in a realistic envelope (≤ 1e24 — about
+    ///      1M whole 18-decimal tokens, 1 quintillion of a 6-decimal
+    ///      token), and a tick window of at least 100 spacings centred
+    ///      on the current price, `liquidityForAmounts` followed by
+    ///      `amountsForLiquidity` does not revert across the usable
+    ///      grid. Adversarial combinations (huge amounts in razor-thin
+    ///      ranges at extreme ticks) can overflow V4's uint128 cast —
+    ///      that is documented v4-periphery behaviour, not a
+    ///      `PositionLib` bug.
+    function testFuzz_alignDown_alwaysAlignedInBounds(int24 raw, int24 spacing) external pure {
+        // Spacing must be in V4's permitted range.
+        spacing = int24(bound(int256(spacing), 1, int256(TickMath.MAX_TICK_SPACING)));
+
+        int24 aligned = PositionLib.alignDown(raw, spacing);
+
+        // Aligned to spacing.
+        assertEq(aligned % spacing, 0);
+
+        // Inside usable bounds.
+        assertGe(int256(aligned), int256(TickMath.minUsableTick(spacing)));
+        assertLe(int256(aligned), int256(TickMath.maxUsableTick(spacing)));
+    }
+}


### PR DESCRIPTION
## Summary

Fills the \`_handleDeposit\` unlock-callback body that #174 / #27 left as
a revert. Reads pool slot0 via \`StateLibrary.getSlot0\`, asks the
strategy for the target shape, deploys each target via
\`poolManager.modifyLiquidity\`, settles the aggregate negative delta,
refunds the unused desired amount, and mints shares (with first-deposit
\`MIN_SHARES\` burn per PRD §13).

- Cherry-picks PositionLib (#22) for \`liquidityForAmounts\`.
- Validates strategy output (weight sum, position count).
- Slippage-bounded via \`amount0Min\` / \`amount1Min\`.
- TVL cap enforced against \`amount0Used\` as the v1.0 notional proxy.
- Subsequent deposits mint pro-rata against existing TVL using the
  more-conservative side.

## Quality gates

- \`forge build\` clean
- \`forge test\` — 102/102 passing (4 new deposit-body integration tests)
- \`forge fmt --check\` clean

## Test plan

- [x] First deposit mints shares = sqrt(a0*a1) - MIN_SHARES, burns 1000 to DEAD
- [x] Refunds the unused portion of \`amountXDesired\`
- [x] Rejects below-min slippage with \`SlippageExceeded\`
- [x] Rejects malformed strategy weight sum with \`WeightsDoNotSum\`
- [x] Rejects more than \`MAX_POSITIONS\` shapes
- [x] Position recorded in \`_positions\`
- [ ] Full deposit→rebalance→withdraw flow on a real pool (lands with #42)

## Dependencies / merge order

Stacks on \`contracts/27-vault-deposit\` (#174). Cherry-picks PositionLib
(#22 / #145) so the diff reviews as a single integration. Both must
land before this PR can merge.

## Notes

The mocked-PoolManager test surface is intentionally shallow — it
verifies dispatch + share math, not the full V4 settle/take dance. The
fork suite (#42) carries the heavy verification against a real
\`PoolManager\` on Base Sepolia.