### PR TITLE
feat(keeper): lifecycle — /health, tini, hardened Dockerfile, fly.toml

### DIFF
--- a/apps/keeper/.env.example
+++ b/apps/keeper/.env.example
@@ -19,5 +19,9 @@ POLL_INTERVAL_MS=30000
 # defers the rebalance to the next tick. Default 10.
 MAX_GAS_PRICE_GWEI=10
 
+# Optional: HTTP port for /health and /metrics. Default 8080. Fly.io's
+# default health probe targets this port.
+HEALTH_PORT=8080
+
 # Optional: log level. Default "info". Options: trace, debug, info, warn, error, fatal.
 LOG_LEVEL=info

--- a/apps/keeper/Dockerfile
+++ b/apps/keeper/Dockerfile
@@ -1,0 +1,55 @@
+# PRISM keeper — production image.
+#
+# Two-stage build:
+#   1. deps stage — installs pnpm + the workspace deps once, layer-cached
+#      across rebuilds when only source changes.
+#   2. runtime stage — minimal node:alpine with the built JS, runs the
+#      keeper as a non-root user with a TINI init wrapper for proper
+#      SIGTERM forwarding.
+#
+# Health probe: /health on $HEALTH_PORT (default 8080). The endpoint
+# reports 503 until the first cycle completes, so a freshly-started
+# container that can't reach the RPC fails the first probe and gets
+# rescheduled rather than masquerading as healthy.
+
+FROM node:20-alpine AS deps
+
+WORKDIR /repo
+RUN apk add --no-cache libc6-compat
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY apps/keeper/package.json ./apps/keeper/
+COPY packages/shared/package.json ./packages/shared/
+COPY packages/shared/ ./packages/shared/
+
+RUN corepack enable && corepack prepare pnpm@10.18.0 --activate
+RUN pnpm install --frozen-lockfile --filter @prism/keeper...
+
+COPY apps/keeper/ ./apps/keeper/
+
+RUN pnpm --filter @prism/keeper build
+
+# -----------------------------------------------------------------------
+FROM node:20-alpine AS runtime
+
+WORKDIR /app
+
+# tini ensures SIGTERM reaches the node process — without it docker stop
+# escalates to SIGKILL after 10s and the in-flight cycle is lost.
+RUN apk add --no-cache tini
+
+# Copy the built keeper + its production dependency closure.
+COPY --from=deps /repo/apps/keeper/dist ./dist
+COPY --from=deps /repo/node_modules ./node_modules
+COPY --from=deps /repo/apps/keeper/node_modules ./apps/keeper/node_modules
+COPY --from=deps /repo/packages/shared ./packages/shared
+COPY --from=deps /repo/apps/keeper/package.json ./apps/keeper/package.json
+
+# Drop privileges. The default node:alpine "node" user has uid 1000.
+USER node
+
+# Health endpoint port (defaults to 8080 — overridable via HEALTH_PORT).
+EXPOSE 8080
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node", "dist/index.js"]

--- a/apps/keeper/fly.toml
+++ b/apps/keeper/fly.toml
@@ -1,0 +1,59 @@
+# Fly.io configuration for the PRISM keeper.
+#
+# Deploy from the repo root:
+#   fly deploy --dockerfile apps/keeper/Dockerfile --config apps/keeper/fly.toml
+#
+# Secrets (NEVER commit these — set via `fly secrets set`):
+#   - BASE_SEPOLIA_RPC_URL
+#   - KEEPER_PRIVATE_KEY
+#   - VAULT_FACTORY_ADDRESS
+#   - POOL_MANAGER_ADDRESS
+
+app = "prism-keeper"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+# Single-instance keeper. We don't want two processes racing for the same
+# nonce; submission (#58) pins the nonce per cycle so concurrent runs
+# would reprice each other into the ground.
+[deploy]
+  strategy = "immediate"
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 8080
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+  [[services.http_checks]]
+    interval = "15s"
+    timeout = "5s"
+    grace_period = "60s"
+    method = "get"
+    path = "/health"
+
+[env]
+  POLL_INTERVAL_MS = "30000"
+  MAX_GAS_PRICE_GWEI = "10"
+  HEALTH_PORT = "8080"
+  LOG_LEVEL = "info"
+
+# 256MB is comfortable for a single-process keeper. Bump if the cycle
+# log emits memory pressure warnings under sustained load.
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 256

--- a/apps/keeper/src/config.ts
+++ b/apps/keeper/src/config.ts
@@ -13,6 +13,7 @@ const envSchema = z.object({
     .regex(/^0x[a-fA-F0-9]{40}$/, "POOL_MANAGER_ADDRESS must be a 0x-prefixed address"),
   POLL_INTERVAL_MS: z.coerce.number().int().positive().default(30_000),
   MAX_GAS_PRICE_GWEI: z.coerce.number().int().positive().default(10),
+  HEALTH_PORT: z.coerce.number().int().positive().default(8080),
   LOG_LEVEL: z
     .enum(["trace", "debug", "info", "warn", "error", "fatal"])
     .default("info"),

--- a/apps/keeper/src/health.ts
+++ b/apps/keeper/src/health.ts
@@ -1,0 +1,68 @@
+import {createServer, type Server} from "node:http";
+import type {Logger} from "pino";
+
+import type {Metrics} from "./metrics.js";
+
+export interface HealthDeps {
+  port: number;
+  logger: Logger;
+  metrics: Metrics;
+}
+
+/// Start the lifecycle HTTP server: GET /health and GET /metrics.
+///
+/// /health returns 200 OK with a tiny JSON body once the keeper has
+/// completed at least one cycle (so a freshly-started container that
+/// can't reach the RPC fails the first health probe and gets restarted
+/// rather than masquerading as healthy). The cycle-count check is
+/// computed off the live Metrics snapshot.
+///
+/// /metrics returns the same Metrics snapshot in JSON. A Prometheus
+/// text exporter is a follow-up — the JSON shape is sufficient for
+/// the Fly.io health check + ad-hoc curl debugging that #60 targets.
+///
+/// Returns the Server so the caller can shut it down on SIGTERM.
+export function startHealthServer(deps: HealthDeps): Server {
+  const {port, logger, metrics} = deps;
+
+  const server = createServer((req, res) => {
+    if (req.method !== "GET") {
+      res.writeHead(405, {"content-type": "text/plain"}).end("method not allowed");
+      return;
+    }
+
+    if (req.url === "/health") {
+      const snapshot = metrics.snapshot();
+      const healthy = snapshot.cycleCount > 0;
+      const body = JSON.stringify({
+        status: healthy ? "ok" : "starting",
+        uptimeMs: snapshot.uptimeMs,
+        cycleCount: snapshot.cycleCount,
+        cycleErrors: snapshot.cycleErrors,
+      });
+      res.writeHead(healthy ? 200 : 503, {"content-type": "application/json"}).end(body);
+      return;
+    }
+
+    if (req.url === "/metrics") {
+      res.writeHead(200, {"content-type": "application/json"}).end(JSON.stringify(metrics.snapshot()));
+      return;
+    }
+
+    res.writeHead(404, {"content-type": "text/plain"}).end("not found");
+  });
+
+  server.listen(port, () => {
+    logger.info({port}, "health server listening");
+  });
+
+  return server;
+}
+
+/// Wraps server.close in a Promise so the lifecycle code can await
+/// graceful shutdown alongside the poll-loop drain.
+export function stopHealthServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}

--- a/apps/keeper/src/index.ts
+++ b/apps/keeper/src/index.ts
@@ -4,6 +4,7 @@ import {baseSepolia} from "viem/chains";
 import pino from "pino";
 
 import {loadConfig} from "./config.js";
+import {startHealthServer, stopHealthServer} from "./health.js";
 import {Metrics} from "./metrics.js";
 import {runPollLoop} from "./poll.js";
 import {gweiToWei} from "./submit.js";
@@ -56,6 +57,7 @@ async function main() {
   } as unknown as Parameters<typeof runPollLoop>[0]["client"];
 
   const metrics = new Metrics();
+  const healthServer = startHealthServer({port: config.HEALTH_PORT, logger, metrics});
 
   const stop = runPollLoop({
     client,
@@ -77,14 +79,28 @@ async function main() {
     logger.info({metrics: metrics.snapshot()}, "metric snapshot");
   }, METRIC_SNAPSHOT_INTERVAL_MS);
 
-  // #60 hardens this further: /health endpoint + structured shutdown
-  // semantics on both SIGTERM + SIGINT.
+  // Graceful shutdown: drain the in-flight cycle, stop the metric
+  // snapshot timer, then close the health server. SIGTERM is what
+  // platforms (Fly.io, k8s) send for orderly stops; SIGINT is Ctrl-C
+  // in dev. We treat both identically.
   await new Promise<void>((resolve) => {
-    process.on("SIGTERM", () => {
-      logger.info("SIGTERM received — draining in-flight cycle");
+    let shuttingDown = false;
+    const shutdown = async (signal: string): Promise<void> => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      logger.info({signal}, "received shutdown signal — draining");
       clearInterval(metricTimer);
-      stop().then(resolve);
-    });
+      try {
+        await stop();
+        await stopHealthServer(healthServer);
+      } catch (err) {
+        logger.error({err}, "shutdown error");
+      }
+      logger.info({metrics: metrics.snapshot()}, "shutdown complete");
+      resolve();
+    };
+    process.on("SIGTERM", () => void shutdown("SIGTERM"));
+    process.on("SIGINT", () => void shutdown("SIGINT"));
   });
 }
 


### PR DESCRIPTION
## Summary

The lifecycle layer:

- \`src/health.ts\` — GET \`/health\` (503 until the first cycle
  completes; 200 ok after) and GET \`/metrics\` (JSON snapshot of the
  #59 Metrics sink).
- \`index.ts\` — SIGTERM + SIGINT both drain the in-flight cycle, stop
  the metric snapshot timer, then close the health server.
  Idempotent: duplicate signals during shutdown are ignored.
- \`Dockerfile\` — tini-wrapped entrypoint so SIGTERM forwards
  correctly to node, non-root \`node\` user, two-stage build with
  workspace dep cache.
- \`fly.toml\` — Fly.io config with /health probe, single-instance
  deploy (avoids nonce races), 256MB / 1 shared CPU.
- New env: \`HEALTH_PORT\` (default 8080).

## Quality gates

- \`pnpm --filter @prism/keeper typecheck\` clean
- \`docker build -f apps/keeper/Dockerfile .\` will green via the existing
  workflow once #165 / #63 lands

## Test plan

- [x] Typecheck passes
- [ ] Manual: \`fly deploy\` + \`fly status\` health check passing
- [ ] Manual: \`docker run prism-keeper\` exits cleanly on \`docker stop\`

## Dependencies / merge order

Stacks on \`keeper/59-logs\` (#192). Final keeper PR — closes the
keeper/55..60 stack.

## Notes

Secrets (\`BASE_SEPOLIA_RPC_URL\`, \`KEEPER_PRIVATE_KEY\`, etc.) are set
via \`fly secrets set\` per fly.toml's deploy comment — never committed.