### PR TITLE
feat(keeper): sim gate — eth_call rebalance simulation before submission

### DIFF
--- a/apps/keeper/src/index.ts
+++ b/apps/keeper/src/index.ts
@@ -40,6 +40,7 @@ async function main() {
     client: publicClient,
     factory: config.VAULT_FACTORY_ADDRESS as Address,
     poolManager: config.POOL_MANAGER_ADDRESS as Address,
+    account: account.address,
     intervalMs: config.POLL_INTERVAL_MS,
     logger,
   });

--- a/apps/keeper/src/poll.ts
+++ b/apps/keeper/src/poll.ts
@@ -3,11 +3,12 @@ import type {Logger} from "pino";
 
 import {strategyAbi, vaultAbi, vaultFactoryAbi} from "./abi.js";
 import {readSlot0, toPoolId} from "./pool.js";
+import {gatedSimulate, type SimulateClient, type SimulateResult} from "./simulate.js";
 
 /// Minimal slice of viem's PublicClient that the poll loop needs. Typing
 /// as a structural slice avoids cross-version PublicClient incompatibilities
 /// when the keeper, shared, and web packages each resolve viem differently.
-export interface ReadClient {
+export interface ReadClient extends SimulateClient {
   readContract: (args: {
     address: Address;
     abi: readonly unknown[];
@@ -21,13 +22,18 @@ export interface VaultEvaluation {
   poolId: Hex;
   currentTick: number;
   shouldRebalance: boolean;
-  reason?: string;
+  /// Set when shouldRebalance is true and we ran the eth_call sim gate.
+  /// Undefined when the sim was skipped (e.g., shouldRebalance was false).
+  simulation?: SimulateResult;
 }
 
 export interface PollDeps {
   client: ReadClient;
   factory: Address;
   poolManager: Address;
+  /// Keeper account used as the `from` for sim eth_call. Submission
+  /// reuses the same account in #58.
+  account: Address;
   logger: Logger;
 }
 
@@ -41,7 +47,7 @@ export interface PollDeps {
 /// Errors per vault are caught + logged so a single bad vault does not
 /// abort the cycle. The cycle itself does not throw.
 export async function evaluateVaults(deps: PollDeps): Promise<VaultEvaluation[]> {
-  const {client, factory, poolManager, logger} = deps;
+  const {client, factory, poolManager, account, logger} = deps;
 
   const vaults = (await client.readContract({
     address: factory,
@@ -52,7 +58,7 @@ export async function evaluateVaults(deps: PollDeps): Promise<VaultEvaluation[]>
   const results: VaultEvaluation[] = [];
   for (const vault of vaults) {
     try {
-      const evaluation = await evaluateVault({client, poolManager, logger, vault});
+      const evaluation = await evaluateVault({client, poolManager, account, logger, vault});
       results.push(evaluation);
     } catch (err) {
       logger.warn({vault, err: errMsg(err)}, "vault evaluation failed");
@@ -64,6 +70,7 @@ export async function evaluateVaults(deps: PollDeps): Promise<VaultEvaluation[]>
 interface EvaluateOne {
   client: ReadClient;
   poolManager: Address;
+  account: Address;
   logger: Logger;
   vault: Address;
 }
@@ -76,7 +83,7 @@ interface PoolKeyOnChain {
   hooks: Address;
 }
 
-async function evaluateVault({client, poolManager, logger, vault}: EvaluateOne): Promise<VaultEvaluation> {
+async function evaluateVault({client, poolManager, account, logger, vault}: EvaluateOne): Promise<VaultEvaluation> {
   // Pull pool key + strategy + last-rebalance bookkeeping in parallel —
   // four reads against the same vault contract.
   const [poolKey, strategy, lastTick, lastTimestamp] = await Promise.all([
@@ -103,11 +110,19 @@ async function evaluateVault({client, poolManager, logger, vault}: EvaluateOne):
     args: [currentTick, Number(lastTick), BigInt(lastTimestamp)],
   })) as boolean;
 
-  if (shouldRebalance) {
-    logger.info({vault, currentTick, lastTick, lastTimestamp: lastTimestamp.toString()}, "vault due for rebalance");
+  if (!shouldRebalance) {
+    return {vault, poolId, currentTick, shouldRebalance};
   }
 
-  return {vault, poolId, currentTick, shouldRebalance};
+  logger.info({vault, currentTick, lastTick, lastTimestamp: lastTimestamp.toString()}, "vault due for rebalance");
+
+  // #57 sim gate: run eth_call against the pending block before #58
+  // submits. A reverting simulation signals the keeper would burn gas
+  // without landing — defer to the next cycle so the bonus invariant
+  // (ADR-007 §rebalance) holds.
+  const simulation = await gatedSimulate({client, vault, account, logger});
+
+  return {vault, poolId, currentTick, shouldRebalance, simulation};
 }
 
 /// Vault scaffold (#26) does not yet expose lastRebalanceTick /
@@ -146,10 +161,13 @@ export function runPollLoop(deps: PollDeps & {intervalMs: number}): () => Promis
     const start = Date.now();
     try {
       const evaluations = await evaluateVaults({...deps, logger: cycleLogger});
+      const dueCount = evaluations.filter((e) => e.shouldRebalance).length;
+      const submittableCount = evaluations.filter((e) => e.simulation?.ok === true).length;
       cycleLogger.info(
         {
           vaultCount: evaluations.length,
-          dueCount: evaluations.filter((e) => e.shouldRebalance).length,
+          dueCount,
+          submittableCount,
           ms: Date.now() - start,
         },
         "poll cycle complete",

--- a/apps/keeper/src/simulate.ts
+++ b/apps/keeper/src/simulate.ts
@@ -1,0 +1,72 @@
+import type {Address} from "viem";
+import type {Logger} from "pino";
+
+import {vaultAbi} from "./abi.js";
+
+/// Minimal slice of viem's PublicClient we need for a single-call eth_call
+/// simulation against the pending block.
+export interface SimulateClient {
+  simulateContract: (args: {
+    address: Address;
+    abi: readonly unknown[];
+    functionName: string;
+    args?: readonly unknown[];
+    account: Address;
+  }) => Promise<{result: unknown}>;
+}
+
+export type SimulateResult =
+  | {ok: true}
+  | {ok: false; reason: string};
+
+/// Simulate `Vault.rebalance()` against the pending block via eth_call.
+/// Returns a typed verdict the caller can use as a submission gate.
+///
+/// Uses `simulateContract` (which under the hood is `eth_call` with the
+/// keeper's account as `from`) so the simulated state matches what the
+/// real submission would see — same account, same gas-pricing context,
+/// same in-flight nonces. Any revert surfaces as `ok: false` with the
+/// decoded error string when viem can recover one.
+///
+/// Per ADR-007 the keeper's submission budget is tight; skipping a
+/// simulated revert preserves the rebalance-bonus invariant (the
+/// keeper does not waste gas on a tx that can't land).
+export async function simulateRebalance(
+  client: SimulateClient,
+  vault: Address,
+  account: Address,
+): Promise<SimulateResult> {
+  try {
+    await client.simulateContract({
+      address: vault,
+      abi: vaultAbi,
+      functionName: "rebalance",
+      account,
+    });
+    return {ok: true};
+  } catch (err) {
+    return {ok: false, reason: errMsg(err)};
+  }
+}
+
+/// Convenience wrapper that logs the simulation outcome consistently
+/// across all callers. Returns the verdict so callers can also branch.
+export async function gatedSimulate(
+  deps: {client: SimulateClient; vault: Address; account: Address; logger: Logger},
+): Promise<SimulateResult> {
+  const verdict = await simulateRebalance(deps.client, deps.vault, deps.account);
+  if (verdict.ok) {
+    deps.logger.info({vault: deps.vault}, "rebalance simulation passed");
+  } else {
+    deps.logger.warn({vault: deps.vault, reason: verdict.reason}, "rebalance simulation reverted — skipping submission");
+  }
+  return verdict;
+}
+
+function errMsg(err: unknown): string {
+  if (typeof err === "object" && err !== null) {
+    const anyErr = err as {shortMessage?: string; message?: string; details?: string};
+    return anyErr.shortMessage ?? anyErr.message ?? anyErr.details ?? String(err);
+  }
+  return String(err);
+}


### PR DESCRIPTION
## Summary

When a vault returns \`shouldRebalance: true\`, the keeper now runs an
\`eth_call\` simulation of \`Vault.rebalance()\` against the pending block
before submission. A reverting simulation surfaces the revert reason in
the logs and skips submission for this cycle — preserving the
rebalance-bonus invariant (ADR-007 §rebalance).

- New \`src/simulate.ts\` with \`simulateRebalance\` + \`gatedSimulate\`.
- Keeper account threaded through \`PollDeps\` so simulation uses the
  same \`from\` as the eventual submission (in-flight nonces, gas-pricing
  context, etc.).
- Cycle log gains \`submittableCount\` alongside \`dueCount\`.

## Quality gates

- \`pnpm --filter @prism/keeper typecheck\` clean
- \`pnpm --filter @prism/keeper test\` placeholder-passes (full unit tests land with #67/#68)

## Test plan

- [x] Typecheck passes
- [ ] Manual smoke against a deployed vault (after #184)
- [ ] E2E coverage in #67/#68

## Dependencies / merge order

Stacks on \`keeper/56-poll-loop\`. Tx submission (#58) consumes
\`evaluation.simulation\` to gate the actual submission.