### PR TITLE
feat(keeper): poll loop — enumerate vaults + evaluate shouldRebalance

### DIFF
--- a/apps/keeper/.env.example
+++ b/apps/keeper/.env.example
@@ -8,6 +8,10 @@ KEEPER_PRIVATE_KEY=0x00000000000000000000000000000000000000000000000000000000000
 # Required: VaultFactory address on Base Sepolia (set after #64 deploy).
 VAULT_FACTORY_ADDRESS=0x0000000000000000000000000000000000000000
 
+# Required: V4 PoolManager on Base Sepolia. Read once per cycle per
+# vault for slot0 (sqrtPriceX96 + tick).
+POOL_MANAGER_ADDRESS=0x0000000000000000000000000000000000000000
+
 # Optional: poll interval in milliseconds. Default 30_000 (30s).
 POLL_INTERVAL_MS=30000
 

--- a/apps/keeper/src/abi.ts
+++ b/apps/keeper/src/abi.ts
@@ -1,0 +1,89 @@
+// Inline ABI fragments the keeper depends on. The full typed ABIs land
+// once #46 (scripts/export-abis.ts) is wired; until then we define only
+// the surface this package needs so viem can infer return types.
+
+export const vaultFactoryAbi = [
+  {
+    type: "function",
+    name: "allVaults",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{name: "", type: "address[]"}],
+  },
+] as const;
+
+export const vaultAbi = [
+  {
+    type: "function",
+    name: "strategy",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{name: "", type: "address"}],
+  },
+  {
+    type: "function",
+    name: "poolKey",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "tuple",
+        components: [
+          {name: "currency0", type: "address"},
+          {name: "currency1", type: "address"},
+          {name: "fee", type: "uint24"},
+          {name: "tickSpacing", type: "int24"},
+          {name: "hooks", type: "address"},
+        ],
+      },
+    ],
+  },
+  {
+    type: "function",
+    name: "rebalance",
+    stateMutability: "nonpayable",
+    inputs: [],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "lastRebalanceTick",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{name: "", type: "int24"}],
+  },
+  {
+    type: "function",
+    name: "lastRebalanceTimestamp",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{name: "", type: "uint256"}],
+  },
+] as const;
+
+export const strategyAbi = [
+  {
+    type: "function",
+    name: "shouldRebalance",
+    stateMutability: "view",
+    inputs: [
+      {name: "currentTick", type: "int24"},
+      {name: "lastRebalanceTick", type: "int24"},
+      {name: "lastRebalanceTimestamp", type: "uint256"},
+    ],
+    outputs: [{name: "", type: "bool"}],
+  },
+] as const;
+
+// PoolManager.extsload(bytes32) — used to read slot0 (sqrtPriceX96 + tick)
+// without pulling StateView/StateLibrary into the keeper's bundle.
+export const poolManagerExtsloadAbi = [
+  {
+    type: "function",
+    name: "extsload",
+    stateMutability: "view",
+    inputs: [{name: "slot", type: "bytes32"}],
+    outputs: [{name: "", type: "bytes32"}],
+  },
+] as const;

--- a/apps/keeper/src/config.ts
+++ b/apps/keeper/src/config.ts
@@ -8,6 +8,9 @@ const envSchema = z.object({
   VAULT_FACTORY_ADDRESS: z
     .string()
     .regex(/^0x[a-fA-F0-9]{40}$/, "VAULT_FACTORY_ADDRESS must be a 0x-prefixed address"),
+  POOL_MANAGER_ADDRESS: z
+    .string()
+    .regex(/^0x[a-fA-F0-9]{40}$/, "POOL_MANAGER_ADDRESS must be a 0x-prefixed address"),
   POLL_INTERVAL_MS: z.coerce.number().int().positive().default(30_000),
   MAX_GAS_PRICE_GWEI: z.coerce.number().int().positive().default(10),
   LOG_LEVEL: z

--- a/apps/keeper/src/index.ts
+++ b/apps/keeper/src/index.ts
@@ -1,9 +1,10 @@
-import {createPublicClient, createWalletClient, http} from "viem";
+import {createPublicClient, createWalletClient, http, type Address} from "viem";
 import {privateKeyToAccount} from "viem/accounts";
 import {baseSepolia} from "viem/chains";
 import pino from "pino";
 
 import {loadConfig} from "./config.js";
+import {runPollLoop} from "./poll.js";
 
 async function main() {
   const config = loadConfig();
@@ -27,24 +28,32 @@ async function main() {
     {
       keeper: account.address,
       factory: config.VAULT_FACTORY_ADDRESS,
+      poolManager: config.POOL_MANAGER_ADDRESS,
       pollIntervalMs: config.POLL_INTERVAL_MS,
       maxGasPriceGwei: config.MAX_GAS_PRICE_GWEI,
       blockNumber: blockNumber.toString(),
     },
-    "PRISM keeper online — poll loop lands in #56",
+    "PRISM keeper online",
   );
 
-  // #56 wires the actual poll loop: enumerate vaults, evaluate
-  // shouldRebalance per vault, simulate via eth_call (#57), submit
-  // (#58), retry on reprice. Health endpoint + SIGTERM in #60.
-  await new Promise<void>(() => {
-    // park forever; #60 replaces with proper lifecycle.
-    setInterval(() => {
-      logger.debug("keeper alive");
-    }, config.POLL_INTERVAL_MS);
+  const stop = runPollLoop({
+    client: publicClient,
+    factory: config.VAULT_FACTORY_ADDRESS as Address,
+    poolManager: config.POOL_MANAGER_ADDRESS as Address,
+    intervalMs: config.POLL_INTERVAL_MS,
+    logger,
   });
 
-  // Mark walletClient as used so TS doesn't drop it from the bundle.
+  // #58 will replace this park-forever with proper tx submission +
+  // confirmation tracking. #60 adds /health + graceful SIGTERM.
+  await new Promise<void>((resolve) => {
+    process.on("SIGTERM", () => {
+      logger.info("SIGTERM received — draining in-flight cycle");
+      stop().then(resolve);
+    });
+  });
+
+  // Suppress unused-var lint for walletClient — #58 wires it for tx submit.
   void walletClient;
 }
 

--- a/apps/keeper/src/poll.ts
+++ b/apps/keeper/src/poll.ts
@@ -1,0 +1,175 @@
+import type {Address, Hex} from "viem";
+import type {Logger} from "pino";
+
+import {strategyAbi, vaultAbi, vaultFactoryAbi} from "./abi.js";
+import {readSlot0, toPoolId} from "./pool.js";
+
+/// Minimal slice of viem's PublicClient that the poll loop needs. Typing
+/// as a structural slice avoids cross-version PublicClient incompatibilities
+/// when the keeper, shared, and web packages each resolve viem differently.
+export interface ReadClient {
+  readContract: (args: {
+    address: Address;
+    abi: readonly unknown[];
+    functionName: string;
+    args?: readonly unknown[];
+  }) => Promise<unknown>;
+}
+
+export interface VaultEvaluation {
+  vault: Address;
+  poolId: Hex;
+  currentTick: number;
+  shouldRebalance: boolean;
+  reason?: string;
+}
+
+export interface PollDeps {
+  client: ReadClient;
+  factory: Address;
+  poolManager: Address;
+  logger: Logger;
+}
+
+/// One pass of the keeper poll loop.
+///
+/// 1. Fetch the active vault list from `VaultFactory.allVaults`.
+/// 2. Per vault: read pool slot0, the strategy address, and the last
+///    rebalance bookkeeping; ask the strategy `shouldRebalance`.
+/// 3. Return the per-vault evaluation. Submission lands in #58.
+///
+/// Errors per vault are caught + logged so a single bad vault does not
+/// abort the cycle. The cycle itself does not throw.
+export async function evaluateVaults(deps: PollDeps): Promise<VaultEvaluation[]> {
+  const {client, factory, poolManager, logger} = deps;
+
+  const vaults = (await client.readContract({
+    address: factory,
+    abi: vaultFactoryAbi,
+    functionName: "allVaults",
+  })) as readonly Address[];
+
+  const results: VaultEvaluation[] = [];
+  for (const vault of vaults) {
+    try {
+      const evaluation = await evaluateVault({client, poolManager, logger, vault});
+      results.push(evaluation);
+    } catch (err) {
+      logger.warn({vault, err: errMsg(err)}, "vault evaluation failed");
+    }
+  }
+  return results;
+}
+
+interface EvaluateOne {
+  client: ReadClient;
+  poolManager: Address;
+  logger: Logger;
+  vault: Address;
+}
+
+interface PoolKeyOnChain {
+  currency0: Address;
+  currency1: Address;
+  fee: number;
+  tickSpacing: number;
+  hooks: Address;
+}
+
+async function evaluateVault({client, poolManager, logger, vault}: EvaluateOne): Promise<VaultEvaluation> {
+  // Pull pool key + strategy + last-rebalance bookkeeping in parallel —
+  // four reads against the same vault contract.
+  const [poolKey, strategy, lastTick, lastTimestamp] = await Promise.all([
+    client.readContract({address: vault, abi: vaultAbi, functionName: "poolKey"}) as Promise<PoolKeyOnChain>,
+    client.readContract({address: vault, abi: vaultAbi, functionName: "strategy"}) as Promise<Address>,
+    safeRead(client, vault, "lastRebalanceTick", 0),
+    safeRead(client, vault, "lastRebalanceTimestamp", 0n),
+  ]);
+
+  const poolId = toPoolId({
+    currency0: poolKey.currency0,
+    currency1: poolKey.currency1,
+    fee: poolKey.fee,
+    tickSpacing: poolKey.tickSpacing,
+    hooks: poolKey.hooks,
+  });
+
+  const {tick: currentTick} = await readSlot0(client, poolManager, poolId);
+
+  const shouldRebalance = (await client.readContract({
+    address: strategy,
+    abi: strategyAbi,
+    functionName: "shouldRebalance",
+    args: [currentTick, Number(lastTick), BigInt(lastTimestamp)],
+  })) as boolean;
+
+  if (shouldRebalance) {
+    logger.info({vault, currentTick, lastTick, lastTimestamp: lastTimestamp.toString()}, "vault due for rebalance");
+  }
+
+  return {vault, poolId, currentTick, shouldRebalance};
+}
+
+/// Vault scaffold (#26) does not yet expose lastRebalanceTick /
+/// lastRebalanceTimestamp; #29 adds them. Treat a missing function as
+/// "no prior rebalance" rather than aborting the whole cycle.
+async function safeRead<T extends number | bigint>(
+  client: ReadClient,
+  vault: Address,
+  fn: "lastRebalanceTick" | "lastRebalanceTimestamp",
+  fallback: T,
+): Promise<T> {
+  try {
+    const result = await client.readContract({address: vault, abi: vaultAbi, functionName: fn});
+    return result as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function errMsg(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/// Run the poll loop forever with the configured cadence. Returns a
+/// stop function that resolves after the in-flight cycle completes.
+export function runPollLoop(deps: PollDeps & {intervalMs: number}): () => Promise<void> {
+  const {logger, intervalMs} = deps;
+  let stopped = false;
+  let inflight: Promise<void> = Promise.resolve();
+
+  const tick = async (): Promise<void> => {
+    if (stopped) return;
+    const cycleId = Date.now().toString(36);
+    const cycleLogger = logger.child({cycle: cycleId});
+    const start = Date.now();
+    try {
+      const evaluations = await evaluateVaults({...deps, logger: cycleLogger});
+      cycleLogger.info(
+        {
+          vaultCount: evaluations.length,
+          dueCount: evaluations.filter((e) => e.shouldRebalance).length,
+          ms: Date.now() - start,
+        },
+        "poll cycle complete",
+      );
+    } catch (err) {
+      cycleLogger.error({err: errMsg(err), ms: Date.now() - start}, "poll cycle failed");
+    }
+  };
+
+  const schedule = (): void => {
+    if (stopped) return;
+    inflight = tick().finally(() => {
+      if (!stopped) setTimeout(schedule, intervalMs);
+    });
+  };
+
+  schedule();
+
+  return async () => {
+    stopped = true;
+    await inflight;
+  };
+}

--- a/apps/keeper/src/pool.ts
+++ b/apps/keeper/src/pool.ts
@@ -1,0 +1,69 @@
+import {keccak256, encodePacked, type Address, type Hex} from "viem";
+
+import {poolManagerExtsloadAbi} from "./abi.js";
+
+/// Minimal shape of viem's PublicClient we need for slot0 reads.
+export interface ExtsloadClient {
+  readContract: (args: {
+    address: Address;
+    abi: readonly unknown[];
+    functionName: string;
+    args?: readonly unknown[];
+  }) => Promise<unknown>;
+}
+
+/// V4 PoolKey shape — currency0/currency1/fee/tickSpacing/hooks. The
+/// keeper reads this once per vault per cycle and derives the PoolId
+/// off-chain so it can extsload slot0 without an extra round-trip.
+export interface PoolKey {
+  currency0: Address;
+  currency1: Address;
+  fee: number;
+  tickSpacing: number;
+  hooks: Address;
+}
+
+/// Compute the V4 PoolId from a PoolKey. Mirrors `PoolIdLibrary.toId` —
+/// `keccak256(abi.encode(poolKey))`.
+export function toPoolId(key: PoolKey): Hex {
+  return keccak256(
+    encodePacked(
+      ["address", "address", "uint24", "int24", "address"],
+      [key.currency0, key.currency1, key.fee, key.tickSpacing, key.hooks],
+    ),
+  );
+}
+
+/// Compute the storage slot for `pools[poolId]` in PoolManager. PoolManager
+/// declares `pools` at slot 6, and the inner Pool.State value sits at
+/// `keccak256(poolId, 6)`.
+function poolStateSlot(poolId: Hex): Hex {
+  return keccak256(encodePacked(["bytes32", "bytes32"], [poolId, "0x".concat("00".repeat(31), "06") as Hex]));
+}
+
+/// Decode V4 slot0: bottom 160 bits sqrtPriceX96, next 24 bits signed tick.
+export function decodeSlot0(raw: Hex): {sqrtPriceX96: bigint; tick: number} {
+  const value = BigInt(raw);
+  const sqrtPriceX96 = value & ((1n << 160n) - 1n);
+  let tick = Number((value >> 160n) & ((1n << 24n) - 1n));
+  // Sign-extend 24-bit tick.
+  if (tick >= 1 << 23) tick -= 1 << 24;
+  return {sqrtPriceX96, tick};
+}
+
+/// Read the post-swap slot0 for a pool. Single extsload — avoids the
+/// StateView contract and keeps the keeper bundle minimal.
+export async function readSlot0(
+  client: ExtsloadClient,
+  poolManager: Address,
+  poolId: Hex,
+): Promise<{sqrtPriceX96: bigint; tick: number}> {
+  const slot = poolStateSlot(poolId);
+  const raw = (await client.readContract({
+    address: poolManager,
+    abi: poolManagerExtsloadAbi,
+    functionName: "extsload",
+    args: [slot],
+  })) as Hex;
+  return decodeSlot0(raw);
+}


### PR DESCRIPTION
## Summary

Replaces the park-forever stub from #163 / #55 with a 30s-cadence poll
loop. Each cycle enumerates \`VaultFactory.allVaults\`, reads the pool
slot0 via PoolManager extsload, queries the strategy's
\`shouldRebalance\`, and logs the per-cycle vault count + dueCount +
latency.

- Per-vault errors are caught + logged so a single bad vault does not
  abort the cycle.
- Reads slot0 via single extsload — no StateView dependency.
- Last-rebalance bookkeeping reads (\`lastRebalanceTick\`,
  \`lastRebalanceTimestamp\`) are forgiving: a missing accessor on the
  current Vault scaffold (#26) treats as "no prior rebalance" rather
  than aborting.

## Quality gates

- \`pnpm --filter @prism/keeper typecheck\` clean
- \`pnpm --filter @prism/keeper test\` passes (existing placeholder; full keeper unit tests land with #67 / #68)

## Test plan

- [x] Typecheck passes
- [ ] Manual smoke: \`pnpm --filter @prism/keeper dev\` against a local Anvil with #64 deployed (after #184 lands)
- [ ] E2E coverage in #67 / #68

## Dependencies / merge order

Stacks on \`keeper/55-scaffold\` (#163). Sim gate (#57), tx submission
(#58), structured logs (#59), and lifecycle hardening (#60) follow.

## Notes

ABIs are inline fragments in \`src/abi.ts\` until #46 wires the typed
ABIs from Foundry's \`out/\`.