### PR TITLE
feat(contracts): Vault._handleWithdraw body — proportional remove + payout

### DIFF
--- a/packages/contracts/src/core/Vault.sol
+++ b/packages/contracts/src/core/Vault.sol
@@ -4,11 +4,15 @@ pragma solidity 0.8.26;
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
 import {IUnlockCallback} from "v4-core/interfaces/callback/IUnlockCallback.sol";
+import {BalanceDelta, BalanceDeltaLibrary} from "v4-core/types/BalanceDelta.sol";
 import {Currency} from "v4-core/types/Currency.sol";
+import {PoolId, PoolIdLibrary} from "v4-core/types/PoolId.sol";
 import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {ModifyLiquidityParams} from "v4-core/types/PoolOperation.sol";
 
 import {IProtocolHook} from "../interfaces/IProtocolHook.sol";
 import {IStrategy} from "../interfaces/IStrategy.sol";
@@ -48,6 +52,8 @@ import {Errors} from "../utils/Errors.sol";
 ///      mitigates the first-depositor inflation attack (PRD §13).
 contract Vault is IVault, ERC20, IUnlockCallback {
     using SafeERC20 for IERC20;
+    using PoolIdLibrary for PoolKey;
+    using BalanceDeltaLibrary for BalanceDelta;
 
     /// @dev Tagged operations for `unlockCallback`. Each entry point
     ///      (deposit / withdraw / rebalance) calls `poolManager.unlock`
@@ -304,11 +310,76 @@ contract Vault is IVault, ERC20, IUnlockCallback {
         revert Errors.UnknownOp();
     }
 
-    /// @dev Stub: real implementation removes a proportional slice of
-    ///      every position via `modifyLiquidity` with negative liquidity
-    ///      delta, takes both currencies, and transfers to `payload.to`.
-    function _handleWithdraw(WithdrawPayload memory /*payload*/ ) internal pure returns (bytes memory) {
-        revert Errors.UnknownOp();
+    /// @dev Proportional withdraw across every active position.
+    ///
+    ///      Shares were already burned by the external `withdraw` entry
+    ///      point before this callback. The pre-burn supply equals
+    ///      `totalSupply() + payload.shares` — the user's fraction of
+    ///      the vault is `payload.shares / preSupply`. We remove that
+    ///      fraction of liquidity from each position and the same
+    ///      fraction of any idle balance.
+    ///
+    ///      Per ADR-002 + invariant 6, withdraw is never pausable and
+    ///      never reverts on a healthy state. The slippage gate is the
+    ///      one revert path the user can hit.
+    function _handleWithdraw(WithdrawPayload memory payload) internal returns (bytes memory) {
+        uint256 preSupply = totalSupply() + payload.shares;
+
+        // Snapshot idle balance BEFORE removing positions so the
+        // withdrawer's idle slice is computed against pre-withdraw state.
+        uint256 idle0 = token0.balanceOf(address(this));
+        uint256 idle1 = token1.balanceOf(address(this));
+        uint256 idleTake0 = Math.mulDiv(idle0, payload.shares, preSupply);
+        uint256 idleTake1 = Math.mulDiv(idle1, payload.shares, preSupply);
+
+        // Remove the user's proportional liquidity slice from each
+        // position. Track aggregate positive deltas so we can take
+        // the right amount in one settle pass.
+        uint256 owed0;
+        uint256 owed1;
+
+        uint256 n = _positions.length;
+        for (uint256 i = 0; i < n; i++) {
+            Position storage p = _positions[i];
+            uint128 share = uint128(Math.mulDiv(uint256(p.liquidity), payload.shares, preSupply));
+            if (share == 0) continue;
+
+            (BalanceDelta delta,) = poolManager.modifyLiquidity(
+                _poolKey,
+                ModifyLiquidityParams({
+                    tickLower: p.tickLower,
+                    tickUpper: p.tickUpper,
+                    liquidityDelta: -int256(uint256(share)),
+                    salt: bytes32(uint256(i))
+                }),
+                ""
+            );
+
+            int128 d0 = delta.amount0();
+            int128 d1 = delta.amount1();
+            if (d0 > 0) owed0 += uint128(d0);
+            if (d1 > 0) owed1 += uint128(d1);
+
+            p.liquidity = p.liquidity - share;
+        }
+
+        // Take the modifyLiquidity proceeds out of PoolManager. take()
+        // shifts the positive delta into a real balance on the vault.
+        if (owed0 > 0) poolManager.take(_poolKey.currency0, address(this), owed0);
+        if (owed1 > 0) poolManager.take(_poolKey.currency1, address(this), owed1);
+
+        uint256 amount0 = owed0 + idleTake0;
+        uint256 amount1 = owed1 + idleTake1;
+
+        // Slippage gate — the only user-reachable revert in withdraw.
+        if (amount0 < payload.amount0Min) revert Errors.SlippageExceeded(amount0, payload.amount0Min);
+        if (amount1 < payload.amount1Min) revert Errors.SlippageExceeded(amount1, payload.amount1Min);
+
+        // Forward the recovered amounts to the recipient.
+        if (amount0 > 0) token0.safeTransfer(payload.to, amount0);
+        if (amount1 > 0) token1.safeTransfer(payload.to, amount1);
+
+        return abi.encode(amount0, amount1);
     }
 
     /// @inheritdoc IVault

--- a/packages/contracts/test/core/Vault.t.sol
+++ b/packages/contracts/test/core/Vault.t.sol
@@ -3,15 +3,76 @@ pragma solidity 0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
 import {IHooks} from "v4-core/interfaces/IHooks.sol";
 import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {IUnlockCallback} from "v4-core/interfaces/callback/IUnlockCallback.sol";
+import {BalanceDelta, toBalanceDelta} from "v4-core/types/BalanceDelta.sol";
 import {Currency} from "v4-core/types/Currency.sol";
 import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {ModifyLiquidityParams} from "v4-core/types/PoolOperation.sol";
 
 import {Vault} from "../../src/core/Vault.sol";
 import {IProtocolHook} from "../../src/interfaces/IProtocolHook.sol";
 import {IStrategy} from "../../src/interfaces/IStrategy.sol";
 import {Errors} from "../../src/utils/Errors.sol";
+
+/// Minimal ERC20 used by the withdraw-body integration tests.
+contract MockERC20 is ERC20 {
+    constructor(string memory n, string memory s) ERC20(n, s) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+/// Minimal PoolManager stand-in that drives `unlock` straight back into
+/// the caller's `unlockCallback` and returns a configurable
+/// BalanceDelta from `modifyLiquidity`. Real pool flow is exercised in
+/// the fork suite (#42); here we only need enough to drive the
+/// unlock callback shape.
+contract MockPoolManager {
+    BalanceDelta public mockedDelta;
+
+    function setDelta(int128 d0, int128 d1) external {
+        mockedDelta = toBalanceDelta(d0, d1);
+    }
+
+    function unlock(bytes calldata data) external returns (bytes memory) {
+        return IUnlockCallback(msg.sender).unlockCallback(data);
+    }
+
+    function modifyLiquidity(
+        PoolKey memory,
+        ModifyLiquidityParams memory,
+        bytes calldata
+    )
+        external
+        view
+        returns (BalanceDelta, BalanceDelta)
+    {
+        return (mockedDelta, BalanceDelta.wrap(0));
+    }
+
+    /// take() in the real PoolManager transfers from manager to recipient.
+    /// We mirror that here so the vault's post-take balance accounting
+    /// matches production. Tests fund the manager with the tokens they
+    /// expect to be paid out.
+    function take(Currency currency, address to, uint256 amount) external {
+        ERC20(Currency.unwrap(currency)).transfer(to, amount);
+    }
+
+    function settle() external payable returns (uint256) {
+        return 0;
+    }
+
+    function sync(Currency) external {}
+
+    function extsload(bytes32) external pure returns (bytes32) {
+        return bytes32(0);
+    }
+}
 
 contract VaultStorageTest is Test {
     address constant POOL_MANAGER = address(0xCa11);
@@ -269,5 +330,131 @@ contract VaultStorageTest is Test {
     function test_erc20_transfer_zeroBalance() public {
         vm.expectRevert();
         vault.transfer(address(0x9999), 1);
+    }
+}
+
+// =============================================================================
+// VaultWithdrawTest — exercises _handleWithdraw against the mock pool.
+// Withdraw burns shares up-front, so we mint shares directly via deal() to
+// simulate a prior depositor and seed _positions via vm.store.
+// =============================================================================
+
+contract VaultWithdrawTest is Test {
+    address constant HOOK = address(0xB00C);
+    address constant OWNER = address(0xACE);
+
+    uint256 constant TVL_CAP = 1_000_000e18;
+
+    Vault vault;
+    MockERC20 token0;
+    MockERC20 token1;
+    MockPoolManager pool;
+    PoolKey key;
+
+    function setUp() public {
+        token0 = new MockERC20("Token0", "TK0");
+        token1 = new MockERC20("Token1", "TK1");
+        if (uint160(address(token1)) < uint160(address(token0))) {
+            (token0, token1) = (token1, token0);
+        }
+
+        pool = new MockPoolManager();
+        key = PoolKey({
+            currency0: Currency.wrap(address(token0)),
+            currency1: Currency.wrap(address(token1)),
+            fee: 0x800000,
+            tickSpacing: 60,
+            hooks: IHooks(HOOK)
+        });
+
+        vault = new Vault(
+            IPoolManager(address(pool)), key, IStrategy(address(0xBEEF)), IProtocolHook(HOOK), OWNER, TVL_CAP, "v", "v"
+        );
+    }
+
+    function test_withdraw_proportionalRemoveTransfersPayout() public {
+        // Seed: 100 shares total — 90 to alice, 10 to DEAD (MIN_SHARES burn).
+        address alice = address(0xA11CE);
+        deal(address(vault), alice, 90, true);
+        deal(address(vault), 0x000000000000000000000000000000000000dEaD, 10, true);
+        // Single position of 1000 liquidity at [-600, 600].
+        _seedPosition(0, -600, 600, 1000);
+
+        // Vault holds 100 idle of token0, 200 idle of token1 (e.g. fee dust).
+        token0.mint(address(vault), 100);
+        token1.mint(address(vault), 200);
+
+        // modifyLiquidity returns +18 / +27 — alice's 9% liquidity slice (= 90 / 1000).
+        pool.setDelta(int128(18), int128(27));
+        // Manager pre-funded so take() succeeds.
+        token0.mint(address(pool), 18);
+        token1.mint(address(pool), 27);
+
+        vm.prank(alice);
+        (uint256 amount0, uint256 amount1) = vault.withdraw(90, 0, 0, alice);
+
+        // Idle proportional: 90/100 = 90% of idle balance.
+        // owed0 = 18; idleTake0 = 100 * 90 / 100 = 90 → amount0 = 108.
+        // owed1 = 27; idleTake1 = 200 * 90 / 100 = 180 → amount1 = 207.
+        assertEq(amount0, 108, "amount0");
+        assertEq(amount1, 207, "amount1");
+
+        // Recipient received the payout.
+        assertEq(token0.balanceOf(alice), 108, "alice token0");
+        assertEq(token1.balanceOf(alice), 207, "alice token1");
+
+        // Position liquidity reduced by alice's 90% slice (900 of 1000).
+        assertEq(vault.getPositions()[0].liquidity, 1000 - 900, "position liquidity post-burn");
+    }
+
+    function test_withdraw_revertsOnSlippage() public {
+        address alice = address(0xA11CE);
+        deal(address(vault), alice, 50, true);
+        _seedPosition(0, -600, 600, 1000);
+        pool.setDelta(int128(10), int128(10));
+        token0.mint(address(pool), 10);
+        token1.mint(address(pool), 10);
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(Errors.SlippageExceeded.selector, 10, 100));
+        vault.withdraw(50, 100, 0, alice);
+    }
+
+    function test_withdraw_neverPaused_runsToCompletion() public {
+        // Even with deposits paused, withdraw must reach _handleWithdraw.
+        vm.prank(OWNER);
+        vault.setDepositsPaused(true);
+
+        address alice = address(0xA11CE);
+        deal(address(vault), alice, 50, true);
+        deal(address(vault), 0x000000000000000000000000000000000000dEaD, 50, true);
+        _seedPosition(0, -600, 600, 1000);
+        pool.setDelta(int128(5), int128(5));
+        token0.mint(address(pool), 5);
+        token1.mint(address(pool), 5);
+
+        vm.prank(alice);
+        (uint256 a0, uint256 a1) = vault.withdraw(50, 0, 0, alice);
+        assertEq(a0, 5, "amount0");
+        assertEq(a1, 5, "amount1");
+    }
+
+    /// Vault.Position[] is at storage slot 7 in the current layout
+    /// (ERC20 fields 0–4, owner 5, depositsPaused/tvlCap 6, _positions 7).
+    /// Foundry's `vm.store` on a dynamic array sets length at the slot
+    /// itself; the data lives at keccak256(slot). We use the contract's
+    /// own getPositions() helper to verify the seed worked.
+    function _seedPosition(uint256 index, int24 tickLower, int24 tickUpper, uint128 liquidity) internal {
+        bytes32 lengthSlot = bytes32(uint256(7));
+        // Set length to index + 1 (overwrites any previous seed).
+        vm.store(address(vault), lengthSlot, bytes32(uint256(index + 1)));
+
+        bytes32 dataSlot = keccak256(abi.encode(lengthSlot));
+        // Position struct: tickLower (int24) + tickUpper (int24) + liquidity (uint128)
+        // pack into one 256-bit slot per index. tickLower in bits 0..23,
+        // tickUpper in 24..47, liquidity in 48..175.
+        uint256 packed = (uint256(uint24(tickLower)) & ((1 << 24) - 1))
+            | ((uint256(uint24(tickUpper)) & ((1 << 24) - 1)) << 24) | (uint256(liquidity) << 48);
+        vm.store(address(vault), bytes32(uint256(dataSlot) + index), bytes32(packed));
     }
 }


### PR DESCRIPTION
## Summary

Fills the \`_handleWithdraw\` unlock-callback body that #175 / #28 left
as a revert. Removes a proportional liquidity slice from every active
position, takes the resulting positive deltas out of PoolManager,
forwards the proportional idle-balance share, and applies a slippage
gate.

- Proportional fraction: \`payload.shares / (totalSupply() + payload.shares)\`
  (pre-burn supply, since the external entry point burns shares before
  unlock).
- Idle-balance slice snapshotted before position removals.
- Per-position stored liquidity decremented so subsequent withdraws
  stay consistent.
- Withdraw remains never-pausable per ADR-002 + invariant 6;
  \`SlippageExceeded\` is the only user-reachable revert.

## Quality gates

- \`forge build\` clean
- \`forge test\` — 86/86 passing (3 new withdraw-body integration tests)
- \`forge fmt --check\` clean

## Test plan

- [x] Proportional remove + idle share payout
- [x] Stored position liquidity reduced by user's slice
- [x] \`SlippageExceeded\` on min not met
- [x] Reachable under \`DepositsPaused\` (invariant 6)
- [ ] Full flow against Base Sepolia (lands with #42)

## Dependencies / merge order

Stacks on \`contracts/28-vault-withdraw\` (#175). Independent of the
deposit-body integration (#187) and the rebalance-body integration to
follow — all three target the same Vault.sol but at distinct branches.