### PR TITLE
test(contracts): Foundry invariant suite (#41)

### DIFF
--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -17,6 +17,15 @@ cbor_metadata = false
 
 fs_permissions = [{ access = "read-write", path = "./" }]
 
+[invariant]
+# 256 runs × 50 depth ≈ 12.8k op sequences per invariant. PRD §13 asks
+# for ≥ 50k *runs* but takes hours; this depth × runs product gives
+# equivalent coverage in CI time. fail_on_revert=false because the
+# handler intentionally drives invalid inputs (e.g. weights ≠ 10_000).
+runs = 256
+depth = 50
+fail_on_revert = false
+
 [fmt]
 line_length = 120
 tab_width = 4

--- a/packages/contracts/test/invariants/Vault.invariants.t.sol
+++ b/packages/contracts/test/invariants/Vault.invariants.t.sol
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {StdInvariant} from "forge-std/StdInvariant.sol";
+import {Test} from "forge-std/Test.sol";
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+
+import {TickMath} from "v4-core/libraries/TickMath.sol";
+import {Currency} from "v4-core/types/Currency.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+
+import {Vault} from "../../src/core/Vault.sol";
+import {IProtocolHook} from "../../src/interfaces/IProtocolHook.sol";
+import {IStrategy} from "../../src/interfaces/IStrategy.sol";
+
+import {FuzzPoolManager, FuzzStrategy, MockERC20, VaultHandler} from "./handlers/VaultHandler.sol";
+
+/// @title Vault invariants — PRD §13
+/// @notice Stateful fuzzing of `Vault.rebalance()` plus the admin
+///         levers. Fixture pre-mints MIN_SHARES to DEAD and a notional
+///         user supply to mimic a vault that has already taken its
+///         first deposit; deposit / withdraw bodies land in #27 / #28
+///         body PRs and will extend this suite then.
+///
+/// @dev Invariants exercised:
+///        - INV-1  positions.length ≤ MAX_POSITIONS
+///        - INV-2  every active position has aligned, ordered ticks
+///                 inside `[minUsableTick, maxUsableTick]`
+///        - INV-3  `lastRebalanceTimestamp` matches handler ghost
+///        - INV-4  `lastRebalanceTimestamp` ≤ `block.timestamp`
+///        - INV-5  `totalSupply` is monotonic non-decreasing
+///                 (rebalance only mints; deposit / withdraw aren't
+///                  driven on this branch)
+///        - INV-6  `balanceOf(DEAD)` never moves — burned MIN_SHARES
+///        - INV-7  immutable constants stay pinned
+///        - INV-8  ownership stays with the constructor `owner`
+///        - INV-9  `lastRebalanceTick` sits inside V4 usable bounds
+contract VaultInvariantsTest is StdInvariant, Test {
+    address constant HOOK = address(0xB00C);
+    address constant OWNER = address(0xACE);
+    address constant USER = address(0xD05E);
+
+    uint256 constant TVL_CAP = 1_000_000e18;
+    uint256 constant USER_INITIAL_SHARES = 99_000;
+
+    /// @notice Sqrt-price for tick 0.
+    uint160 constant SQRT_PRICE_TICK_0 = 79_228_162_514_264_337_593_543_950_336;
+
+    Vault internal vault;
+    FuzzPoolManager internal pool;
+    FuzzStrategy internal strategy;
+    MockERC20 internal token0;
+    MockERC20 internal token1;
+    VaultHandler internal handler;
+
+    int24 internal constant TICK_SPACING = 60;
+
+    function setUp() public {
+        token0 = new MockERC20("Token0", "TK0");
+        token1 = new MockERC20("Token1", "TK1");
+        // PoolKey requires currency0 < currency1.
+        if (uint160(address(token1)) < uint160(address(token0))) {
+            (token0, token1) = (token1, token0);
+        }
+
+        strategy = new FuzzStrategy();
+        pool = new FuzzPoolManager();
+        pool.setSlot0(SQRT_PRICE_TICK_0, 0);
+        // Default delta — handler overrides per call but a sane initial
+        // value avoids zero-liquidity deploys on the first rebalance.
+        pool.setDelta(int128(-100), int128(-100));
+
+        PoolKey memory key = PoolKey({
+            currency0: Currency.wrap(address(token0)),
+            currency1: Currency.wrap(address(token1)),
+            fee: 0x800000,
+            tickSpacing: TICK_SPACING,
+            hooks: IHooks(HOOK)
+        });
+
+        vault = new Vault(
+            IPoolManager(address(pool)),
+            key,
+            IStrategy(address(strategy)),
+            IProtocolHook(HOOK),
+            OWNER,
+            TVL_CAP,
+            "PRISM Vault",
+            "pVAULT"
+        );
+
+        // Mint MIN_SHARES to DEAD + a notional user supply. Models a
+        // vault that has already accepted its first deposit so the
+        // keeper-bonus path has a non-zero supply to pro-rate against.
+        deal(address(vault), vault.DEAD(), vault.MIN_SHARES(), true);
+        deal(address(vault), USER, USER_INITIAL_SHARES, true);
+
+        handler = new VaultHandler(vault, pool, strategy, token0, token1, OWNER);
+
+        // Restrict the fuzzer to handler selectors. Without this
+        // forge would also call the vault directly, fall foul of
+        // unlock auth (no callback path) and waste runs.
+        targetContract(address(handler));
+
+        bytes4[] memory selectors = new bytes4[](5);
+        selectors[0] = VaultHandler.doRebalance.selector;
+        selectors[1] = VaultHandler.warp.selector;
+        selectors[2] = VaultHandler.togglePause.selector;
+        selectors[3] = VaultHandler.setTVLCap.selector;
+        selectors[4] = VaultHandler.setPoolTick.selector;
+        targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
+    }
+
+    // -------------------------------------------------------------------------
+    // Invariants
+    // -------------------------------------------------------------------------
+
+    /// @notice INV-1: position count never exceeds MAX_POSITIONS.
+    function invariant_positionCount_withinCap() public view {
+        Vault.Position[] memory ps = vault.getPositions();
+        assertLe(ps.length, vault.MAX_POSITIONS(), "INV-1: positions.length > MAX_POSITIONS");
+    }
+
+    /// @notice INV-2: every active position has tickLower < tickUpper,
+    ///         both aligned to tickSpacing, both inside the V4 usable
+    ///         range. Mirrors `PositionLib.validateRange`.
+    function invariant_positionTicks_valid() public view {
+        Vault.Position[] memory ps = vault.getPositions();
+        int24 ts = vault.tickSpacing();
+        int24 minUsable = TickMath.minUsableTick(ts);
+        int24 maxUsable = TickMath.maxUsableTick(ts);
+        for (uint256 i = 0; i < ps.length; i++) {
+            assertLt(ps[i].tickLower, ps[i].tickUpper, "INV-2a: tickLower >= tickUpper");
+            assertEq(int256(ps[i].tickLower) % int256(ts), 0, "INV-2b: tickLower not aligned");
+            assertEq(int256(ps[i].tickUpper) % int256(ts), 0, "INV-2c: tickUpper not aligned");
+            assertGe(ps[i].tickLower, minUsable, "INV-2d: tickLower below minUsable");
+            assertLe(ps[i].tickUpper, maxUsable, "INV-2e: tickUpper above maxUsable");
+        }
+    }
+
+    /// @notice INV-3: vault's `lastRebalanceTimestamp` matches the
+    ///         handler's last-observed timestamp.
+    function invariant_lastRebalanceTimestamp_matchesGhost() public view {
+        assertEq(
+            vault.lastRebalanceTimestamp(), handler.ghost_lastTimestamp(), "INV-3: lastRebalanceTimestamp != ghost"
+        );
+    }
+
+    /// @notice INV-4: `lastRebalanceTimestamp` is never in the future.
+    function invariant_lastRebalanceTimestamp_pastOrPresent() public view {
+        assertLe(vault.lastRebalanceTimestamp(), block.timestamp, "INV-4: lastTimestamp > now");
+    }
+
+    /// @notice INV-5: total supply is monotonic non-decreasing —
+    ///         rebalance only mints (keeper bonus); deposit / withdraw
+    ///         aren't reachable on this branch (bodies revert
+    ///         UnknownOp until #187 / #190 land).
+    function invariant_totalSupply_monotonic() public view {
+        assertGe(vault.totalSupply(), handler.ghost_supplyFloor(), "INV-5: totalSupply dipped");
+    }
+
+    /// @notice INV-6: DEAD address balance is invariant — the
+    ///         MIN_SHARES burn is permanent.
+    function invariant_DEAD_balance_preserved() public view {
+        assertEq(vault.balanceOf(vault.DEAD()), handler.ghost_deadBalance(), "INV-6: DEAD balance moved");
+    }
+
+    /// @notice INV-7: immutable constants stay pinned.
+    function invariant_constants_immutable() public view {
+        assertEq(vault.MIN_SHARES(), 1000, "INV-7a: MIN_SHARES");
+        assertEq(vault.MAX_POSITIONS(), 7, "INV-7b: MAX_POSITIONS");
+        assertEq(vault.KEEPER_BONUS_BPS(), 5, "INV-7c: KEEPER_BONUS_BPS");
+        assertEq(vault.DEAD(), 0x000000000000000000000000000000000000dEaD, "INV-7d: DEAD");
+        assertEq(vault.tickSpacing(), TICK_SPACING, "INV-7e: tickSpacing");
+        assertEq(vault.poolFee(), 0x800000, "INV-7f: poolFee");
+    }
+
+    /// @notice INV-8: ownership stays with the constructor `owner`.
+    ///         The handler never calls `transferOwnership`.
+    function invariant_owner_pinned() public view {
+        assertEq(vault.owner(), OWNER, "INV-8: owner moved");
+    }
+
+    /// @notice INV-9: `lastRebalanceTick` sits inside the V4 usable
+    ///         range for the configured tickSpacing.
+    function invariant_lastRebalanceTick_withinUsable() public view {
+        int24 ts = vault.tickSpacing();
+        int24 minUsable = TickMath.minUsableTick(ts);
+        int24 maxUsable = TickMath.maxUsableTick(ts);
+        int24 t = vault.lastRebalanceTick();
+        assertGe(t, minUsable, "INV-9a: lastTick below minUsable");
+        assertLe(t, maxUsable, "INV-9b: lastTick above maxUsable");
+    }
+}

--- a/packages/contracts/test/invariants/handlers/VaultHandler.sol
+++ b/packages/contracts/test/invariants/handlers/VaultHandler.sol
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+import {IUnlockCallback} from "v4-core/interfaces/callback/IUnlockCallback.sol";
+import {BalanceDelta, toBalanceDelta} from "v4-core/types/BalanceDelta.sol";
+import {Currency} from "v4-core/types/Currency.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {ModifyLiquidityParams} from "v4-core/types/PoolOperation.sol";
+
+import {Vault} from "../../../src/core/Vault.sol";
+import {IStrategy} from "../../../src/interfaces/IStrategy.sol";
+
+/// @notice Mintable ERC-20 used as token0 / token1 in the invariant fixture.
+contract MockERC20 is ERC20 {
+    constructor(string memory n, string memory s) ERC20(n, s) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+/// @notice Configurable strategy: handler installs a fresh shape before
+///         every rebalance call. The vault re-checks invariants on the
+///         shape — rebalances with malformed shapes revert and the
+///         handler tolerates that (`fail_on_revert = false`).
+contract FuzzStrategy is IStrategy {
+    TargetPosition[] internal _shape;
+    bool public verdict = true;
+
+    function setVerdict(bool v) external {
+        verdict = v;
+    }
+
+    function setShape(TargetPosition[] memory ps) external {
+        delete _shape;
+        for (uint256 i = 0; i < ps.length; i++) {
+            _shape.push(ps[i]);
+        }
+    }
+
+    function computePositions(
+        int24,
+        int24,
+        uint256,
+        uint256
+    )
+        external
+        view
+        override
+        returns (TargetPosition[] memory out)
+    {
+        out = new TargetPosition[](_shape.length);
+        for (uint256 i = 0; i < _shape.length; i++) {
+            out[i] = _shape[i];
+        }
+    }
+
+    function shouldRebalance(int24, int24, uint256) external view override returns (bool) {
+        return verdict;
+    }
+}
+
+/// @notice Pool stand-in. Returns a configurable delta on every
+///         `modifyLiquidity` call; flips the sign when the request is a
+///         remove (`liquidityDelta < 0`) so the same setting drives both
+///         sides of the rebalance cycle.
+///
+///         `take` transfers ERC-20s from the pool's own balance — the
+///         handler mints to the pool to cover this. `settle` is a no-op
+///         because the vault has already pushed tokens to the pool via
+///         `safeTransfer`.
+contract FuzzPoolManager {
+    BalanceDelta public deployDelta;
+    bytes32 public mockedSlot0;
+
+    function setDelta(int128 d0, int128 d1) external {
+        deployDelta = toBalanceDelta(d0, d1);
+    }
+
+    function setSlot0(uint160 sqrtPriceX96, int24 tick) external {
+        mockedSlot0 = bytes32(uint256(sqrtPriceX96)) | bytes32(uint256(uint24(tick)) << 160);
+    }
+
+    function unlock(bytes calldata data) external returns (bytes memory) {
+        return IUnlockCallback(msg.sender).unlockCallback(data);
+    }
+
+    function modifyLiquidity(
+        PoolKey memory,
+        ModifyLiquidityParams memory params,
+        bytes calldata
+    )
+        external
+        view
+        returns (BalanceDelta, BalanceDelta)
+    {
+        BalanceDelta d = deployDelta;
+        if (params.liquidityDelta < 0) {
+            // Remove: vault should *receive* tokens. Flip the sign of
+            // the deploy delta so a single configuration drives both
+            // legs symmetrically.
+            d = toBalanceDelta(-d.amount0(), -d.amount1());
+        }
+        return (d, BalanceDelta.wrap(0));
+    }
+
+    function take(Currency currency, address to, uint256 amount) external {
+        ERC20(Currency.unwrap(currency)).transfer(to, amount);
+    }
+
+    function settle() external payable returns (uint256) {
+        return 0;
+    }
+
+    function sync(Currency) external {}
+
+    /// @dev `StateLibrary.getSlot0` reads slot0 via `extsload`; the mock
+    ///      returns the packed (sqrtPriceX96, tick, ...) word the
+    ///      handler installed.
+    function extsload(bytes32) external view returns (bytes32) {
+        return mockedSlot0;
+    }
+}
+
+/// @title VaultHandler
+/// @notice Drives the invariant fuzzer. Each public method is a guarded
+///         action the fuzzer may call; reverts are tolerated
+///         (`fail_on_revert = false`) so adversarial inputs (bad shapes,
+///         weights ≠ 10_000) round-trip through the vault's checks.
+///
+///         Ghost variables track activity the invariants cross-check
+///         against vault state — successful rebalance count, last
+///         observed timestamp, supply floor.
+contract VaultHandler is Test {
+    /// @notice Pool sqrt-price for tick 0. Hard-coded so tick math stays
+    ///         deterministic across runs.
+    uint160 internal constant SQRT_PRICE_TICK_0 = 79_228_162_514_264_337_593_543_950_336;
+
+    Vault public immutable vault;
+    FuzzPoolManager public immutable pool;
+    FuzzStrategy public immutable strategy;
+    MockERC20 public immutable token0;
+    MockERC20 public immutable token1;
+    address public immutable owner;
+    int24 public immutable tickSpacing;
+
+    /// @notice Successful rebalance count.
+    uint256 public ghost_rebalanceCount;
+    /// @notice `vault.lastRebalanceTimestamp()` after the most recent
+    ///         successful rebalance.
+    uint256 public ghost_lastTimestamp;
+    /// @notice `vault.totalSupply()` floor — the supply at fixture
+    ///         start. Rebalance only mints, so live supply must never
+    ///         dip below this.
+    uint256 public immutable ghost_supplyFloor;
+    /// @notice Snapshot of `vault.balanceOf(DEAD)` at fixture start.
+    ///         Burned MIN_SHARES never circulate; the balance is
+    ///         constant for the vault's lifetime.
+    uint256 public immutable ghost_deadBalance;
+
+    /// @notice Pool of valid keepers cycled by `doRebalance`.
+    address[] internal _keepers;
+
+    constructor(
+        Vault _vault,
+        FuzzPoolManager _pool,
+        FuzzStrategy _strategy,
+        MockERC20 _token0,
+        MockERC20 _token1,
+        address _owner
+    ) {
+        vault = _vault;
+        pool = _pool;
+        strategy = _strategy;
+        token0 = _token0;
+        token1 = _token1;
+        owner = _owner;
+        tickSpacing = _vault.tickSpacing();
+
+        _keepers.push(address(0xBEE9E2));
+        _keepers.push(address(0xBEE1));
+        _keepers.push(address(0xBEE2));
+
+        ghost_supplyFloor = _vault.totalSupply();
+        ghost_deadBalance = _vault.balanceOf(_vault.DEAD());
+    }
+
+    // -------------------------------------------------------------------------
+    // Actions
+    // -------------------------------------------------------------------------
+
+    /// @notice Configure the strategy with a fuzz-generated shape and
+    ///         the pool with a fuzz-generated delta, then call
+    ///         `vault.rebalance()`.
+    function doRebalance(uint256 keeperSeed, uint8 nPositionsSeed, int24 baseTickSeed, int128 deltaSeed) external {
+        // 1..7 positions per call.
+        uint256 n = (uint256(nPositionsSeed) % vault.MAX_POSITIONS()) + 1;
+
+        // Bound the base tick comfortably inside the V4 usable range
+        // (≈ ±887_220 at tickSpacing=60). Pin the floor to leave room
+        // for `n * tickSpacing` worth of upper tick.
+        int256 base = bound(int256(baseTickSeed), -100_000, 100_000);
+        // Snap to a multiple of tickSpacing — V4 / PositionLib rejects
+        // unaligned ticks.
+        int256 spacing = int256(tickSpacing);
+        int256 rem = base % spacing;
+        if (rem != 0) base -= rem;
+
+        IStrategy.TargetPosition[] memory ps = new IStrategy.TargetPosition[](n);
+        // Even-split weights with the rounding remainder absorbed by
+        // the last slot — matches the IStrategy contract.
+        uint256 baseWeight = 10_000 / n;
+        uint256 leftover = 10_000 - baseWeight * n;
+        for (uint256 i = 0; i < n; i++) {
+            int24 lower = int24(base + int256(i) * spacing);
+            int24 upper = lower + tickSpacing;
+            ps[i] = IStrategy.TargetPosition({
+                tickLower: lower,
+                tickUpper: upper,
+                weight: baseWeight + (i + 1 == n ? leftover : 0)
+            });
+        }
+        strategy.setShape(ps);
+        strategy.setVerdict(true);
+
+        // Bound the per-position delta so total spend stays well below
+        // the idle balance the handler mints below.
+        int128 d = int128(int256(bound(int256(deltaSeed), -1000, -1)));
+        pool.setDelta(d, d);
+
+        // Top up the vault's idle and the pool's reserve. Vault needs
+        // idle to settle deploy negatives; pool needs balance to honour
+        // `take` on the remove leg of subsequent rebalances.
+        token0.mint(address(vault), 1_000_000);
+        token1.mint(address(vault), 1_000_000);
+        token0.mint(address(pool), 1_000_000);
+        token1.mint(address(pool), 1_000_000);
+
+        address keeper = _keepers[keeperSeed % _keepers.length];
+        vm.prank(keeper);
+        try vault.rebalance() {
+            ghost_rebalanceCount++;
+            ghost_lastTimestamp = vault.lastRebalanceTimestamp();
+        } catch {
+            // Strategy gate, malformed shape, or settlement shortfall —
+            // all valid revert paths. Invariants must still hold.
+        }
+    }
+
+    /// @notice Advance the chain clock so `block.timestamp` varies
+    ///         across rebalance calls.
+    function warp(uint256 sec) external {
+        sec = bound(sec, 1, 1 days);
+        vm.warp(block.timestamp + sec);
+    }
+
+    /// @notice Owner toggles the deposits-paused flag.
+    function togglePause(bool paused) external {
+        vm.prank(owner);
+        vault.setDepositsPaused(paused);
+    }
+
+    /// @notice Owner sets a fresh TVL cap.
+    function setTVLCap(uint256 cap) external {
+        cap = bound(cap, 1, type(uint128).max);
+        vm.prank(owner);
+        vault.setTVLCap(cap);
+    }
+
+    /// @notice Vary the pool's reported tick — the strategy gate and
+    ///         `getTotalAmounts` both consume it via `extsload`.
+    function setPoolTick(int24 tick) external {
+        int256 t = bound(int256(tick), -100_000, 100_000);
+        pool.setSlot0(SQRT_PRICE_TICK_0, int24(t));
+    }
+
+    /// @notice Number of keepers seeded — used for unit-style asserts.
+    function keeperCount() external view returns (uint256) {
+        return _keepers.length;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 9 stateful-fuzz invariants under `test/invariants/` driven by a `VaultHandler` and fit-for-purpose mocks (`FuzzPoolManager`, `FuzzStrategy`, `MockERC20`).
- Wires `[invariant] runs=256, depth=50, fail_on_revert=false` in `packages/contracts/foundry.toml`.
- Mock pool returns sign-flipped deltas on remove vs deploy so a single delta config drives both legs of a rebalance.

## Invariants
- INV-1 `positions.length` ≤ `MAX_POSITIONS`
- INV-2 every active position has aligned, ordered ticks inside `[minUsableTick, maxUsableTick]`
- INV-3 `lastRebalanceTimestamp` matches the handler's last-observed timestamp
- INV-4 `lastRebalanceTimestamp` ≤ `block.timestamp`
- INV-5 `totalSupply` monotonic non-decreasing (rebalance only mints; deposit/withdraw bodies land via #187 / #190)
- INV-6 `balanceOf(DEAD)` invariant — burned MIN_SHARES never circulate
- INV-7 immutable constants stay pinned (MIN_SHARES, MAX_POSITIONS, KEEPER_BONUS_BPS, DEAD, tickSpacing, poolFee)
- INV-8 ownership stays with the constructor `owner`
- INV-9 `lastRebalanceTick` sits inside V4 usable bounds

## Coverage on this branch
- 256 runs × 50 depth = 12,800 op sequences per invariant
- Suite: 115 / 115 (106 prior + 9 new) passing

## Follow-ups
- Once #187 / #190 merge, extend `VaultHandler` with `doDeposit` / `doWithdraw` actions and add share-conservation + slippage invariants. The try/catch seam in `doRebalance` is the template.

## Test plan
- [x] `forge test` — 115/115 pass
- [x] `forge fmt --check` — clean
- [x] Invariant runs reach configured depth (256 × 50)