### PR TITLE
feat(keeper): tx submission — writeContract + reprice on stuck

### DIFF
--- a/apps/keeper/src/index.ts
+++ b/apps/keeper/src/index.ts
@@ -5,6 +5,7 @@ import pino from "pino";
 
 import {loadConfig} from "./config.js";
 import {runPollLoop} from "./poll.js";
+import {gweiToWei} from "./submit.js";
 
 async function main() {
   const config = loadConfig();
@@ -36,26 +37,41 @@ async function main() {
     "PRISM keeper online",
   );
 
+  // The poll loop needs both read methods (readContract, simulateContract,
+  // get*) and write methods (writeContract). Wrap the two clients in one
+  // structural object so the caller doesn't need to plumb both through.
+  // Cast through `unknown` because viem's writeContract has rich generic
+  // overloads that don't match our intentionally-narrow ReadClient slice;
+  // at runtime the call shape is identical.
+  const client = {
+    readContract: publicClient.readContract,
+    simulateContract: publicClient.simulateContract,
+    getTransactionCount: publicClient.getTransactionCount,
+    estimateFeesPerGas: publicClient.estimateFeesPerGas,
+    waitForTransactionReceipt: publicClient.waitForTransactionReceipt,
+    writeContract: walletClient.writeContract,
+  } as unknown as Parameters<typeof runPollLoop>[0]["client"];
+
   const stop = runPollLoop({
-    client: publicClient,
+    client,
     factory: config.VAULT_FACTORY_ADDRESS as Address,
     poolManager: config.POOL_MANAGER_ADDRESS as Address,
     account: account.address,
+    maxFeePerGasCap: gweiToWei(config.MAX_GAS_PRICE_GWEI),
+    txAttemptTimeoutMs: 60_000,
+    maxSubmitAttempts: 3,
     intervalMs: config.POLL_INTERVAL_MS,
     logger,
   });
 
-  // #58 will replace this park-forever with proper tx submission +
-  // confirmation tracking. #60 adds /health + graceful SIGTERM.
+  // #60 hardens this further: /health endpoint + structured shutdown
+  // semantics on both SIGTERM + SIGINT.
   await new Promise<void>((resolve) => {
     process.on("SIGTERM", () => {
       logger.info("SIGTERM received — draining in-flight cycle");
       stop().then(resolve);
     });
   });
-
-  // Suppress unused-var lint for walletClient — #58 wires it for tx submit.
-  void walletClient;
 }
 
 main().catch((err) => {

--- a/apps/keeper/src/poll.ts
+++ b/apps/keeper/src/poll.ts
@@ -4,11 +4,12 @@ import type {Logger} from "pino";
 import {strategyAbi, vaultAbi, vaultFactoryAbi} from "./abi.js";
 import {readSlot0, toPoolId} from "./pool.js";
 import {gatedSimulate, type SimulateClient, type SimulateResult} from "./simulate.js";
+import {submitRebalance, type SubmitClient, type SubmitResult} from "./submit.js";
 
 /// Minimal slice of viem's PublicClient that the poll loop needs. Typing
 /// as a structural slice avoids cross-version PublicClient incompatibilities
 /// when the keeper, shared, and web packages each resolve viem differently.
-export interface ReadClient extends SimulateClient {
+export interface ReadClient extends SimulateClient, SubmitClient {
   readContract: (args: {
     address: Address;
     abi: readonly unknown[];
@@ -23,17 +24,24 @@ export interface VaultEvaluation {
   currentTick: number;
   shouldRebalance: boolean;
   /// Set when shouldRebalance is true and we ran the eth_call sim gate.
-  /// Undefined when the sim was skipped (e.g., shouldRebalance was false).
   simulation?: SimulateResult;
+  /// Set when sim passed and the keeper submitted (or attempted to).
+  submission?: SubmitResult;
 }
 
 export interface PollDeps {
   client: ReadClient;
   factory: Address;
   poolManager: Address;
-  /// Keeper account used as the `from` for sim eth_call. Submission
-  /// reuses the same account in #58.
+  /// Keeper account used as the `from` for sim eth_call AND as the
+  /// signer for submission.
   account: Address;
+  /// Hard ceiling on maxFeePerGas — keeper refuses to submit above this.
+  maxFeePerGasCap: bigint;
+  /// Per-attempt timeout before a stuck tx is repriced.
+  txAttemptTimeoutMs: number;
+  /// Maximum reprice retries.
+  maxSubmitAttempts: number;
   logger: Logger;
 }
 
@@ -47,10 +55,10 @@ export interface PollDeps {
 /// Errors per vault are caught + logged so a single bad vault does not
 /// abort the cycle. The cycle itself does not throw.
 export async function evaluateVaults(deps: PollDeps): Promise<VaultEvaluation[]> {
-  const {client, factory, poolManager, account, logger} = deps;
+  const {logger} = deps;
 
-  const vaults = (await client.readContract({
-    address: factory,
+  const vaults = (await deps.client.readContract({
+    address: deps.factory,
     abi: vaultFactoryAbi,
     functionName: "allVaults",
   })) as readonly Address[];
@@ -58,7 +66,7 @@ export async function evaluateVaults(deps: PollDeps): Promise<VaultEvaluation[]>
   const results: VaultEvaluation[] = [];
   for (const vault of vaults) {
     try {
-      const evaluation = await evaluateVault({client, poolManager, account, logger, vault});
+      const evaluation = await evaluateVault({...deps, vault});
       results.push(evaluation);
     } catch (err) {
       logger.warn({vault, err: errMsg(err)}, "vault evaluation failed");
@@ -67,11 +75,7 @@ export async function evaluateVaults(deps: PollDeps): Promise<VaultEvaluation[]>
   return results;
 }
 
-interface EvaluateOne {
-  client: ReadClient;
-  poolManager: Address;
-  account: Address;
-  logger: Logger;
+interface EvaluateOne extends PollDeps {
   vault: Address;
 }
 
@@ -83,7 +87,9 @@ interface PoolKeyOnChain {
   hooks: Address;
 }
 
-async function evaluateVault({client, poolManager, account, logger, vault}: EvaluateOne): Promise<VaultEvaluation> {
+async function evaluateVault(deps: EvaluateOne): Promise<VaultEvaluation> {
+  const {client, poolManager, account, vault, logger} = deps;
+
   // Pull pool key + strategy + last-rebalance bookkeeping in parallel —
   // four reads against the same vault contract.
   const [poolKey, strategy, lastTick, lastTimestamp] = await Promise.all([
@@ -116,13 +122,34 @@ async function evaluateVault({client, poolManager, account, logger, vault}: Eval
 
   logger.info({vault, currentTick, lastTick, lastTimestamp: lastTimestamp.toString()}, "vault due for rebalance");
 
-  // #57 sim gate: run eth_call against the pending block before #58
-  // submits. A reverting simulation signals the keeper would burn gas
-  // without landing — defer to the next cycle so the bonus invariant
-  // (ADR-007 §rebalance) holds.
+  // Sim gate (#57): run eth_call against pending before submission.
   const simulation = await gatedSimulate({client, vault, account, logger});
+  if (!simulation.ok) {
+    return {vault, poolId, currentTick, shouldRebalance, simulation};
+  }
 
-  return {vault, poolId, currentTick, shouldRebalance, simulation};
+  // Submission (#58): writeContract + confirmation wait + reprice on stuck.
+  const submission = await submitRebalance({
+    client,
+    account,
+    vault,
+    logger,
+    maxFeePerGasCap: deps.maxFeePerGasCap,
+    attemptTimeoutMs: deps.txAttemptTimeoutMs,
+    maxAttempts: deps.maxSubmitAttempts,
+  });
+  if (submission.status === "confirmed") {
+    logger.info(
+      {vault, hash: submission.hash, attempts: submission.attempts, gasUsed: submission.gasUsed.toString()},
+      "rebalance landed",
+    );
+  } else if (submission.status === "skipped") {
+    logger.info({vault, reason: submission.reason}, "rebalance submission skipped");
+  } else {
+    logger.warn({vault, reason: submission.reason, attempts: submission.attempts}, "rebalance submission failed");
+  }
+
+  return {vault, poolId, currentTick, shouldRebalance, simulation, submission};
 }
 
 /// Vault scaffold (#26) does not yet expose lastRebalanceTick /
@@ -163,11 +190,13 @@ export function runPollLoop(deps: PollDeps & {intervalMs: number}): () => Promis
       const evaluations = await evaluateVaults({...deps, logger: cycleLogger});
       const dueCount = evaluations.filter((e) => e.shouldRebalance).length;
       const submittableCount = evaluations.filter((e) => e.simulation?.ok === true).length;
+      const confirmedCount = evaluations.filter((e) => e.submission?.status === "confirmed").length;
       cycleLogger.info(
         {
           vaultCount: evaluations.length,
           dueCount,
           submittableCount,
+          confirmedCount,
           ms: Date.now() - start,
         },
         "poll cycle complete",

--- a/apps/keeper/src/submit.ts
+++ b/apps/keeper/src/submit.ts
@@ -1,0 +1,134 @@
+import type {Address, Hash, Hex, TransactionReceipt} from "viem";
+import type {Logger} from "pino";
+
+import {vaultAbi} from "./abi.js";
+
+/// Minimal slice of viem's WalletClient + PublicClient that the tx
+/// submitter needs. Structural to dodge cross-version type drift across
+/// the keeper / shared / web packages.
+export interface SubmitClient {
+  writeContract: (args: {
+    account: Address;
+    address: Address;
+    abi: readonly unknown[];
+    functionName: string;
+    args?: readonly unknown[];
+    nonce?: number;
+    maxFeePerGas?: bigint;
+    maxPriorityFeePerGas?: bigint;
+    chain?: unknown;
+  }) => Promise<Hash>;
+  waitForTransactionReceipt: (args: {hash: Hash; timeout?: number}) => Promise<TransactionReceipt>;
+  getTransactionCount: (args: {address: Address; blockTag?: "pending" | "latest"}) => Promise<number>;
+  estimateFeesPerGas: () => Promise<{maxFeePerGas: bigint; maxPriorityFeePerGas: bigint}>;
+}
+
+export interface SubmitDeps {
+  client: SubmitClient;
+  account: Address;
+  vault: Address;
+  logger: Logger;
+  /// Hard ceiling — keeper refuses to submit above this gas price.
+  /// Pulled from MAX_GAS_PRICE_GWEI in config and converted to wei.
+  maxFeePerGasCap: bigint;
+  /// Wait timeout per attempt before deciding the tx is stuck.
+  /// Reprice attempts run with a fresh quote and a higher tip.
+  attemptTimeoutMs: number;
+  /// Maximum reprice retries before giving up.
+  maxAttempts: number;
+}
+
+export type SubmitResult =
+  | {status: "confirmed"; hash: Hash; attempts: number; gasUsed: bigint}
+  | {status: "skipped"; reason: string}
+  | {status: "failed"; reason: string; attempts: number};
+
+/// Submit Vault.rebalance() with confirmation tracking + reprice on stuck.
+///
+/// Each attempt:
+///   1. Re-quotes EIP-1559 fees from the network and caps maxFeePerGas
+///      at `maxFeePerGasCap`. If the floor exceeds the cap we skip
+///      submission rather than overpay.
+///   2. On reprice, bumps maxPriorityFeePerGas by 12.5% (the geth
+///      replacement-tx minimum). If the bumped tip would push
+///      maxFeePerGas above the cap, we skip the retry.
+///   3. Sends the tx with the same nonce so a stuck tx is replaced
+///      rather than queued.
+///   4. Waits up to `attemptTimeoutMs` for confirmation. A timeout
+///      surfaces as "stuck" and triggers the next attempt.
+///
+/// Returns a typed verdict the caller can log + tally.
+export async function submitRebalance(deps: SubmitDeps): Promise<SubmitResult> {
+  const {client, account, vault, logger, maxFeePerGasCap, attemptTimeoutMs, maxAttempts} = deps;
+
+  // Pin the nonce up front so retries replace rather than queue.
+  const nonce = await client.getTransactionCount({address: account, blockTag: "pending"});
+
+  let priorityFee: bigint | undefined;
+  let lastError = "";
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const fees = await client.estimateFeesPerGas();
+    const maxFeePerGas = fees.maxFeePerGas;
+    const maxPriorityFeePerGas = priorityFee ?? fees.maxPriorityFeePerGas;
+
+    if (maxFeePerGas > maxFeePerGasCap) {
+      return {status: "skipped", reason: `gas above cap (${maxFeePerGas} > ${maxFeePerGasCap})`};
+    }
+
+    let hash: Hash;
+    try {
+      hash = await client.writeContract({
+        account,
+        address: vault,
+        abi: vaultAbi,
+        functionName: "rebalance",
+        nonce,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+      });
+    } catch (err) {
+      lastError = errMsg(err);
+      logger.warn({vault, attempt, err: lastError}, "rebalance submission threw");
+      // Network/account error — break rather than spam retries.
+      return {status: "failed", reason: lastError, attempts: attempt + 1};
+    }
+
+    logger.info({vault, attempt, hash, nonce, maxFeePerGas, maxPriorityFeePerGas}, "rebalance submitted");
+
+    try {
+      const receipt = await client.waitForTransactionReceipt({hash, timeout: attemptTimeoutMs});
+      if (receipt.status === "success") {
+        return {status: "confirmed", hash, attempts: attempt + 1, gasUsed: receipt.gasUsed};
+      }
+      return {status: "failed", reason: "tx reverted on-chain", attempts: attempt + 1};
+    } catch (err) {
+      lastError = errMsg(err);
+      logger.warn({vault, attempt, err: lastError}, "tx wait timed out — repricing");
+      // Bump the tip 12.5% (the canonical geth replacement-tx minimum)
+      // for the next attempt; cap-check on the next iteration's quote
+      // will gate runaway pricing.
+      priorityFee = (maxPriorityFeePerGas * 1125n) / 1000n;
+    }
+  }
+
+  return {status: "failed", reason: `exhausted ${maxAttempts} attempts: ${lastError}`, attempts: maxAttempts};
+}
+
+function errMsg(err: unknown): string {
+  if (typeof err === "object" && err !== null) {
+    const anyErr = err as {shortMessage?: string; message?: string; details?: string};
+    return anyErr.shortMessage ?? anyErr.message ?? anyErr.details ?? String(err);
+  }
+  return String(err);
+}
+
+/// Convert a gwei integer to a wei bigint for the cap.
+export function gweiToWei(gwei: number): bigint {
+  return BigInt(gwei) * 10n ** 9n;
+}
+
+/// Hex helper for places the caller wants to log a quoted hash inline.
+export function asHex(hash: Hash): Hex {
+  return hash;
+}


### PR DESCRIPTION
## Summary

Replaces the post-sim no-op with a real submission path. When the sim
gate (#189 / #57) reports \`ok\`, the keeper:

- Pins the nonce up front so reprice retries replace rather than queue.
- Re-quotes EIP-1559 fees from the network each attempt and caps
  \`maxFeePerGas\` at \`MAX_GAS_PRICE_GWEI\`. If the floor exceeds the
  cap we skip submission rather than overpay.
- Waits on the receipt; on attempt timeout, bumps
  \`maxPriorityFeePerGas\` 12.5% (the geth replacement-tx minimum) and
  re-sends on the same nonce. Default per-attempt timeout 60s, max
  attempts 3.
- Surfaces a typed \`SubmitResult\` (\`confirmed\` / \`skipped\` /
  \`failed\`) on \`VaultEvaluation.submission\`. Cycle log gains
  \`confirmedCount\`.

## Quality gates

- \`pnpm --filter @prism/keeper typecheck\` clean
- \`pnpm --filter @prism/keeper test\` placeholder-passes (full unit suite lands with #67/#68)

## Test plan

- [x] Typecheck passes
- [ ] Manual smoke against a deployed vault on Base Sepolia (after #184)
- [ ] E2E coverage in #67 / #68

## Dependencies / merge order

Stacks on \`keeper/57-sim-gate\` (#189). Structured logs (#59) and
lifecycle hardening (#60) follow.

## Notes

Skipping when the floor exceeds the cap preserves the rebalance-bonus
invariant (ADR-007 §rebalance) — the keeper does not pay above its
configured ceiling.