### PR TITLE
feat(frontend): DepositForm + TxFlowStatus union (#52)

### DIFF
--- a/apps/web/app/vaults/[address]/page.tsx
+++ b/apps/web/app/vaults/[address]/page.tsx
@@ -2,8 +2,9 @@
 
 import {notFound} from "next/navigation";
 import {useMemo} from "react";
-import {isAddress} from "viem";
+import {isAddress, zeroAddress, type Address} from "viem";
 
+import {DepositForm} from "@/components/DepositForm";
 import {formatBps, formatUsd} from "@/lib/vault-list";
 
 interface PageProps {
@@ -34,7 +35,11 @@ export default function VaultDetailPage({params}: PageProps) {
 
       <PositionsTable positions={detail.positions} />
 
-      <DepositPanel placeholder />
+      <DepositForm
+        vaultAddress={detail.address as Address}
+        token0={detail.token0}
+        token1={detail.token1}
+      />
     </article>
   );
 }
@@ -101,25 +106,18 @@ function PositionsTable({positions}: {positions: PlaceholderPosition[]}) {
   );
 }
 
-function DepositPanel({placeholder}: {placeholder: boolean}) {
-  return (
-    <section className="rounded-xl border border-border bg-surface p-5 shadow-card">
-      <h2 className="mb-2 text-base font-medium text-text">Deposit</h2>
-      <p className="text-sm text-text-muted">
-        {placeholder
-          ? "Form lands with #52 (deposit form). Wallet + wagmi reads are wired; M2 contracts surface the on-chain state."
-          : null}
-      </p>
-    </section>
-  );
-}
-
 interface PlaceholderPosition {
   tickLower: number;
   tickUpper: number;
   liquidity: bigint;
   token0: bigint;
   token1: bigint;
+}
+
+interface PlaceholderToken {
+  address: Address;
+  symbol: string;
+  decimals: number;
 }
 
 interface PlaceholderDetail {
@@ -130,6 +128,8 @@ interface PlaceholderDetail {
   apr24hBps: number;
   sharePriceUsd: bigint;
   positions: PlaceholderPosition[];
+  token0: PlaceholderToken;
+  token1: PlaceholderToken;
 }
 
 function usePlaceholderVault(address: string): PlaceholderDetail {
@@ -142,6 +142,10 @@ function usePlaceholderVault(address: string): PlaceholderDetail {
       apr24hBps: 0,
       sharePriceUsd: 1_000_000n, // 1.000000 USDC (6 decimals)
       positions: [],
+      // Token metadata is fixed for the placeholder vault; real values
+      // come from the data layer once #31 (VaultFactory) lands.
+      token0: {address: zeroAddress, symbol: "WETH", decimals: 18},
+      token1: {address: zeroAddress, symbol: "USDC", decimals: 6},
     }),
     [address],
   );

--- a/apps/web/components/DepositForm.tsx
+++ b/apps/web/components/DepositForm.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import {useEffect, useMemo, useState} from "react";
+import {erc20Abi, formatUnits, parseUnits, zeroAddress, type Address, type Hex} from "viem";
+import {
+  useAccount,
+  useReadContracts,
+  useSimulateContract,
+  useWaitForTransactionReceipt,
+  useWriteContract,
+} from "wagmi";
+
+import {VaultAbi} from "@prism/shared";
+import {classifyTxError} from "@/lib/tx-errors";
+import {isBusy, statusLabel, type TxFlowStatus} from "@/lib/tx-status";
+
+export interface DepositFormToken {
+  address: Address;
+  symbol: string;
+  decimals: number;
+}
+
+interface DepositFormProps {
+  vaultAddress: Address;
+  token0: DepositFormToken;
+  token1: DepositFormToken;
+  /// Default slippage as basis points. 50 = 0.5%.
+  defaultSlippageBps?: number;
+}
+
+/**
+ * Deposit form for a PRISM vault. Walks the user through:
+ *   1. Approve token0 (if allowance < amount0Desired)
+ *   2. Approve token1 (if allowance < amount1Desired)
+ *   3. Deposit
+ *
+ * State machine in `status: TxFlowStatus` — see `lib/tx-status.ts`.
+ *
+ * The simulate hook runs whenever inputs are valid and both allowances
+ * cover the desired amounts; its return value drives the submit
+ * button's enabled state and surfaces revert reasons before the user
+ * pays gas.
+ */
+export function DepositForm({vaultAddress, token0, token1, defaultSlippageBps = 50}: DepositFormProps) {
+  const {address: account, chainId} = useAccount();
+
+  const [amount0, setAmount0] = useState("");
+  const [amount1, setAmount1] = useState("");
+  const [slippageBps, setSlippageBps] = useState(defaultSlippageBps);
+  const [status, setStatus] = useState<TxFlowStatus>({kind: "idle"});
+
+  const placeholderVault = vaultAddress === zeroAddress;
+
+  const amount0Desired = useMemo(
+    () => parseAmountSafe(amount0, token0.decimals),
+    [amount0, token0.decimals],
+  );
+  const amount1Desired = useMemo(
+    () => parseAmountSafe(amount1, token1.decimals),
+    [amount1, token1.decimals],
+  );
+
+  const inputsValid = (amount0Desired > 0n || amount1Desired > 0n) && !!account;
+
+  // Read balances + allowances for both tokens in one batch.
+  const {data: tokenReads, refetch: refetchTokenReads} = useReadContracts({
+    contracts: account
+      ? [
+        {
+          address: token0.address,
+          abi: erc20Abi,
+          functionName: "balanceOf",
+          args: [account],
+        },
+        {
+          address: token0.address,
+          abi: erc20Abi,
+          functionName: "allowance",
+          args: [account, vaultAddress],
+        },
+        {
+          address: token1.address,
+          abi: erc20Abi,
+          functionName: "balanceOf",
+          args: [account],
+        },
+        {
+          address: token1.address,
+          abi: erc20Abi,
+          functionName: "allowance",
+          args: [account, vaultAddress],
+        },
+      ]
+      : [],
+    query: {enabled: !!account && !placeholderVault},
+  });
+
+  const balance0 = (tokenReads?.[0]?.result as bigint | undefined) ?? 0n;
+  const allowance0 = (tokenReads?.[1]?.result as bigint | undefined) ?? 0n;
+  const balance1 = (tokenReads?.[2]?.result as bigint | undefined) ?? 0n;
+  const allowance1 = (tokenReads?.[3]?.result as bigint | undefined) ?? 0n;
+
+  const needsApproval0 = amount0Desired > allowance0 && amount0Desired > 0n;
+  const needsApproval1 = amount1Desired > allowance1 && amount1Desired > 0n;
+  const allowancesOk = !needsApproval0 && !needsApproval1;
+
+  const amount0Min = applySlippage(amount0Desired, slippageBps);
+  const amount1Min = applySlippage(amount1Desired, slippageBps);
+
+  // Pre-flight simulate the deposit only when allowances cover the
+  // intended amounts — running it earlier would always revert with
+  // ERC-20 transfer failure noise and obscure real reverts.
+  const simulate = useSimulateContract({
+    address: vaultAddress,
+    abi: VaultAbi,
+    functionName: "deposit",
+    args: account
+      ? [amount0Desired, amount1Desired, amount0Min, amount1Min, account]
+      : undefined,
+    query: {enabled: inputsValid && allowancesOk && !placeholderVault},
+  });
+
+  const {writeContractAsync: writeApprove, data: approveHash} = useWriteContract();
+  const {writeContractAsync: writeDeposit, data: depositHash} = useWriteContract();
+
+  const approveReceipt = useWaitForTransactionReceipt({hash: approveHash});
+  const depositReceipt = useWaitForTransactionReceipt({hash: depositHash});
+
+  // Refresh allowances when an approval lands so the form transitions
+  // out of `awaiting-approval` automatically.
+  useEffect(() => {
+    if (approveReceipt.isSuccess) {
+      void refetchTokenReads();
+      setStatus({kind: "awaiting-submit"});
+    }
+  }, [approveReceipt.isSuccess, refetchTokenReads]);
+
+  useEffect(() => {
+    if (depositReceipt.isSuccess && depositHash) {
+      setStatus({kind: "confirmed", hash: depositHash});
+      void refetchTokenReads();
+    }
+  }, [depositReceipt.isSuccess, depositHash, refetchTokenReads]);
+
+  const insufficient0 = amount0Desired > balance0;
+  const insufficient1 = amount1Desired > balance1;
+  const insufficientBalance = insufficient0 || insufficient1;
+
+  const submitDisabled =
+    !inputsValid ||
+    isBusy(status) ||
+    insufficientBalance ||
+    (allowancesOk && simulate.status === "error") ||
+    placeholderVault;
+
+  async function onApprove(token: DepositFormToken, amount: bigint) {
+    setStatus({kind: "awaiting-approval", token: token.address});
+    try {
+      const hash = await writeApprove({
+        address: token.address,
+        abi: erc20Abi,
+        functionName: "approve",
+        args: [vaultAddress, amount],
+      });
+      setStatus({kind: "approving", token: token.address, hash});
+    } catch (err) {
+      const e = classifyTxError(err);
+      setStatus({kind: "failed", reason: e.message});
+    }
+  }
+
+  async function onDeposit() {
+    if (!account) return;
+
+    if (needsApproval0) {
+      await onApprove(token0, amount0Desired);
+      return;
+    }
+    if (needsApproval1) {
+      await onApprove(token1, amount1Desired);
+      return;
+    }
+
+    setStatus({kind: "simulating"});
+    if (simulate.status !== "success") {
+      const reason = simulate.error?.message ?? "Simulation did not produce a request.";
+      setStatus({kind: "simulation-failed", reason});
+      return;
+    }
+
+    setStatus({kind: "awaiting-submit"});
+    try {
+      const hash = await writeDeposit(simulate.data.request);
+      setStatus({kind: "pending", hash});
+    } catch (err) {
+      const e = classifyTxError(err);
+      setStatus({kind: "failed", reason: e.message});
+    }
+  }
+
+  return (
+    <section className="rounded-xl border border-border bg-surface p-5 shadow-card" aria-label="Deposit">
+      <h2 className="mb-4 text-base font-medium text-text">Deposit</h2>
+
+      <div className="flex flex-col gap-4">
+        <AmountInput
+          label={token0.symbol}
+          value={amount0}
+          onChange={setAmount0}
+          balance={balance0}
+          decimals={token0.decimals}
+          insufficient={insufficient0}
+          disabled={isBusy(status) || placeholderVault}
+        />
+        <AmountInput
+          label={token1.symbol}
+          value={amount1}
+          onChange={setAmount1}
+          balance={balance1}
+          decimals={token1.decimals}
+          insufficient={insufficient1}
+          disabled={isBusy(status) || placeholderVault}
+        />
+
+        <SlippageRow value={slippageBps} onChange={setSlippageBps} disabled={isBusy(status)} />
+
+        <button
+          type="button"
+          onClick={() => void onDeposit()}
+          disabled={submitDisabled}
+          className="rounded-lg bg-accent px-4 py-3 text-sm font-medium text-canvas transition-base
+                     hover:shadow-glow-violet disabled:cursor-not-allowed disabled:opacity-50
+                     disabled:hover:shadow-none"
+        >
+          {placeholderVault
+            ? "Vault not deployed"
+            : !account
+            ? "Connect wallet"
+            : insufficientBalance
+            ? "Insufficient balance"
+            : needsApproval0
+            ? `Approve ${token0.symbol}`
+            : needsApproval1
+            ? `Approve ${token1.symbol}`
+            : "Deposit"}
+        </button>
+
+        <StatusBanner status={status} />
+      </div>
+    </section>
+  );
+}
+
+function AmountInput({
+  label,
+  value,
+  onChange,
+  balance,
+  decimals,
+  insufficient,
+  disabled,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  balance: bigint;
+  decimals: number;
+  insufficient: boolean;
+  disabled?: boolean;
+}) {
+  const formattedBalance = formatUnits(balance, decimals);
+  return (
+    <label className="flex flex-col gap-1.5 text-sm">
+      <span className="flex items-baseline justify-between text-text-muted">
+        <span>{label}</span>
+        <button
+          type="button"
+          onClick={() => onChange(formattedBalance)}
+          disabled={disabled || balance === 0n}
+          className="font-mono text-xs text-text-faint hover:text-text disabled:cursor-not-allowed
+                     disabled:opacity-60"
+        >
+          balance {formattedBalance}
+        </button>
+      </span>
+      <input
+        type="text"
+        inputMode="decimal"
+        value={value}
+        onChange={(e) => onChange(sanitizeAmount(e.target.value))}
+        disabled={disabled}
+        placeholder="0.0"
+        className={`rounded-lg border bg-surface-raised px-3 py-2 font-mono text-base text-text
+                    outline-none transition-base disabled:cursor-not-allowed disabled:opacity-60
+                    ${insufficient ? "border-danger/60" : "border-border focus:border-border-strong"}`}
+      />
+      {insufficient ? (
+        <span className="text-xs text-danger">Exceeds balance.</span>
+      ) : null}
+    </label>
+  );
+}
+
+function SlippageRow({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: number;
+  onChange: (bps: number) => void;
+  disabled?: boolean;
+}) {
+  const presets = [10, 50, 100] as const; // 0.1%, 0.5%, 1%
+  return (
+    <div className="flex items-center justify-between text-sm">
+      <span className="text-text-muted">Max slippage</span>
+      <div className="flex gap-1">
+        {presets.map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => onChange(p)}
+            disabled={disabled}
+            className={`rounded-md border px-2 py-1 font-mono text-xs transition-base
+                        disabled:cursor-not-allowed disabled:opacity-60
+                        ${value === p ? "border-accent bg-accent/10 text-accent" : "border-border text-text-muted"}`}
+          >
+            {(p / 100).toFixed(2)}%
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StatusBanner({status}: {status: TxFlowStatus}) {
+  if (status.kind === "idle") return null;
+
+  const tone =
+    status.kind === "confirmed"
+      ? "border-success/40 bg-success/10 text-success"
+      : status.kind === "failed" || status.kind === "simulation-failed"
+      ? "border-danger/40 bg-danger/10 text-danger"
+      : "border-border bg-surface-raised text-text-muted";
+
+  const hash = "hash" in status ? status.hash : undefined;
+  return (
+    <div className={`rounded-lg border px-3 py-2 text-xs ${tone}`} role="status">
+      <p>{statusLabel(status)}</p>
+      {hash ? (
+        <p className="mt-1 font-mono text-[11px] text-text-faint">{shortHash(hash)}</p>
+      ) : null}
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+function sanitizeAmount(input: string): string {
+  // Allow only digits and a single decimal point.
+  const cleaned = input.replace(/[^0-9.]/g, "");
+  const firstDot = cleaned.indexOf(".");
+  if (firstDot === -1) return cleaned;
+  return cleaned.slice(0, firstDot + 1) + cleaned.slice(firstDot + 1).replace(/\./g, "");
+}
+
+function parseAmountSafe(value: string, decimals: number): bigint {
+  if (!value || value === ".") return 0n;
+  try {
+    return parseUnits(value, decimals);
+  } catch {
+    return 0n;
+  }
+}
+
+function applySlippage(amount: bigint, bps: number): bigint {
+  if (amount === 0n) return 0n;
+  // floor((amount * (10_000 - bps)) / 10_000)
+  return (amount * BigInt(10_000 - bps)) / 10_000n;
+}
+
+function shortHash(h: Hex): string {
+  return `${h.slice(0, 10)}…${h.slice(-8)}`;
+}

--- a/apps/web/lib/tx-status.ts
+++ b/apps/web/lib/tx-status.ts
@@ -1,0 +1,86 @@
+import type {Address, Hex} from "viem";
+
+/**
+ * Discriminated union covering the full deposit / withdraw transaction
+ * lifecycle. Each `kind` carries exactly the fields the UI needs at
+ * that step — no shared optional bag — so the renderer pattern-matches
+ * cleanly on `status.kind` without nullable-everything drift.
+ *
+ * Flow shape:
+ *
+ *   idle
+ *     ↓ (user clicks submit)
+ *   simulating              ← wagmi useSimulateContract
+ *     ↓ (sim ok)
+ *   awaiting-approval *     ← only if ERC-20 allowance < amount; one
+ *                             entry per token that needs approving.
+ *     ↓ (user signs)
+ *   approving *
+ *     ↓ (approval mined)
+ *   awaiting-submit
+ *     ↓ (user signs)
+ *   submitting
+ *     ↓ (tx broadcast)
+ *   pending
+ *     ↓ (receipt mined)
+ *   confirmed | failed
+ *
+ *   * Withdraw skips both approval steps (it burns shares the user
+ *     already owns).
+ */
+export type TxFlowStatus =
+  | {kind: "idle"}
+  | {kind: "simulating"}
+  | {kind: "simulation-failed"; reason: string}
+  | {kind: "awaiting-approval"; token: Address}
+  | {kind: "approving"; token: Address; hash: Hex}
+  | {kind: "awaiting-submit"}
+  | {kind: "submitting"}
+  | {kind: "pending"; hash: Hex}
+  | {kind: "confirmed"; hash: Hex}
+  | {kind: "failed"; reason: string; hash?: Hex};
+
+/// True when the user has work to do — wallet prompt open or the form
+/// should be locked because something is in flight.
+export function isBusy(s: TxFlowStatus): boolean {
+  switch (s.kind) {
+    case "simulating":
+    case "awaiting-approval":
+    case "approving":
+    case "awaiting-submit":
+    case "submitting":
+    case "pending":
+      return true;
+    case "idle":
+    case "simulation-failed":
+    case "confirmed":
+    case "failed":
+      return false;
+  }
+}
+
+/// Human-readable label for the status banner.
+export function statusLabel(s: TxFlowStatus): string {
+  switch (s.kind) {
+    case "idle":
+      return "Ready";
+    case "simulating":
+      return "Simulating…";
+    case "simulation-failed":
+      return `Simulation failed — ${s.reason}`;
+    case "awaiting-approval":
+      return "Waiting for approval signature…";
+    case "approving":
+      return "Approving token…";
+    case "awaiting-submit":
+      return "Waiting for transaction signature…";
+    case "submitting":
+      return "Submitting transaction…";
+    case "pending":
+      return "Transaction pending…";
+    case "confirmed":
+      return "Transaction confirmed";
+    case "failed":
+      return `Transaction failed — ${s.reason}`;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds \`apps/web/components/DepositForm.tsx\` — full approve(token0) → approve(token1) → deposit flow.
- Adds \`apps/web/lib/tx-status.ts\` — generic \`TxFlowStatus\` discriminated union covering every wallet / RPC step. Withdraw (#53) reuses it.
- Wired into \`/vaults/[address]\`; replaces the \`DepositPanel\` placeholder.

## TxFlowStatus
\`idle | simulating | simulation-failed | awaiting-approval | approving | awaiting-submit | submitting | pending | confirmed | failed\`

Each variant carries exactly the fields the UI needs at that step (no shared optional bag). \`isBusy\` and \`statusLabel\` helpers drive the form's locked state and the status banner copy.

## Form features
- Per-token amount inputs with balance + max button
- Slippage presets (0.1% / 0.5% / 1%)
- Pre-flight simulate via \`useSimulateContract\` — surfaces revert reasons before the user pays gas
- Allowance batched read via \`useReadContracts\`; auto-refresh after each approval mines
- Insufficient-balance gating + friendly button states
- Status banner with hash shortform

## Placeholder note
\`detail.token0/token1.address\` is \`zeroAddress\` until #31 (VaultFactory) lands; the submit button shows \"Vault not deployed\" so the form composes cleanly without firing wagmi reads against \`address(0)\`.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean