### PR TITLE
feat(frontend): PrismVisual d3 liquidity distribution (#51)

### DIFF
--- a/apps/web/app/vaults/[address]/page.tsx
+++ b/apps/web/app/vaults/[address]/page.tsx
@@ -4,6 +4,7 @@ import {notFound} from "next/navigation";
 import {useMemo} from "react";
 import {isAddress} from "viem";
 
+import {PrismVisual, type PrismPosition} from "@/components/PrismVisual";
 import {formatBps, formatUsd} from "@/lib/vault-list";
 
 interface PageProps {
@@ -31,6 +32,12 @@ export default function VaultDetailPage({params}: PageProps) {
         <Metric label="APR (24h)" value={formatBps(detail.apr24hBps)} />
         <Metric label="Share price" value={formatUsd(detail.sharePriceUsd)} />
       </section>
+
+      <PrismVisual
+        positions={detail.positions}
+        currentTick={detail.currentTick}
+        tickSpacing={detail.tickSpacing}
+      />
 
       <PositionsTable positions={detail.positions} />
 
@@ -114,10 +121,7 @@ function DepositPanel({placeholder}: {placeholder: boolean}) {
   );
 }
 
-interface PlaceholderPosition {
-  tickLower: number;
-  tickUpper: number;
-  liquidity: bigint;
+interface PlaceholderPosition extends PrismPosition {
   token0: bigint;
   token1: bigint;
 }
@@ -130,6 +134,8 @@ interface PlaceholderDetail {
   apr24hBps: number;
   sharePriceUsd: bigint;
   positions: PlaceholderPosition[];
+  currentTick: number;
+  tickSpacing: number;
 }
 
 function usePlaceholderVault(address: string): PlaceholderDetail {
@@ -141,7 +147,16 @@ function usePlaceholderVault(address: string): PlaceholderDetail {
       tvlUsd: 0n,
       apr24hBps: 0,
       sharePriceUsd: 1_000_000n, // 1.000000 USDC (6 decimals)
-      positions: [],
+      // Placeholder shape — three positions either side of tick 0,
+      // weighted to draw a recognisable bell. Real values land with
+      // #31 (VaultFactory) + getTotalAmounts wire-up in M2.
+      positions: [
+        {tickLower: -1200, tickUpper: -600, liquidity: 4_000_000n, token0: 0n, token1: 0n},
+        {tickLower: -600, tickUpper: 600, liquidity: 10_000_000n, token0: 0n, token1: 0n},
+        {tickLower: 600, tickUpper: 1200, liquidity: 4_000_000n, token0: 0n, token1: 0n},
+      ],
+      currentTick: 0,
+      tickSpacing: 60,
     }),
     [address],
   );

--- a/apps/web/components/PrismVisual.tsx
+++ b/apps/web/components/PrismVisual.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import {scaleLinear} from "d3-scale";
+import {useMemo} from "react";
+
+/// One tick-range position the vault holds, with the V4 liquidity it
+/// represents. Mirrors `Vault.Position` in the contracts package.
+export interface PrismPosition {
+  tickLower: number;
+  tickUpper: number;
+  liquidity: bigint;
+}
+
+interface PrismVisualProps {
+  /// Positions to render. Empty array → empty-state placeholder.
+  positions: PrismPosition[];
+  /// Current pool tick — drawn as a vertical guide line. Omit to skip.
+  currentTick?: number;
+  /// Tick spacing of the underlying pool. Used to widen the x-axis a
+  /// touch beyond the position extents so the side bars don't kiss the
+  /// chart edge.
+  tickSpacing: number;
+  /// Pixel height of the chart. Width is fluid (100%).
+  height?: number;
+  className?: string;
+}
+
+const SPECTRUM = [
+  "rgb(124 92 255)", // violet
+  "rgb(92 138 255)", // indigo
+  "rgb(62 220 255)", // teal
+  "rgb(62 255 155)", // mint
+  "rgb(255 209 102)", // amber
+  "rgb(255 92 138)", // rose
+] as const;
+
+/**
+ * Visualises the vault's prism — a layered set of tick-range positions —
+ * as a horizontal "spectrum" of liquidity blocks along the tick axis.
+ *
+ * Each block spans [`tickLower`, `tickUpper`] horizontally and has a
+ * height proportional to its share of total liquidity. Block colours
+ * cycle through the brand spectrum so adjacent positions stay visually
+ * distinct.
+ */
+export function PrismVisual({
+  positions,
+  currentTick,
+  tickSpacing,
+  height = 180,
+  className,
+}: PrismVisualProps) {
+  const empty = positions.length === 0;
+
+  const layout = useMemo(() => {
+    if (empty) return null;
+
+    const lows = positions.map((p) => p.tickLower);
+    const highs = positions.map((p) => p.tickUpper);
+    const minTick = Math.min(...lows) - tickSpacing;
+    const maxTick = Math.max(...highs) + tickSpacing;
+
+    // d3 linear scale on a 0..100 viewBox keeps the chart fluid — the
+    // SVG itself stretches to fit its container.
+    const x = scaleLinear().domain([minTick, maxTick]).range([0, 100]);
+
+    // Liquidity is bigint on the wire; convert to number for the
+    // height ratio. Loss of precision is acceptable for a *visual*
+    // ratio (we only care about the sort order, not the absolute
+    // value).
+    const maxLiquidity =
+      positions.reduce((acc, p) => (p.liquidity > acc ? p.liquidity : acc), 0n) || 1n;
+    const liquidityRatio = (l: bigint) => Number((l * 1000n) / maxLiquidity) / 1000;
+
+    return {
+      x,
+      minTick,
+      maxTick,
+      blocks: positions.map((p, i) => ({
+        x0: x(p.tickLower),
+        x1: x(p.tickUpper),
+        ratio: liquidityRatio(p.liquidity),
+        color: SPECTRUM[i % SPECTRUM.length],
+      })),
+    };
+  }, [positions, tickSpacing, empty]);
+
+  if (empty) {
+    return (
+      <section
+        className={`rounded-xl border border-border bg-surface p-5 shadow-card ${className ?? ""}`}
+        style={{minHeight: height}}
+      >
+        <h2 className="mb-4 text-base font-medium text-text">Prism</h2>
+        <div className="flex items-center justify-center" style={{height: height - 60}}>
+          <p className="text-sm text-text-muted">No positions deployed yet.</p>
+        </div>
+      </section>
+    );
+  }
+
+  // Non-null assertion — `empty === false` implies layout populated.
+  const {x, minTick, maxTick, blocks} = layout!;
+  const tickIndicatorX =
+    currentTick !== undefined && currentTick >= minTick && currentTick <= maxTick
+      ? x(currentTick)
+      : null;
+
+  return (
+    <section
+      className={`rounded-xl border border-border bg-surface p-5 shadow-card ${className ?? ""}`}
+      aria-label="Prism — vault liquidity distribution"
+    >
+      <header className="mb-4 flex items-baseline justify-between">
+        <h2 className="text-base font-medium text-text">Prism</h2>
+        <p className="text-xs text-text-faint">
+          {positions.length} {positions.length === 1 ? "position" : "positions"}
+        </p>
+      </header>
+
+      <svg
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        role="img"
+        aria-label="Liquidity distribution across tick ranges"
+        style={{width: "100%", height}}
+      >
+        {/* Floor — full-width hairline so empty corridors read clearly. */}
+        <line
+          x1={0}
+          y1={100}
+          x2={100}
+          y2={100}
+          stroke="rgb(var(--color-border-strong))"
+          strokeWidth={0.5}
+          vectorEffect="non-scaling-stroke"
+        />
+
+        {/* Position blocks — height proportional to liquidity. */}
+        {blocks.map((b, i) => {
+          const blockHeight = b.ratio * 90; // leave 10% headroom
+          return (
+            <rect
+              key={i}
+              x={b.x0}
+              y={100 - blockHeight}
+              width={Math.max(b.x1 - b.x0, 0.5)}
+              height={blockHeight}
+              fill={b.color}
+              fillOpacity={0.55}
+              stroke={b.color}
+              strokeWidth={0.5}
+              vectorEffect="non-scaling-stroke"
+              rx={0.5}
+            />
+          );
+        })}
+
+        {/* Current-tick indicator. */}
+        {tickIndicatorX !== null ? (
+          <g>
+            <line
+              x1={tickIndicatorX}
+              y1={0}
+              x2={tickIndicatorX}
+              y2={100}
+              stroke="rgb(var(--color-text))"
+              strokeWidth={0.75}
+              strokeDasharray="2 2"
+              vectorEffect="non-scaling-stroke"
+            />
+          </g>
+        ) : null}
+      </svg>
+
+      <footer className="mt-3 flex justify-between font-mono text-xs text-text-faint">
+        <span>tick {minTick}</span>
+        {currentTick !== undefined ? <span>now {currentTick}</span> : null}
+        <span>tick {maxTick}</span>
+      </footer>
+    </section>
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@rainbow-me/rainbowkit": "^2.2.10",
     "@tanstack/react-query": "^5.100.6",
+    "d3-scale": "^4.0.2",
     "next": "14.2.18",
     "react": "18.3.1",
     "react-dom": "18.3.1",
@@ -21,6 +22,7 @@
     "wagmi": "^2.19.5"
   },
   "devDependencies": {
+    "@types/d3-scale": "^4.0.8",
     "@types/node": "20.16.10",
     "@types/react": "18.3.11",
     "@types/react-dom": "18.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.100.6
         version: 5.100.6(react@18.3.1)
+      d3-scale:
+        specifier: ^4.0.2
+        version: 4.0.2
       next:
         specifier: 14.2.18
         version: 14.2.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -42,6 +45,9 @@ importers:
         specifier: ^2.19.5
         version: 2.19.5(@tanstack/query-core@5.100.6)(@tanstack/react-query@5.100.6(react@18.3.1))(@types/react@18.3.11)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.6.3)(utf-8-validate@5.0.10)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
     devDependencies:
+      '@types/d3-scale':
+        specifier: ^4.0.8
+        version: 4.0.9
       '@types/node':
         specifier: 20.16.10
         version: 20.16.10
@@ -1061,6 +1067,12 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -1724,6 +1736,34 @@ packages:
       typescript:
         optional: true
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -2304,6 +2344,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -5175,6 +5219,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-time@3.0.4': {}
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -6339,6 +6389,34 @@ snapshots:
     optionalDependencies:
       typescript: 5.6.3
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -7088,6 +7166,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.3
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   iron-webcrypto@1.2.1: {}
 


### PR DESCRIPTION
## Summary
- Adds \`apps/web/components/PrismVisual.tsx\`: a horizontal SVG chart that renders each vault position as a coloured block along the tick axis.
- Wired into \`/vaults/[address]\` above the positions table.
- Block height tracks liquidity share; colours cycle through the brand spectrum (violet → rose).

## Design notes
- Uses \`d3-scale\` (~5kB) for tick → x-coord mapping; the rest is pure SVG, so the component stays lean.
- \`viewBox=\"0 0 100 100\"\` + \`preserveAspectRatio=\"none\"\` so the SVG is fluid in both axes inside its container.
- Empty state renders a placeholder card.
- Current-tick guide line drawn as a dashed vertical when \`currentTick\` is provided and within the rendered range.

## Placeholder data
Three positions either side of tick 0, weighted to draw a recognisable bell. Real values land alongside #31 (VaultFactory) + \`getTotalAmounts\` wire-up in M2.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm build\` succeeds (route /vaults/[address] = 9.91 kB)