### PR TITLE
feat(keeper): structured logs — cycle metrics + p50/p99 latency snapshots

### DIFF
--- a/apps/keeper/src/index.ts
+++ b/apps/keeper/src/index.ts
@@ -4,8 +4,11 @@ import {baseSepolia} from "viem/chains";
 import pino from "pino";
 
 import {loadConfig} from "./config.js";
+import {Metrics} from "./metrics.js";
 import {runPollLoop} from "./poll.js";
 import {gweiToWei} from "./submit.js";
+
+const METRIC_SNAPSHOT_INTERVAL_MS = 60_000;
 
 async function main() {
   const config = loadConfig();
@@ -52,6 +55,8 @@ async function main() {
     writeContract: walletClient.writeContract,
   } as unknown as Parameters<typeof runPollLoop>[0]["client"];
 
+  const metrics = new Metrics();
+
   const stop = runPollLoop({
     client,
     factory: config.VAULT_FACTORY_ADDRESS as Address,
@@ -62,13 +67,22 @@ async function main() {
     maxSubmitAttempts: 3,
     intervalMs: config.POLL_INTERVAL_MS,
     logger,
+    metrics,
   });
+
+  // Periodic metric snapshot — emits one structured log line per minute
+  // with cycle counts + p50/p99 latency. /metrics HTTP endpoint that
+  // exposes the same numbers lands in #60.
+  const metricTimer = setInterval(() => {
+    logger.info({metrics: metrics.snapshot()}, "metric snapshot");
+  }, METRIC_SNAPSHOT_INTERVAL_MS);
 
   // #60 hardens this further: /health endpoint + structured shutdown
   // semantics on both SIGTERM + SIGINT.
   await new Promise<void>((resolve) => {
     process.on("SIGTERM", () => {
       logger.info("SIGTERM received — draining in-flight cycle");
+      clearInterval(metricTimer);
       stop().then(resolve);
     });
   });

--- a/apps/keeper/src/metrics.ts
+++ b/apps/keeper/src/metrics.ts
@@ -1,0 +1,103 @@
+/// In-memory metrics collected across the keeper's lifetime. Exposed as
+/// a snapshot the lifecycle layer (#60) serves under /metrics. The
+/// surface is intentionally tiny: a counter set + a latency reservoir
+/// that resolves p50/p99 lazily.
+///
+/// Why hand-rolled instead of prom-client: a single-process keeper with
+/// no scrape endpoint until #60 has no need for the prom-client tax.
+/// The shape is compatible — when /metrics lands, exporting a Prometheus
+/// text body from this snapshot is ~30 lines.
+
+const MAX_RESERVOIR = 1024;
+
+export interface MetricsSnapshot {
+  cycleCount: number;
+  cycleErrors: number;
+  rebalancesSimulated: number;
+  rebalancesSubmitted: number;
+  rebalancesConfirmed: number;
+  rebalancesFailed: number;
+  cycleLatencyP50Ms: number;
+  cycleLatencyP99Ms: number;
+  cycleLatencyMaxMs: number;
+  startedAtMs: number;
+  uptimeMs: number;
+}
+
+export class Metrics {
+  private cycleCount = 0;
+  private cycleErrors = 0;
+  private rebalancesSimulated = 0;
+  private rebalancesSubmitted = 0;
+  private rebalancesConfirmed = 0;
+  private rebalancesFailed = 0;
+
+  /// Reservoir-sampled cycle latencies. Bounded to MAX_RESERVOIR so the
+  /// keeper running for weeks does not retain unbounded samples; older
+  /// entries fall out of the percentile estimate as new ones arrive.
+  /// O(1) writes, O(n log n) reads (only when snapshot is requested).
+  private readonly latencies: number[] = [];
+
+  private readonly startedAtMs = Date.now();
+
+  cycleCompleted(latencyMs: number): void {
+    this.cycleCount++;
+    this.recordLatency(latencyMs);
+  }
+
+  cycleFailed(latencyMs: number): void {
+    this.cycleCount++;
+    this.cycleErrors++;
+    this.recordLatency(latencyMs);
+  }
+
+  rebalanceSimulated(): void {
+    this.rebalancesSimulated++;
+  }
+
+  rebalanceSubmitted(): void {
+    this.rebalancesSubmitted++;
+  }
+
+  rebalanceConfirmed(): void {
+    this.rebalancesConfirmed++;
+  }
+
+  rebalanceFailed(): void {
+    this.rebalancesFailed++;
+  }
+
+  snapshot(): MetricsSnapshot {
+    const sorted = [...this.latencies].sort((a, b) => a - b);
+    return {
+      cycleCount: this.cycleCount,
+      cycleErrors: this.cycleErrors,
+      rebalancesSimulated: this.rebalancesSimulated,
+      rebalancesSubmitted: this.rebalancesSubmitted,
+      rebalancesConfirmed: this.rebalancesConfirmed,
+      rebalancesFailed: this.rebalancesFailed,
+      cycleLatencyP50Ms: percentile(sorted, 0.5),
+      cycleLatencyP99Ms: percentile(sorted, 0.99),
+      cycleLatencyMaxMs: sorted.length === 0 ? 0 : (sorted[sorted.length - 1] ?? 0),
+      startedAtMs: this.startedAtMs,
+      uptimeMs: Date.now() - this.startedAtMs,
+    };
+  }
+
+  private recordLatency(ms: number): void {
+    if (this.latencies.length < MAX_RESERVOIR) {
+      this.latencies.push(ms);
+      return;
+    }
+    // Reservoir replacement — keep the distribution stable as samples
+    // accumulate. Vitter's Algorithm R: replace at random index.
+    const idx = Math.floor(Math.random() * this.latencies.length);
+    this.latencies[idx] = ms;
+  }
+}
+
+function percentile(sorted: readonly number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.floor(p * sorted.length));
+  return sorted[idx] ?? 0;
+}

--- a/apps/keeper/src/poll.ts
+++ b/apps/keeper/src/poll.ts
@@ -3,6 +3,7 @@ import type {Logger} from "pino";
 
 import {strategyAbi, vaultAbi, vaultFactoryAbi} from "./abi.js";
 import {readSlot0, toPoolId} from "./pool.js";
+import {Metrics} from "./metrics.js";
 import {gatedSimulate, type SimulateClient, type SimulateResult} from "./simulate.js";
 import {submitRebalance, type SubmitClient, type SubmitResult} from "./submit.js";
 
@@ -43,6 +44,10 @@ export interface PollDeps {
   /// Maximum reprice retries.
   maxSubmitAttempts: number;
   logger: Logger;
+  /// Optional shared metrics sink. The lifecycle layer (#60) creates
+  /// this at startup and exposes a snapshot via /metrics. When omitted
+  /// the loop runs metric-free — keeps unit tests trivial.
+  metrics?: Metrics;
 }
 
 /// One pass of the keeper poll loop.
@@ -177,7 +182,7 @@ function errMsg(err: unknown): string {
 /// Run the poll loop forever with the configured cadence. Returns a
 /// stop function that resolves after the in-flight cycle completes.
 export function runPollLoop(deps: PollDeps & {intervalMs: number}): () => Promise<void> {
-  const {logger, intervalMs} = deps;
+  const {logger, intervalMs, metrics} = deps;
   let stopped = false;
   let inflight: Promise<void> = Promise.resolve();
 
@@ -191,18 +196,37 @@ export function runPollLoop(deps: PollDeps & {intervalMs: number}): () => Promis
       const dueCount = evaluations.filter((e) => e.shouldRebalance).length;
       const submittableCount = evaluations.filter((e) => e.simulation?.ok === true).length;
       const confirmedCount = evaluations.filter((e) => e.submission?.status === "confirmed").length;
+      const failedCount = evaluations.filter((e) => e.submission?.status === "failed").length;
+
+      if (metrics) {
+        for (const e of evaluations) {
+          if (e.simulation?.ok) metrics.rebalanceSimulated();
+          if (e.submission?.status === "confirmed") {
+            metrics.rebalanceSubmitted();
+            metrics.rebalanceConfirmed();
+          } else if (e.submission?.status === "failed") {
+            metrics.rebalanceSubmitted();
+            metrics.rebalanceFailed();
+          }
+        }
+        metrics.cycleCompleted(Date.now() - start);
+      }
+
       cycleLogger.info(
         {
           vaultCount: evaluations.length,
           dueCount,
           submittableCount,
           confirmedCount,
+          failedCount,
           ms: Date.now() - start,
         },
         "poll cycle complete",
       );
     } catch (err) {
-      cycleLogger.error({err: errMsg(err), ms: Date.now() - start}, "poll cycle failed");
+      const ms = Date.now() - start;
+      if (metrics) metrics.cycleFailed(ms);
+      cycleLogger.error({err: errMsg(err), ms}, "poll cycle failed");
     }
   };
 


### PR DESCRIPTION
## Summary

Adds an in-memory \`Metrics\` sink the poll loop updates every cycle:
\`cycleCount\`, \`cycleErrors\`, \`rebalances{Simulated,Submitted,Confirmed,Failed}\`,
and a reservoir-sampled cycle latency with \`p50/p99/max\` getters.

The keeper logs a \`metric snapshot\` line every 60s with the current
numbers, complementing the per-cycle correlation-ID logs from #56. The
Metrics object is returned so #60 can expose the same snapshot from
\`/metrics\`.

Reservoir is bounded at 1024 samples (Vitter's Algorithm R) so a
long-running keeper does not retain unbounded latency history.

## Quality gates

- \`pnpm --filter @prism/keeper typecheck\` clean

## Test plan

- [x] Typecheck passes
- [ ] Manual smoke: confirm 'metric snapshot' lines appear after a cycle (after #184 deploys)
- [ ] /metrics surface lands in #60

## Dependencies / merge order

Stacks on \`keeper/58-tx-submit\` (#191). Lifecycle hardening (#60)
serves the snapshot from /metrics.