### PR TITLE
feat(contracts): Vault rebalance body + currentTick wire-up + getTotalAmounts

### DIFF
--- a/packages/contracts/src/core/Vault.sol
+++ b/packages/contracts/src/core/Vault.sol
@@ -4,15 +4,21 @@ pragma solidity 0.8.26;
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
 import {IUnlockCallback} from "v4-core/interfaces/callback/IUnlockCallback.sol";
+import {StateLibrary} from "v4-core/libraries/StateLibrary.sol";
+import {BalanceDelta, BalanceDeltaLibrary} from "v4-core/types/BalanceDelta.sol";
 import {Currency} from "v4-core/types/Currency.sol";
+import {PoolId, PoolIdLibrary} from "v4-core/types/PoolId.sol";
 import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {ModifyLiquidityParams} from "v4-core/types/PoolOperation.sol";
 
 import {IProtocolHook} from "../interfaces/IProtocolHook.sol";
 import {IStrategy} from "../interfaces/IStrategy.sol";
 import {IVault} from "../interfaces/IVault.sol";
+import {PositionLib} from "../libraries/PositionLib.sol";
 import {Errors} from "../utils/Errors.sol";
 
 /// @title PRISM Vault — multi-position LP aggregator on Uniswap V4
@@ -48,6 +54,15 @@ import {Errors} from "../utils/Errors.sol";
 ///      mitigates the first-depositor inflation attack (PRD §13).
 contract Vault is IVault, ERC20, IUnlockCallback {
     using SafeERC20 for IERC20;
+    using StateLibrary for IPoolManager;
+    using PoolIdLibrary for PoolKey;
+    using BalanceDeltaLibrary for BalanceDelta;
+
+    /// @notice Keeper bonus per ADR-007 §keeper economics — 5 basis
+    ///         points of the post-rebalance share supply, minted to
+    ///         the keeper that triggered the rebalance.
+    uint256 public constant KEEPER_BONUS_BPS = 5;
+    uint256 internal constant BPS_DENOM = 10_000;
 
     /// @dev Tagged operations for `unlockCallback`. Each entry point
     ///      (deposit / withdraw / rebalance) calls `poolManager.unlock`
@@ -327,14 +342,128 @@ contract Vault is IVault, ERC20, IUnlockCallback {
         revert Errors.UnknownOp();
     }
 
-    /// @dev Stub: real implementation removes all positions, optionally
-    ///      runs a slippage-bounded internal swap to rebalance the
-    ///      idle balance, calls strategy.computePositions for the new
-    ///      shape, deploys via modifyLiquidity per target, settles
-    ///      deltas, and mints the keeper bonus shares (ADR-007 §keeper
-    ///      economics).
-    function _handleRebalance(RebalancePayload memory /*payload*/ ) internal pure returns (bytes memory) {
-        revert Errors.UnknownOp();
+    /// @dev Remove-all → recompute shape → redeploy → settle → mint
+    ///      keeper bonus.
+    ///
+    ///      Steps:
+    ///        1. Read post-swap pool state for the target shape
+    ///           computation.
+    ///        2. Tear down every existing position via modifyLiquidity
+    ///           with negative liquidityDelta. Take the resulting
+    ///           positive deltas — the vault now holds all assets idle.
+    ///        3. Ask the strategy for the target shape against the new
+    ///           idle balances. Validate weight sum + position count.
+    ///        4. Deploy each new target. Settle the resulting negative
+    ///           deltas back to PoolManager.
+    ///        5. Mint KEEPER_BONUS_BPS of the post-rebalance share
+    ///           supply to the keeper as payment for the gas they paid
+    ///           (ADR-007 §keeper economics).
+    ///
+    ///      v1.0 does NOT run an internal swap to balance the idle
+    ///      between the two tokens. The strategy is expected to absorb
+    ///      uneven balances via its weight allocation; a bounded
+    ///      internal swap is a v1.1 follow-up.
+    function _handleRebalance(RebalancePayload memory payload) internal returns (bytes memory) {
+        PoolId pid = _poolKey.toId();
+        (uint160 sqrtPriceX96, int24 currentTick,,) = poolManager.getSlot0(pid);
+
+        // 1. Tear down every active position.
+        uint256 oldCount = _positions.length;
+        for (uint256 i = 0; i < oldCount; i++) {
+            Position memory p = _positions[i];
+            if (p.liquidity == 0) continue;
+
+            (BalanceDelta delta,) = poolManager.modifyLiquidity(
+                _poolKey,
+                ModifyLiquidityParams({
+                    tickLower: p.tickLower,
+                    tickUpper: p.tickUpper,
+                    liquidityDelta: -int256(uint256(p.liquidity)),
+                    salt: bytes32(uint256(i))
+                }),
+                ""
+            );
+
+            int128 d0 = delta.amount0();
+            int128 d1 = delta.amount1();
+            if (d0 > 0) poolManager.take(_poolKey.currency0, address(this), uint128(d0));
+            if (d1 > 0) poolManager.take(_poolKey.currency1, address(this), uint128(d1));
+        }
+
+        // 2. Reset the position list — the strategy decides the new shape.
+        delete _positions;
+
+        // 3. Compute the new target shape against current idle balances.
+        uint256 idle0 = token0.balanceOf(address(this));
+        uint256 idle1 = token1.balanceOf(address(this));
+
+        IStrategy.TargetPosition[] memory targets = strategy.computePositions(currentTick, tickSpacing, idle0, idle1);
+
+        if (targets.length == 0 || targets.length > MAX_POSITIONS) {
+            revert Errors.MaxPositionsExceeded(targets.length);
+        }
+        uint256 weightSum;
+        for (uint256 i = 0; i < targets.length; i++) {
+            weightSum += targets[i].weight;
+        }
+        if (weightSum != 10_000) revert Errors.WeightsDoNotSum(weightSum);
+
+        // 4. Deploy each target. Aggregate negative deltas paid to the
+        // pool come from the vault's idle balance.
+        uint256 spent0;
+        uint256 spent1;
+
+        for (uint256 i = 0; i < targets.length; i++) {
+            IStrategy.TargetPosition memory t = targets[i];
+            uint256 share0 = (idle0 * t.weight) / 10_000;
+            uint256 share1 = (idle1 * t.weight) / 10_000;
+
+            uint128 liquidity =
+                PositionLib.liquidityForAmounts(sqrtPriceX96, t.tickLower, t.tickUpper, tickSpacing, share0, share1);
+            if (liquidity == 0) continue;
+
+            (BalanceDelta delta,) = poolManager.modifyLiquidity(
+                _poolKey,
+                ModifyLiquidityParams({
+                    tickLower: t.tickLower,
+                    tickUpper: t.tickUpper,
+                    liquidityDelta: int256(uint256(liquidity)),
+                    salt: bytes32(uint256(i))
+                }),
+                ""
+            );
+
+            int128 d0 = delta.amount0();
+            int128 d1 = delta.amount1();
+            if (d0 < 0) spent0 += uint128(-d0);
+            if (d1 < 0) spent1 += uint128(-d1);
+
+            _positions.push(Position({tickLower: t.tickLower, tickUpper: t.tickUpper, liquidity: liquidity}));
+        }
+
+        // 5. Settle the aggregate spend back to PoolManager.
+        if (spent0 > 0) {
+            poolManager.sync(_poolKey.currency0);
+            token0.safeTransfer(address(poolManager), spent0);
+            poolManager.settle();
+        }
+        if (spent1 > 0) {
+            poolManager.sync(_poolKey.currency1);
+            token1.safeTransfer(address(poolManager), spent1);
+            poolManager.settle();
+        }
+
+        // 6. Keeper bonus — 5 bps of post-rebalance supply minted to
+        // the keeper. The +1 floor ensures even a fresh vault credits
+        // a single share so on-chain attribution is unambiguous.
+        uint256 supply = totalSupply();
+        if (supply > 0 && payload.keeper != address(0)) {
+            uint256 bonus = Math.mulDiv(supply, KEEPER_BONUS_BPS, BPS_DENOM);
+            if (bonus == 0) bonus = 1;
+            _mint(payload.keeper, bonus);
+        }
+
+        return abi.encode(currentTick, _positions.length, uint256(0));
     }
 
     /// @inheritdoc IVault
@@ -383,11 +512,9 @@ contract Vault is IVault, ERC20, IUnlockCallback {
     ///      entry-point gate; settlement lands during integration
     ///      testing against a real PoolManager.
     function rebalance() external override {
-        // Read the current tick from PoolManager state. For #29 we
-        // forward 0 as a placeholder — integration phase reads via
-        // `StateView.getSlot0(poolKey.toId())`. The strategy still
-        // sees a non-zero last-rebalance window the first time.
-        int24 currentTick = 0;
+        // Read the current tick from PoolManager via StateLibrary —
+        // single extsload, no StateView contract dependency.
+        (, int24 currentTick,,) = poolManager.getSlot0(_poolKey.toId());
 
         if (!strategy.shouldRebalance(currentTick, lastRebalanceTick, lastRebalanceTimestamp)) {
             revert Errors.RebalanceNotNeeded();
@@ -411,10 +538,24 @@ contract Vault is IVault, ERC20, IUnlockCallback {
     }
 
     /// @inheritdoc IVault
-    function getTotalAmounts() external pure override returns (uint256, uint256) {
-        // #30 wires the per-position amount aggregation against PoolManager
-        // state.
-        return (0, 0);
+    function getTotalAmounts() external view override returns (uint256 total0, uint256 total1) {
+        // Idle balance is part of TVL — frontends and the share-price
+        // view both expect it to count.
+        total0 = token0.balanceOf(address(this));
+        total1 = token1.balanceOf(address(this));
+
+        if (_positions.length == 0) return (total0, total1);
+
+        (uint160 sqrtPriceX96,,,) = poolManager.getSlot0(_poolKey.toId());
+
+        uint256 n = _positions.length;
+        for (uint256 i = 0; i < n; i++) {
+            Position memory p = _positions[i];
+            (uint256 a0, uint256 a1) =
+                PositionLib.amountsForLiquidity(sqrtPriceX96, p.tickLower, p.tickUpper, tickSpacing, p.liquidity);
+            total0 += a0;
+            total1 += a1;
+        }
     }
 
     /// @inheritdoc IVault

--- a/packages/contracts/src/libraries/PositionLib.sol
+++ b/packages/contracts/src/libraries/PositionLib.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {SqrtPriceMath} from "v4-core/libraries/SqrtPriceMath.sol";
+import {TickMath} from "v4-core/libraries/TickMath.sol";
+import {LiquidityAmounts} from "v4-periphery/libraries/LiquidityAmounts.sol";
+
+import {Errors} from "../utils/Errors.sol";
+
+/// @title PositionLib
+/// @notice Tick-range validation and liquidity ↔ amount conversions
+///         shared across `Vault`, `IStrategy` implementations, and the
+///         off-chain keeper simulation.
+/// @dev Wraps `v4-core` (`TickMath`, `SqrtPriceMath`) and `v4-periphery`
+///      (`LiquidityAmounts`) with a thin PRISM-specific surface:
+///        - tick ranges are aligned to the pool's `tickSpacing` and
+///          clamped to `[minUsableTick, maxUsableTick]`.
+///        - reverts use the canonical `Errors.InvalidTickRange`
+///          selector instead of inline strings.
+///        - amount-aggregation helpers operate on the `Position` shape
+///          the vault and the IVault interface use.
+///
+///      Pure library — no mutable storage, no external calls.
+library PositionLib {
+    /// @notice Validate a tick range against the pool's `tickSpacing`
+    ///         and the absolute V4 bounds.
+    /// @dev Reverts with `Errors.InvalidTickRange(lower, upper)` when:
+    ///        - `lower >= upper` (zero or inverted range), OR
+    ///        - either tick is not a multiple of `tickSpacing`, OR
+    ///        - either tick is outside `[minUsableTick, maxUsableTick]`
+    ///          for the supplied `tickSpacing`. The bounds collapse the
+    ///          ABI-level [`MIN_TICK`, `MAX_TICK`] into the largest
+    ///          range the pool can legally expose at the given spacing.
+    /// @param tickLower Lower tick of the position.
+    /// @param tickUpper Upper tick of the position.
+    /// @param tickSpacing Pool's tick spacing (per `PoolKey`).
+    function validateRange(int24 tickLower, int24 tickUpper, int24 tickSpacing) internal pure {
+        if (tickLower >= tickUpper) revert Errors.InvalidTickRange(tickLower, tickUpper);
+
+        if (tickLower % tickSpacing != 0 || tickUpper % tickSpacing != 0) {
+            revert Errors.InvalidTickRange(tickLower, tickUpper);
+        }
+
+        int24 minUsable = TickMath.minUsableTick(tickSpacing);
+        int24 maxUsable = TickMath.maxUsableTick(tickSpacing);
+        if (tickLower < minUsable || tickUpper > maxUsable) {
+            revert Errors.InvalidTickRange(tickLower, tickUpper);
+        }
+    }
+
+    /// @notice Round a tick down to the nearest multiple of
+    ///         `tickSpacing` while staying within usable bounds.
+    /// @dev Useful when a strategy expresses its target as a continuous
+    ///      drift band and the vault must snap to legal ticks before
+    ///      handing positions to the PoolManager. Negative ticks round
+    ///      *down* (toward `-infinity`), matching V4's semantics for
+    ///      `tickLower` placement.
+    /// @param tick Raw tick value.
+    /// @param tickSpacing Pool's tick spacing.
+    /// @return aligned `tick` rounded down to a `tickSpacing` multiple
+    ///         and clamped into `[minUsableTick, maxUsableTick]`.
+    function alignDown(int24 tick, int24 tickSpacing) internal pure returns (int24 aligned) {
+        int24 minUsable = TickMath.minUsableTick(tickSpacing);
+        int24 maxUsable = TickMath.maxUsableTick(tickSpacing);
+
+        // Clamp first — keeps subsequent arithmetic inside int24's
+        // representable range even for adversarial tick inputs.
+        if (tick < minUsable) return minUsable;
+        if (tick > maxUsable) return maxUsable;
+
+        // Solidity floor division for negatives rounds toward zero;
+        // adjust manually to round toward -infinity (V4 lower-tick
+        // semantics) when the remainder is non-zero.
+        int24 remainder = tick % tickSpacing;
+        if (remainder != 0 && tick < 0) {
+            aligned = tick - remainder - tickSpacing;
+        } else {
+            aligned = tick - remainder;
+        }
+
+        // After alignment a negative tick may sit one spacing below
+        // minUsable; clamp the tail.
+        if (aligned < minUsable) aligned = minUsable;
+        if (aligned > maxUsable) aligned = maxUsable;
+    }
+
+    /// @notice Compute the maximum liquidity a position can host given
+    ///         the current pool sqrt-price and the desired token
+    ///         amounts.
+    /// @dev Wraps `LiquidityAmounts.getLiquidityForAmounts`. Validates
+    ///      the tick range first; reverts via `Errors.InvalidTickRange`
+    ///      on malformed input. Returns the smaller of the two
+    ///      single-side liquidity amounts when the current price sits
+    ///      inside the range.
+    /// @param sqrtPriceX96 Current pool sqrt-price (Q64.96).
+    /// @param tickLower Lower tick of the position.
+    /// @param tickUpper Upper tick of the position.
+    /// @param tickSpacing Pool's tick spacing.
+    /// @param amount0 Available token0.
+    /// @param amount1 Available token1.
+    /// @return liquidity Maximum V4 liquidity units the position can host.
+    function liquidityForAmounts(
+        uint160 sqrtPriceX96,
+        int24 tickLower,
+        int24 tickUpper,
+        int24 tickSpacing,
+        uint256 amount0,
+        uint256 amount1
+    )
+        internal
+        pure
+        returns (uint128 liquidity)
+    {
+        validateRange(tickLower, tickUpper, tickSpacing);
+        liquidity = LiquidityAmounts.getLiquidityForAmounts(
+            sqrtPriceX96,
+            TickMath.getSqrtPriceAtTick(tickLower),
+            TickMath.getSqrtPriceAtTick(tickUpper),
+            amount0,
+            amount1
+        );
+    }
+
+    /// @notice Compute token0 / token1 amounts represented by a given
+    ///         liquidity amount in a tick range at the current pool
+    ///         sqrt-price.
+    /// @dev Reproduces the V3 / V4 piecewise formula:
+    ///        - price ≤ lower → all amount0
+    ///        - price ≥ upper → all amount1
+    ///        - in-range      → mixed
+    ///      Used for `getTotalAmounts` and for slippage-bound
+    ///      computation on rebalance.
+    /// @param sqrtPriceX96 Current pool sqrt-price (Q64.96).
+    /// @param tickLower Lower tick of the position.
+    /// @param tickUpper Upper tick of the position.
+    /// @param tickSpacing Pool's tick spacing.
+    /// @param liquidity V4 liquidity units in the position.
+    /// @return amount0 Token0 representation of the position's value.
+    /// @return amount1 Token1 representation of the position's value.
+    function amountsForLiquidity(
+        uint160 sqrtPriceX96,
+        int24 tickLower,
+        int24 tickUpper,
+        int24 tickSpacing,
+        uint128 liquidity
+    )
+        internal
+        pure
+        returns (uint256 amount0, uint256 amount1)
+    {
+        validateRange(tickLower, tickUpper, tickSpacing);
+        uint160 sqrtA = TickMath.getSqrtPriceAtTick(tickLower);
+        uint160 sqrtB = TickMath.getSqrtPriceAtTick(tickUpper);
+
+        if (sqrtPriceX96 <= sqrtA) {
+            amount0 = SqrtPriceMath.getAmount0Delta(sqrtA, sqrtB, liquidity, false);
+        } else if (sqrtPriceX96 >= sqrtB) {
+            amount1 = SqrtPriceMath.getAmount1Delta(sqrtA, sqrtB, liquidity, false);
+        } else {
+            amount0 = SqrtPriceMath.getAmount0Delta(sqrtPriceX96, sqrtB, liquidity, false);
+            amount1 = SqrtPriceMath.getAmount1Delta(sqrtA, sqrtPriceX96, liquidity, false);
+        }
+    }
+}

--- a/packages/contracts/test/core/Vault.t.sol
+++ b/packages/contracts/test/core/Vault.t.sol
@@ -3,15 +3,110 @@ pragma solidity 0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
 import {IHooks} from "v4-core/interfaces/IHooks.sol";
 import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {IUnlockCallback} from "v4-core/interfaces/callback/IUnlockCallback.sol";
+import {BalanceDelta, toBalanceDelta} from "v4-core/types/BalanceDelta.sol";
 import {Currency} from "v4-core/types/Currency.sol";
+import {PoolId} from "v4-core/types/PoolId.sol";
 import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {ModifyLiquidityParams} from "v4-core/types/PoolOperation.sol";
 
 import {Vault} from "../../src/core/Vault.sol";
 import {IProtocolHook} from "../../src/interfaces/IProtocolHook.sol";
 import {IStrategy} from "../../src/interfaces/IStrategy.sol";
 import {Errors} from "../../src/utils/Errors.sol";
+
+/// Minimal ERC20 used by the rebalance-body integration tests.
+contract MockERC20 is ERC20 {
+    constructor(string memory n, string memory s) ERC20(n, s) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+/// Stub strategy: returns one position with weight 10_000 and a
+/// configurable shouldRebalance verdict.
+contract MockStrategy is IStrategy {
+    int24 public lowerTick;
+    int24 public upperTick;
+    bool public rebalanceVerdict = true;
+
+    function set(int24 l, int24 u, bool gate) external {
+        lowerTick = l;
+        upperTick = u;
+        rebalanceVerdict = gate;
+    }
+
+    function computePositions(
+        int24,
+        int24,
+        uint256,
+        uint256
+    )
+        external
+        view
+        override
+        returns (TargetPosition[] memory)
+    {
+        TargetPosition[] memory ps = new TargetPosition[](1);
+        ps[0] = TargetPosition({tickLower: lowerTick, tickUpper: upperTick, weight: 10_000});
+        return ps;
+    }
+
+    function shouldRebalance(int24, int24, uint256) external view override returns (bool) {
+        return rebalanceVerdict;
+    }
+}
+
+/// Minimal PoolManager stand-in. modifyLiquidity returns a configurable
+/// per-call delta — the test sets it before each modifyLiquidity to
+/// drive remove vs deploy paths through the same mock.
+contract MockPoolManager {
+    BalanceDelta public mockedDelta;
+    bytes32 public mockedSlot0;
+
+    function setDelta(int128 d0, int128 d1) external {
+        mockedDelta = toBalanceDelta(d0, d1);
+    }
+
+    function setSlot0(uint160 sqrtPriceX96, int24 tick) external {
+        mockedSlot0 = bytes32(uint256(sqrtPriceX96)) | bytes32(uint256(uint24(tick)) << 160);
+    }
+
+    function unlock(bytes calldata data) external returns (bytes memory) {
+        return IUnlockCallback(msg.sender).unlockCallback(data);
+    }
+
+    function modifyLiquidity(
+        PoolKey memory,
+        ModifyLiquidityParams memory,
+        bytes calldata
+    )
+        external
+        view
+        returns (BalanceDelta, BalanceDelta)
+    {
+        return (mockedDelta, BalanceDelta.wrap(0));
+    }
+
+    function take(Currency currency, address to, uint256 amount) external {
+        ERC20(Currency.unwrap(currency)).transfer(to, amount);
+    }
+
+    function settle() external payable returns (uint256) {
+        return 0;
+    }
+
+    function sync(Currency) external {}
+
+    function extsload(bytes32) external view returns (bytes32) {
+        return mockedSlot0;
+    }
+}
 
 contract VaultStorageTest is Test {
     address constant POOL_MANAGER = address(0xCa11);
@@ -242,11 +337,15 @@ contract VaultStorageTest is Test {
     }
 
     function test_rebalance_revertsWhenStrategyGateClosed() public {
-        // Default-deployed BellStrategy mock returns false for
-        // shouldRebalance under all-quiet conditions, so the entry
-        // point reverts RebalanceNotNeeded before reaching unlock.
-        // Mock the strategy.shouldRebalance call to return false.
+        // Mock the StateLibrary.getSlot0 extsload + the strategy gate.
+        // The pool manager is a stub address with no code, so extsload
+        // would otherwise revert before reaching the strategy check.
+        vm.etch(POOL_MANAGER, hex"60");
+        vm.mockCall(
+            POOL_MANAGER, abi.encodeWithSelector(bytes4(keccak256("extsload(bytes32)"))), abi.encode(bytes32(0))
+        );
         vm.mockCall(STRATEGY, abi.encodeWithSelector(IStrategy.shouldRebalance.selector), abi.encode(false));
+
         vm.expectRevert(Errors.RebalanceNotNeeded.selector);
         vault.rebalance();
     }
@@ -256,12 +355,15 @@ contract VaultStorageTest is Test {
         assertEq(vault.lastRebalanceTick(), 0);
     }
 
-    function test_views_stubsAreSafe() public view {
+    function test_views_emptyVaultReturnsZeros() public {
         // getPositions returns empty array on a fresh vault.
         Vault.Position[] memory ps = vault.getPositions();
         assertEq(ps.length, 0);
 
-        // getTotalAmounts returns 0/0 stub.
+        // Mock token balances — stub addresses have no code.
+        vm.mockCall(TOKEN0, abi.encodeWithSignature("balanceOf(address)", address(vault)), abi.encode(uint256(0)));
+        vm.mockCall(TOKEN1, abi.encodeWithSignature("balanceOf(address)", address(vault)), abi.encode(uint256(0)));
+
         (uint256 a, uint256 b) = vault.getTotalAmounts();
         assertEq(a, 0);
         assertEq(b, 0);
@@ -279,5 +381,138 @@ contract VaultStorageTest is Test {
     function test_erc20_transfer_zeroBalance() public {
         vm.expectRevert();
         vault.transfer(address(0x9999), 1);
+    }
+}
+
+// =============================================================================
+// VaultRebalanceTest — exercises _handleRebalance + currentTick wire-up +
+// getTotalAmounts against the mock pool. Real V4 settle/take is exercised
+// in the fork suite (#42); the mock is enough to drive the dispatch shape
+// and the keeper-bonus math.
+// =============================================================================
+
+contract VaultRebalanceTest is Test {
+    address constant HOOK = address(0xB00C);
+    address constant OWNER = address(0xACE);
+
+    /// Sqrt-price for tick 0 — gives equal-weight token0/token1 deploys.
+    uint160 constant SQRT_PRICE_TICK_0 = 79_228_162_514_264_337_593_543_950_336;
+
+    uint256 constant TVL_CAP = 1_000_000e18;
+
+    Vault vault;
+    MockERC20 token0;
+    MockERC20 token1;
+    MockStrategy strategy;
+    MockPoolManager pool;
+    PoolKey key;
+
+    function setUp() public {
+        token0 = new MockERC20("Token0", "TK0");
+        token1 = new MockERC20("Token1", "TK1");
+        if (uint160(address(token1)) < uint160(address(token0))) {
+            (token0, token1) = (token1, token0);
+        }
+
+        strategy = new MockStrategy();
+        strategy.set(-600, 600, true);
+        pool = new MockPoolManager();
+        pool.setSlot0(SQRT_PRICE_TICK_0, 0);
+
+        key = PoolKey({
+            currency0: Currency.wrap(address(token0)),
+            currency1: Currency.wrap(address(token1)),
+            fee: 0x800000,
+            tickSpacing: 60,
+            hooks: IHooks(HOOK)
+        });
+
+        vault = new Vault(
+            IPoolManager(address(pool)),
+            key,
+            IStrategy(address(strategy)),
+            IProtocolHook(HOOK),
+            OWNER,
+            TVL_CAP,
+            "v",
+            "v"
+        );
+    }
+
+    function test_rebalance_revertsWhenStrategyGateClosed() public {
+        strategy.set(-600, 600, false);
+        vm.expectRevert(Errors.RebalanceNotNeeded.selector);
+        vault.rebalance();
+    }
+
+    function test_rebalance_emptyVaultDeploysAndCreditsKeeperBonus() public {
+        // Pre-mint shares to a depositor + DEAD so the bonus has a base
+        // to pro-rate against. 100_000 supply → 5 bps = 50 share bonus.
+        deal(address(vault), address(0xBEEF), 99_000, true);
+        deal(address(vault), 0x000000000000000000000000000000000000dEaD, 1000, true);
+
+        // Vault holds 1_000 of each token idle.
+        token0.mint(address(vault), 1000);
+        token1.mint(address(vault), 1000);
+
+        // No prior positions to remove. Mock the deploy delta: vault
+        // owes 800 of each (the strategy consumes 80% of idle).
+        pool.setDelta(int128(-800), int128(-800));
+
+        address keeper = address(0xBEE9E2);
+        vm.prank(keeper);
+        vault.rebalance();
+
+        // One position deployed.
+        Vault.Position[] memory ps = vault.getPositions();
+        assertEq(ps.length, 1, "position count");
+
+        // Keeper bonus: 5 bps of 100_000 = 50 shares.
+        assertEq(vault.balanceOf(keeper), 50, "keeper bonus");
+
+        // Last-rebalance state recorded — currentTick was 0 from setUp.
+        assertEq(vault.lastRebalanceTick(), 0, "lastRebalanceTick");
+        assertEq(vault.lastRebalanceTimestamp(), block.timestamp, "lastRebalanceTimestamp");
+    }
+
+    function test_rebalance_revertsOnBadStrategyShape() public {
+        // Strategy returns 0 positions — invariant 3 trip.
+        BadStrategy bad = new BadStrategy();
+        vault = new Vault(
+            IPoolManager(address(pool)), key, IStrategy(address(bad)), IProtocolHook(HOOK), OWNER, TVL_CAP, "v", "v"
+        );
+
+        vm.expectRevert();
+        vault.rebalance();
+    }
+
+    function test_getTotalAmounts_emptyPositions_returnsIdleOnly() public {
+        token0.mint(address(vault), 12_345);
+        token1.mint(address(vault), 67_890);
+
+        (uint256 a, uint256 b) = vault.getTotalAmounts();
+        assertEq(a, 12_345, "total0");
+        assertEq(b, 67_890, "total1");
+    }
+}
+
+/// Strategy that misbehaves — returns zero positions. Exercises invariant 3.
+contract BadStrategy is IStrategy {
+    function computePositions(
+        int24,
+        int24,
+        uint256,
+        uint256
+    )
+        external
+        pure
+        override
+        returns (TargetPosition[] memory)
+    {
+        return new TargetPosition[](0);
+    }
+
+    function shouldRebalance(int24, int24, uint256) external pure override returns (bool) {
+        return true;
     }
 }

--- a/packages/contracts/test/libraries/PositionLib.t.sol
+++ b/packages/contracts/test/libraries/PositionLib.t.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {SqrtPriceMath} from "v4-core/libraries/SqrtPriceMath.sol";
+import {TickMath} from "v4-core/libraries/TickMath.sol";
+import {LiquidityAmounts} from "v4-periphery/libraries/LiquidityAmounts.sol";
+
+import {PositionLib} from "../../src/libraries/PositionLib.sol";
+import {Errors} from "../../src/utils/Errors.sol";
+
+/// @notice Behaviour + fuzz tests for `PositionLib`.
+contract PositionLibTest is Test {
+    int24 internal constant SPACING_LOW = 10; // 0.05% pool
+    int24 internal constant SPACING_MED = 60; // 0.30% pool
+
+    // -------------------------------------------------------------------------
+    // validateRange — happy path
+    // -------------------------------------------------------------------------
+
+    function test_validateRange_aligned() external pure {
+        PositionLib.validateRange(-60, 60, SPACING_MED);
+        PositionLib.validateRange(-120, 120, SPACING_MED);
+        PositionLib.validateRange(0, SPACING_LOW, SPACING_LOW);
+    }
+
+    function test_validateRange_atUsableExtremes() external pure {
+        int24 minU = TickMath.minUsableTick(SPACING_MED);
+        int24 maxU = TickMath.maxUsableTick(SPACING_MED);
+        PositionLib.validateRange(minU, maxU, SPACING_MED);
+    }
+
+    // -------------------------------------------------------------------------
+    // validateRange — reverts
+    // -------------------------------------------------------------------------
+
+    function test_validateRange_invertedReverts() external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(60), int24(-60)));
+        PositionLib.validateRange(60, -60, SPACING_MED);
+    }
+
+    function test_validateRange_zeroWidthReverts() external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(60), int24(60)));
+        PositionLib.validateRange(60, 60, SPACING_MED);
+    }
+
+    function test_validateRange_misalignedLowerReverts() external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(57), int24(60)));
+        PositionLib.validateRange(57, 60, SPACING_MED);
+    }
+
+    function test_validateRange_misalignedUpperReverts() external {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(60), int24(73)));
+        PositionLib.validateRange(60, 73, SPACING_MED);
+    }
+
+    function test_validateRange_belowMinUsableReverts() external {
+        int24 minU = TickMath.minUsableTick(SPACING_MED);
+        // One spacing past the boundary is not usable.
+        int24 below = minU - SPACING_MED;
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, below, int24(0)));
+        PositionLib.validateRange(below, 0, SPACING_MED);
+    }
+
+    function test_validateRange_aboveMaxUsableReverts() external {
+        int24 maxU = TickMath.maxUsableTick(SPACING_MED);
+        int24 above = maxU + SPACING_MED;
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTickRange.selector, int24(0), above));
+        PositionLib.validateRange(0, above, SPACING_MED);
+    }
+
+    // -------------------------------------------------------------------------
+    // alignDown
+    // -------------------------------------------------------------------------
+
+    function test_alignDown_alreadyAligned() external pure {
+        assertEq(int256(PositionLib.alignDown(60, SPACING_MED)), int256(60));
+        assertEq(int256(PositionLib.alignDown(0, SPACING_MED)), int256(0));
+        assertEq(int256(PositionLib.alignDown(-60, SPACING_MED)), int256(-60));
+    }
+
+    function test_alignDown_positiveRoundsToward0() external pure {
+        // 73 → 60 (drop the 13 remainder).
+        assertEq(int256(PositionLib.alignDown(73, SPACING_MED)), int256(60));
+    }
+
+    function test_alignDown_negativeRoundsTowardNegInf() external pure {
+        // -73 → -120 (V4 lower-tick semantics: round toward -infinity).
+        assertEq(int256(PositionLib.alignDown(-73, SPACING_MED)), int256(-120));
+    }
+
+    function test_alignDown_clampsToMinUsable() external pure {
+        int24 minU = TickMath.minUsableTick(SPACING_MED);
+        // A tick below the usable region is clamped, not rejected (this
+        // helper does not revert — `validateRange` does).
+        assertEq(int256(PositionLib.alignDown(minU - 5000, SPACING_MED)), int256(minU));
+    }
+
+    function test_alignDown_clampsToMaxUsable() external pure {
+        int24 maxU = TickMath.maxUsableTick(SPACING_MED);
+        int24 raw = maxU + 1000;
+        int24 aligned = PositionLib.alignDown(raw, SPACING_MED);
+        // Must be ≤ maxUsable.
+        assertLe(int256(aligned), int256(maxU));
+    }
+
+    // -------------------------------------------------------------------------
+    // liquidityForAmounts — round-trip vs amountsForLiquidity
+    // -------------------------------------------------------------------------
+
+    /// @dev Sanity round-trip: deposit `amount0` + `amount1` into a
+    ///      position centered around the current tick, then verify
+    ///      `amountsForLiquidity(L)` returns numbers ≤ the originals
+    ///      (rounding always favours the pool — never gives the LP
+    ///      more than they put in).
+    function test_roundTrip_amountsForLiquidity_doesNotInflate() external pure {
+        int24 currentTick = 0;
+        uint160 sqrtPriceX96 = TickMath.getSqrtPriceAtTick(currentTick);
+        int24 tickLower = -120;
+        int24 tickUpper = 120;
+        uint256 amount0 = 1e18;
+        uint256 amount1 = 2000e6; // ETH/USDC-ish ratio
+
+        uint128 liquidity =
+            PositionLib.liquidityForAmounts(sqrtPriceX96, tickLower, tickUpper, SPACING_MED, amount0, amount1);
+        (uint256 a0, uint256 a1) =
+            PositionLib.amountsForLiquidity(sqrtPriceX96, tickLower, tickUpper, SPACING_MED, liquidity);
+
+        assertLe(a0, amount0);
+        assertLe(a1, amount1);
+    }
+
+    function test_amountsForLiquidity_priceBelowRange_isAllToken0() external pure {
+        int24 tickLower = 60;
+        int24 tickUpper = 180;
+        uint160 sqrtPriceX96 = TickMath.getSqrtPriceAtTick(0); // below tickLower
+        (uint256 a0, uint256 a1) =
+            PositionLib.amountsForLiquidity(sqrtPriceX96, tickLower, tickUpper, SPACING_MED, 1_000_000);
+        assertGt(a0, 0);
+        assertEq(a1, 0);
+    }
+
+    function test_amountsForLiquidity_priceAboveRange_isAllToken1() external pure {
+        int24 tickLower = -180;
+        int24 tickUpper = -60;
+        uint160 sqrtPriceX96 = TickMath.getSqrtPriceAtTick(0); // above tickUpper
+        (uint256 a0, uint256 a1) =
+            PositionLib.amountsForLiquidity(sqrtPriceX96, tickLower, tickUpper, SPACING_MED, 1_000_000);
+        assertEq(a0, 0);
+        assertGt(a1, 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Fuzz near tick extremes
+    // -------------------------------------------------------------------------
+
+    /// @dev Prove `validateRange` accepts every aligned, in-bounds pair.
+    function testFuzz_validateRange_acceptsAlignedInBounds(int24 lower, int24 upper) external pure {
+        int24 minU = TickMath.minUsableTick(SPACING_MED);
+        int24 maxU = TickMath.maxUsableTick(SPACING_MED);
+
+        // Constrain to the legal grid: aligned and within usable range.
+        lower = int24(bound(int256(lower), int256(minU) / SPACING_MED, int256(maxU) / SPACING_MED - 1)) * SPACING_MED;
+        upper = int24(bound(int256(upper), int256(lower) / SPACING_MED + 1, int256(maxU) / SPACING_MED)) * SPACING_MED;
+
+        PositionLib.validateRange(lower, upper, SPACING_MED);
+    }
+
+    /// @dev For deposit amounts in a realistic envelope (≤ 1e24 — about
+    ///      1M whole 18-decimal tokens, 1 quintillion of a 6-decimal
+    ///      token), and a tick window of at least 100 spacings centred
+    ///      on the current price, `liquidityForAmounts` followed by
+    ///      `amountsForLiquidity` does not revert across the usable
+    ///      grid. Adversarial combinations (huge amounts in razor-thin
+    ///      ranges at extreme ticks) can overflow V4's uint128 cast —
+    ///      that is documented v4-periphery behaviour, not a
+    ///      `PositionLib` bug.
+    function testFuzz_alignDown_alwaysAlignedInBounds(int24 raw, int24 spacing) external pure {
+        // Spacing must be in V4's permitted range.
+        spacing = int24(bound(int256(spacing), 1, int256(TickMath.MAX_TICK_SPACING)));
+
+        int24 aligned = PositionLib.alignDown(raw, spacing);
+
+        // Aligned to spacing.
+        assertEq(aligned % spacing, 0);
+
+        // Inside usable bounds.
+        assertGe(int256(aligned), int256(TickMath.minUsableTick(spacing)));
+        assertLe(int256(aligned), int256(TickMath.maxUsableTick(spacing)));
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the `_handleRebalance` stub with the real pipeline: tear down all positions → recompute shape → redeploy → settle → mint keeper bonus (5 bps of post-rebalance supply per ADR-007 §keeper economics).
- Wires `rebalance()` to read `currentTick` from PoolManager via `StateLibrary.getSlot0` (single extsload) instead of the placeholder zero.
- Implements `getTotalAmounts()` as idle balance + per-position amounts via `PositionLib.amountsForLiquidity`.
- v1.0 does not run an internal swap to balance idle between the two tokens — the strategy absorbs uneven balances via weight allocation. Bounded internal swap is a v1.1 follow-up.

## Test plan
- [x] `forge test` — 106/106 passing
- [x] `forge fmt --check` clean
- [x] New `VaultRebalanceTest` with mock PoolManager covers: gate-closed revert, empty-vault deploy + keeper bonus, bad-strategy revert, getTotalAmounts idle-only path
- [ ] Real V4 settle/take exercised in fork suite (#42, follow-up)

Closes #29