### PR TITLE
feat(deploy): post-deploy verification — verify-hook + addresses.json + runbook

### DIFF
--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -1,0 +1,104 @@
+# PRISM Deploy Runbook
+
+End-to-end deploy procedure for the PRISM contract stack on Base Sepolia (testnet) and Base (mainnet, gated on audit completion per ADR-006). The flow is broadcast → post-deploy → verify.
+
+## 1. Prerequisites
+
+Required env vars (same set for both chains; only the RPC differs):
+
+| Variable | Notes |
+|---|---|
+| `DEPLOYER_PRIVATE_KEY` | Hex-prefixed deployer key. Must hold enough native gas. |
+| `POOL_MANAGER` | Uniswap V4 PoolManager address on the target chain. |
+| `DEFAULT_OWNER` | Multisig that becomes the owner of every vault deployed by the factory. |
+| `CHAINLINK_FEED` | Primary price feed (e.g. ETH/USD on Base). |
+| `SEQUENCER_FEED` | L2 sequencer uptime feed (Base sequencer feed). |
+| `PRICE_SCALE_NUM` / `PRICE_SCALE_DEN` | Q192 numerator/denominator computed off-chain to convert the Chainlink price into the V4 sqrtPriceX96 scale for the target pool. |
+| `BASE_SEPOLIA_RPC_URL` *or* `BASE_RPC_URL` | RPC endpoint. |
+| `BASESCAN_API_KEY` | Required for `--verify`. |
+
+Pinned toolchain (CI also enforces these — see `.github/workflows/contracts.yml`):
+
+| Tool | Version |
+|---|---|
+| Node | `>=18` |
+| pnpm | `>=9` (repo declares `packageManager: pnpm@10.18.0`) |
+| Foundry | per `foundry.toml` (`solc 0.8.26`, `evm_version cancun`) |
+
+## 2. Pre-deploy gate
+
+Run from the repo root:
+
+```bash
+# Contracts
+pnpm --filter @prism/contracts test
+forge build --root packages/contracts
+
+# Frontend + keeper
+pnpm typecheck
+pnpm lint
+```
+
+Do not proceed if any gate fails.
+
+## 3. Broadcast
+
+```bash
+forge script packages/contracts/script/Deploy.s.sol:Deploy \
+  --rpc-url $BASE_SEPOLIA_RPC_URL \
+  --broadcast \
+  --verify \
+  --etherscan-api-key $BASESCAN_API_KEY
+```
+
+`Deploy.s.sol` itself asserts:
+- ProtocolHook address bits = `0x05C0` (BEFORE_INITIALIZE | AFTER_INITIALIZE | AFTER_ADD_LIQUIDITY | AFTER_REMOVE_LIQUIDITY).
+- VaultFactory CREATE address matches the address used in the hook constructor (no nonce drift).
+
+If either assertion fails the broadcast reverts atomically — nothing is deployed.
+
+## 4. Post-deploy
+
+```bash
+pnpm post-deploy --chain base-sepolia
+```
+
+This script:
+1. Parses `packages/contracts/broadcast/Deploy.s.sol/<chainId>/run-latest.json`.
+2. Extracts the four deployed contract addresses + the configured PoolManager.
+3. Writes `addresses.json` at the repo root (operator-readable).
+4. Updates `packages/shared/src/addresses.ts` (typed app code) — replaces the `PLACEHOLDER` mapping for the target chain with a deployed block bracketed by sentinels so re-runs are clean.
+5. Invokes `verify-hook.ts` against the deployed `ProtocolHook`, which:
+   - Confirms bytecode is non-empty.
+   - Calls `getHookPermissions()` and re-derives the expected address mask.
+   - Asserts the mask matches the low 14 bits of the deployed address.
+
+If `verify-hook` fails, the deployment is **broken** — proceed to rollback.
+
+## 5. Verification checklist
+
+- [ ] All four contracts show `Verified` on Basescan.
+- [ ] `pnpm verify-hook --chain base-sepolia` exits 0.
+- [ ] `addresses.json` committed.
+- [ ] `packages/shared/src/addresses.ts` committed.
+- [ ] Frontend boots locally with the new addresses (`pnpm --filter @prism/web dev` → wallet connects on Base Sepolia).
+
+## 6. Rollback
+
+The PRISM contracts are immutable (ADR-006). There is no upgrade path; rollback means abandoning the broken deployment and redeploying.
+
+1. **Halt operations.** Pause the keeper service (`fly scale count 0 --app prism-keeper-sepolia`) so it stops trying to rebalance against the broken deploy.
+2. **Communicate.** Post in the incident channel with the broken addresses + the broadcast tx hash.
+3. **Tag the broken deploy.** Tag the broadcast at `addresses.json@<broken-deploy>` with `--annotated` for forensic later.
+4. **Redeploy.** Fix the underlying issue, repeat from §3 with a fresh deployer nonce.
+5. **Migrate users.** If the broken vault held real testnet funds, document the recovery path (`withdraw()` is never pausable per invariant 6, so users can always exit, even from a broken vault).
+
+If the issue is purely off-chain (wrong addresses written, frontend out of sync), redeploy is **not** required — re-run `pnpm post-deploy` against the existing broadcast file.
+
+## 7. Mainnet differences
+
+Mainnet (`base`) deploys are gated behind audit sign-off per ADR-006. When that gate is cleared:
+
+- Use `BASE_RPC_URL` and pass `--chain base` to `pnpm post-deploy`.
+- The `[CHAIN_IDS.base]: undefined` entry in `addresses.ts` is auto-replaced with the deployed block by the post-deploy script.
+- A cold wallet must hold the deployer key. Hardware-wallet signing via Frame or Foundry's `--ledger` is required.

--- a/package.json
+++ b/package.json
@@ -17,11 +17,14 @@
     "dev": "turbo run dev",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md,yml,yaml}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md,yml,yaml}\"",
-    "export-abis": "tsx scripts/export-abis.ts"
+    "export-abis": "tsx scripts/export-abis.ts",
+    "post-deploy": "tsx scripts/post-deploy.ts",
+    "verify-hook": "tsx scripts/verify-hook.ts"
   },
   "devDependencies": {
     "prettier": "^3.3.3",
     "tsx": "^4.19.2",
-    "turbo": "^2.3.3"
+    "turbo": "^2.3.3",
+    "viem": "^2.48.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,34 @@ importers:
       turbo:
         specifier: ^2.3.3
         version: 2.9.6
+      viem:
+        specifier: ^2.48.4
+        version: 2.48.4(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+
+  apps/keeper:
+    dependencies:
+      '@prism/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      pino:
+        specifier: ^9.5.0
+        version: 9.14.0
+      viem:
+        specifier: ^2.48.4
+        version: 2.48.4(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: 20.16.10
+        version: 20.16.10
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
 
   apps/web:
     dependencies:
@@ -568,6 +596,9 @@ packages:
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
     deprecated: 'The package is now available as "qr": npm install qr'
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2797,6 +2828,10 @@ packages:
   on-exit-leak-free@0.2.0:
     resolution: {integrity: sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -2915,11 +2950,21 @@ packages:
   pino-abstract-transport@0.5.0:
     resolution: {integrity: sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
   pino-std-serializers@4.0.0:
     resolution: {integrity: sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==}
 
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
   pino@7.11.0:
     resolution: {integrity: sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==}
+    hasBin: true
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
 
   pirates@4.0.7:
@@ -3036,6 +3081,9 @@ packages:
   process-warning@1.0.0:
     resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3136,6 +3184,10 @@ packages:
 
   real-require@0.1.0:
     resolution: {integrity: sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==}
+    engines: {node: '>= 12.13.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
   reflect.getprototypeof@1.0.10:
@@ -3275,6 +3327,9 @@ packages:
   sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3405,6 +3460,9 @@ packages:
 
   thread-stream@0.15.2:
     resolution: {integrity: sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
@@ -4401,6 +4459,8 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@paulmillr/qr@0.2.1': {}
+
+  '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -7605,6 +7665,8 @@ snapshots:
 
   on-exit-leak-free@0.2.0: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -7770,7 +7832,13 @@ snapshots:
       duplexify: 4.1.3
       split2: 4.2.0
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
   pino-std-serializers@4.0.0: {}
+
+  pino-std-serializers@7.1.0: {}
 
   pino@7.11.0:
     dependencies:
@@ -7785,6 +7853,20 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 2.8.0
       thread-stream: 0.15.2
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.1.0
 
   pirates@4.0.7: {}
 
@@ -7868,6 +7950,8 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   process-warning@1.0.0: {}
+
+  process-warning@5.0.0: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -7974,6 +8058,8 @@ snapshots:
   readdirp@5.0.0: {}
 
   real-require@0.1.0: {}
+
+  real-require@0.2.0: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -8150,6 +8236,10 @@ snapshots:
     dependencies:
       atomic-sleep: 1.0.0
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
 
   split-on-first@1.1.0: {}
@@ -8314,6 +8404,10 @@ snapshots:
   thread-stream@0.15.2:
     dependencies:
       real-require: 0.1.0
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
 
   tinyglobby@0.2.16:
     dependencies:

--- a/scripts/post-deploy.ts
+++ b/scripts/post-deploy.ts
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+// Post-deploy orchestrator. Reads the latest Foundry broadcast for
+// `Deploy.s.sol` on a given chain, extracts the deployed contract
+// addresses, writes them to `addresses.json` (operator-readable) and
+// updates `packages/shared/src/addresses.ts` (typed app code), then
+// runs `verify-hook.ts` against the deployed ProtocolHook.
+//
+// Run:
+//   tsx scripts/post-deploy.ts --chain base-sepolia
+//
+// The Foundry broadcast file is written automatically by
+// `forge script ... --broadcast` to:
+//   packages/contracts/broadcast/Deploy.s.sol/<chainId>/run-latest.json
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+
+interface BroadcastTx {
+  contractName?: string;
+  contractAddress?: string;
+  transactionType?: string;
+}
+
+interface BroadcastFile {
+  transactions: BroadcastTx[];
+}
+
+interface ChainConfig {
+  name: string;
+  chainId: number;
+  recordKey: "baseSepolia" | "base";
+}
+
+const CHAINS: Record<string, ChainConfig> = {
+  "base-sepolia": { name: "base-sepolia", chainId: 84532, recordKey: "baseSepolia" },
+  base: { name: "base", chainId: 8453, recordKey: "base" },
+};
+
+interface Deployed {
+  vaultFactory: string;
+  protocolHook: string;
+  bellStrategy: string;
+  chainlinkAdapter: string;
+  poolManager: string;
+}
+
+function parseArgs(): { chain: string; poolManager: string | null; skipVerify: boolean } {
+  const argv = process.argv.slice(2);
+  let chain = "base-sepolia";
+  let poolManager: string | null = null;
+  let skipVerify = false;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--chain") chain = argv[++i] ?? chain;
+    else if (a === "--pool-manager") poolManager = argv[++i] ?? null;
+    else if (a === "--skip-verify") skipVerify = true;
+  }
+  return { chain, poolManager, skipVerify };
+}
+
+function extractAddresses(broadcastPath: string, poolManagerOverride: string | null): Deployed {
+  const data = JSON.parse(readFileSync(broadcastPath, "utf8")) as BroadcastFile;
+  const creates = data.transactions.filter((t) => t.transactionType === "CREATE" || t.transactionType === "CREATE2");
+
+  const find = (name: string): string => {
+    const tx = creates.find((t) => t.contractName === name);
+    if (!tx?.contractAddress) {
+      throw new Error(`No CREATE/CREATE2 transaction found for ${name} in ${broadcastPath}`);
+    }
+    return tx.contractAddress;
+  };
+
+  const poolManager =
+    poolManagerOverride ?? process.env.POOL_MANAGER ?? "0x0000000000000000000000000000000000000000";
+
+  return {
+    bellStrategy: find("BellStrategy"),
+    chainlinkAdapter: find("ChainlinkAdapter"),
+    protocolHook: find("ProtocolHook"),
+    vaultFactory: find("VaultFactory"),
+    poolManager,
+  };
+}
+
+function writeAddressesJson(chainId: number, deployed: Deployed) {
+  const path = join(REPO_ROOT, "addresses.json");
+  let existing: Record<string, Deployed> = {};
+  if (existsSync(path)) {
+    existing = JSON.parse(readFileSync(path, "utf8")) as Record<string, Deployed>;
+  }
+  existing[String(chainId)] = deployed;
+  writeFileSync(path, JSON.stringify(existing, null, 2) + "\n", "utf8");
+  console.log(`addresses.json updated for chainId=${chainId}`);
+}
+
+function updateSharedAddressesTs(recordKey: "baseSepolia" | "base", deployed: Deployed) {
+  const path = join(REPO_ROOT, "packages", "shared", "src", "addresses.ts");
+  const src = readFileSync(path, "utf8");
+
+  const block = `const ${recordKey.toUpperCase()}: DeploymentAddresses = {
+  vaultFactory: "${deployed.vaultFactory}",
+  protocolHook: "${deployed.protocolHook}",
+  bellStrategy: "${deployed.bellStrategy}",
+  chainlinkAdapter: "${deployed.chainlinkAdapter}",
+  poolManager: "${deployed.poolManager}",
+};`;
+
+  // Re-emit the file with a deployed block above ADDRESSES, replacing
+  // any prior emitted block for this chain. We mark our blocks with
+  // a sentinel comment so they can be cleanly re-rewritten.
+  const sentinelStart = `// <<deployed-${recordKey}>>`;
+  const sentinelEnd = `// <</deployed-${recordKey}>>`;
+  const replacement = `${sentinelStart}\n${block}\n${sentinelEnd}`;
+
+  let next: string;
+  if (src.includes(sentinelStart)) {
+    next = src.replace(new RegExp(`${sentinelStart}[\\s\\S]*?${sentinelEnd}`), replacement);
+  } else {
+    next = src.replace("export const ADDRESSES", `${replacement}\n\nexport const ADDRESSES`);
+  }
+
+  // Swap the placeholder reference for the deployed reference.
+  const placeholderRef = `[CHAIN_IDS.${recordKey}]: PLACEHOLDER`;
+  const deployedRef = `[CHAIN_IDS.${recordKey}]: ${recordKey.toUpperCase()}`;
+  if (next.includes(placeholderRef)) {
+    next = next.replace(placeholderRef, deployedRef);
+  } else {
+    // Already pointed at deployed, or undefined. Only flip from
+    // undefined to deployed for base if the user explicitly deploys.
+    next = next.replace(`[CHAIN_IDS.${recordKey}]: undefined`, deployedRef);
+  }
+
+  writeFileSync(path, next, "utf8");
+  console.log(`packages/shared/src/addresses.ts updated for ${recordKey}`);
+}
+
+function main() {
+  const { chain, poolManager, skipVerify } = parseArgs();
+  const cfg = CHAINS[chain];
+  if (!cfg) throw new Error(`Unsupported chain '${chain}'. Use 'base-sepolia' or 'base'.`);
+
+  const broadcastPath = join(
+    REPO_ROOT,
+    "packages",
+    "contracts",
+    "broadcast",
+    "Deploy.s.sol",
+    String(cfg.chainId),
+    "run-latest.json",
+  );
+  if (!existsSync(broadcastPath)) {
+    throw new Error(
+      `Broadcast file not found at ${broadcastPath}. Run \`forge script Deploy --broadcast --rpc-url <chain>\` first.`,
+    );
+  }
+
+  const deployed = extractAddresses(broadcastPath, poolManager);
+  console.log("Deployed addresses:");
+  for (const [k, v] of Object.entries(deployed)) console.log(`  ${k.padEnd(18)} ${v}`);
+
+  writeAddressesJson(cfg.chainId, deployed);
+  updateSharedAddressesTs(cfg.recordKey, deployed);
+
+  if (!skipVerify) {
+    console.log("\nRunning verify-hook.ts...");
+    execFileSync("tsx", [join(REPO_ROOT, "scripts", "verify-hook.ts"), "--chain", cfg.name], {
+      stdio: "inherit",
+    });
+  }
+
+  console.log("\nPost-deploy complete.");
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+}

--- a/scripts/verify-hook.ts
+++ b/scripts/verify-hook.ts
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+// Off-chain post-deploy verification of the ProtocolHook address.
+//
+// V4 hooks must have their address bits match the permission flags
+// returned by `getHookPermissions()`. The deploy script asserts this
+// at deploy time; this script re-verifies the deployed contract on
+// the target chain so that operators can run the check independently
+// of the deploy run.
+//
+// Permission bit layout (least-significant nibble groups, per V4):
+//   bit  6  BEFORE_INITIALIZE
+//   bit  7  AFTER_INITIALIZE
+//   bit  8  BEFORE_ADD_LIQUIDITY
+//   bit  9  AFTER_ADD_LIQUIDITY
+//   bit 10  BEFORE_REMOVE_LIQUIDITY
+//   bit 11  AFTER_REMOVE_LIQUIDITY
+//   bit 12  BEFORE_SWAP
+//   bit 13  AFTER_SWAP
+//   bit 14  BEFORE_DONATE
+//   bit 15  AFTER_DONATE
+//   bit 16  BEFORE_SWAP_RETURN_DELTA
+//   bit 17  AFTER_SWAP_RETURN_DELTA
+//   bit 18  AFTER_ADD_LIQUIDITY_RETURN_DELTA
+//   bit 19  AFTER_REMOVE_LIQUIDITY_RETURN_DELTA
+//
+// PRISM's hook sets bits 6, 7, 9, 11 of the lowest byte mask =>
+// address & 0x3FFF == 0x05C0. (See ProtocolHook.getHookPermissions.)
+//
+// Run:
+//   tsx scripts/verify-hook.ts --chain base-sepolia
+// or:
+//   tsx scripts/verify-hook.ts --hook 0x... --rpc https://...
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createPublicClient, http, type Address, type Hex } from "viem";
+import { baseSepolia, base } from "viem/chains";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+
+const CHAIN_IDS = { baseSepolia: 84532, base: 8453 } as const;
+type SupportedChainId = (typeof CHAIN_IDS)[keyof typeof CHAIN_IDS];
+
+interface DeployedSet {
+  vaultFactory: Address;
+  protocolHook: Address;
+  bellStrategy: Address;
+  chainlinkAdapter: Address;
+  poolManager: Address;
+}
+
+function loadAddressesFromJson(chainId: SupportedChainId): DeployedSet | null {
+  const path = join(REPO_ROOT, "addresses.json");
+  if (!existsSync(path)) return null;
+  const data = JSON.parse(readFileSync(path, "utf8")) as Record<string, DeployedSet>;
+  return data[String(chainId)] ?? null;
+}
+
+interface HookPermissions {
+  beforeInitialize: boolean;
+  afterInitialize: boolean;
+  beforeAddLiquidity: boolean;
+  afterAddLiquidity: boolean;
+  beforeRemoveLiquidity: boolean;
+  afterRemoveLiquidity: boolean;
+  beforeSwap: boolean;
+  afterSwap: boolean;
+  beforeDonate: boolean;
+  afterDonate: boolean;
+  beforeSwapReturnDelta: boolean;
+  afterSwapReturnDelta: boolean;
+  afterAddLiquidityReturnDelta: boolean;
+  afterRemoveLiquidityReturnDelta: boolean;
+}
+
+const HOOK_FLAGS: Array<{ flag: keyof HookPermissions; bit: number }> = [
+  { flag: "beforeInitialize", bit: 13 },
+  { flag: "afterInitialize", bit: 12 },
+  { flag: "beforeAddLiquidity", bit: 11 },
+  { flag: "afterAddLiquidity", bit: 10 },
+  { flag: "beforeRemoveLiquidity", bit: 9 },
+  { flag: "afterRemoveLiquidity", bit: 8 },
+  { flag: "beforeSwap", bit: 7 },
+  { flag: "afterSwap", bit: 6 },
+  { flag: "beforeDonate", bit: 5 },
+  { flag: "afterDonate", bit: 4 },
+  { flag: "beforeSwapReturnDelta", bit: 3 },
+  { flag: "afterSwapReturnDelta", bit: 2 },
+  { flag: "afterAddLiquidityReturnDelta", bit: 1 },
+  { flag: "afterRemoveLiquidityReturnDelta", bit: 0 },
+];
+
+const GET_HOOK_PERMISSIONS_ABI = [
+  {
+    inputs: [],
+    name: "getHookPermissions",
+    outputs: [
+      {
+        components: HOOK_FLAGS.map(({ flag }) => ({ name: flag, type: "bool" })),
+        name: "permissions",
+        type: "tuple",
+      },
+    ],
+    stateMutability: "pure",
+    type: "function",
+  },
+] as const;
+
+function parseArgs(): { chain: string | null; hook: Address | null; rpc: string | null } {
+  const argv = process.argv.slice(2);
+  let chain: string | null = null;
+  let hook: Address | null = null;
+  let rpc: string | null = null;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--chain") chain = argv[++i] ?? null;
+    else if (a === "--hook") hook = (argv[++i] ?? null) as Address | null;
+    else if (a === "--rpc") rpc = argv[++i] ?? null;
+  }
+  return { chain, hook, rpc };
+}
+
+function chainConfigFor(name: string): { chainId: SupportedChainId; viemChain: typeof baseSepolia | typeof base } {
+  if (name === "base-sepolia") return { chainId: CHAIN_IDS.baseSepolia, viemChain: baseSepolia };
+  if (name === "base") return { chainId: CHAIN_IDS.base, viemChain: base };
+  throw new Error(`Unsupported chain '${name}'. Use 'base-sepolia' or 'base'.`);
+}
+
+function permissionsToAddressMask(p: HookPermissions): number {
+  let mask = 0;
+  for (const { flag, bit } of HOOK_FLAGS) {
+    if (p[flag]) mask |= 1 << bit;
+  }
+  return mask;
+}
+
+function lowMaskOf(addr: Address): number {
+  // Lowest 14 bits — covers all hook permission flags.
+  return Number(BigInt(addr) & 0x3fffn);
+}
+
+async function main() {
+  const args = parseArgs();
+
+  let hookAddress: Address;
+  let rpcUrl: string;
+  let viemChain: typeof baseSepolia | typeof base;
+
+  if (args.hook && args.rpc) {
+    hookAddress = args.hook;
+    rpcUrl = args.rpc;
+    viemChain = baseSepolia;
+  } else {
+    const chainName = args.chain ?? "base-sepolia";
+    const { chainId, viemChain: vc } = chainConfigFor(chainName);
+    const addrs = loadAddressesFromJson(chainId);
+    if (!addrs) {
+      throw new Error(
+        `No addresses.json entry for chainId=${chainId}. Run \`pnpm post-deploy --chain ${chainName}\` first, or pass --hook + --rpc.`,
+      );
+    }
+    hookAddress = addrs.protocolHook;
+    if (hookAddress === "0x0000000000000000000000000000000000000000") {
+      throw new Error(`ProtocolHook address is zero for ${chainName}.`);
+    }
+    const envRpc =
+      chainId === CHAIN_IDS.baseSepolia ? process.env.BASE_SEPOLIA_RPC_URL : process.env.BASE_RPC_URL;
+    if (!envRpc) {
+      throw new Error(
+        `Set ${chainId === CHAIN_IDS.baseSepolia ? "BASE_SEPOLIA_RPC_URL" : "BASE_RPC_URL"} or pass --rpc.`,
+      );
+    }
+    rpcUrl = envRpc;
+    viemChain = vc;
+  }
+
+  const client = createPublicClient({ chain: viemChain, transport: http(rpcUrl) });
+
+  // 1. Bytecode must be non-empty.
+  const code: Hex = await client.getBytecode({ address: hookAddress }) ?? "0x";
+  if (code === "0x" || code.length <= 2) {
+    console.error(`FAIL: no bytecode at ${hookAddress}`);
+    process.exit(1);
+  }
+
+  // 2. Read getHookPermissions() and compute the expected address mask.
+  const perms = (await client.readContract({
+    address: hookAddress,
+    abi: GET_HOOK_PERMISSIONS_ABI,
+    functionName: "getHookPermissions",
+  })) as HookPermissions;
+
+  const expectedMask = permissionsToAddressMask(perms);
+  const actualMask = lowMaskOf(hookAddress);
+
+  console.log(`hook        : ${hookAddress}`);
+  console.log(`bytecode    : ${(code.length - 2) / 2} bytes`);
+  console.log(`expected    : 0x${expectedMask.toString(16).padStart(4, "0")}`);
+  console.log(`actual      : 0x${actualMask.toString(16).padStart(4, "0")}`);
+
+  if (expectedMask !== actualMask) {
+    console.error("FAIL: address bits do not match getHookPermissions().");
+    for (const { flag, bit } of HOOK_FLAGS) {
+      const expected = perms[flag];
+      const actual = (actualMask & (1 << bit)) !== 0;
+      if (expected !== actual) console.error(`  ${flag.padEnd(34)} expected=${expected} actual=${actual}`);
+    }
+    process.exit(1);
+  }
+
+  console.log("OK: hook permissions match address bits.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #65.

## Summary
- `scripts/verify-hook.ts` — off-chain re-verification of deployed hook bits vs `getHookPermissions()`
- `scripts/post-deploy.ts` — parses Foundry broadcast output, writes `addresses.json`, updates `packages/shared/src/addresses.ts` (via sentinel-bracketed blocks for clean re-runs), invokes verify-hook
- `docs/deploy-runbook.md` — pre-deploy gate, broadcast, post-deploy, verification checklist, rollback, mainnet differences
- pnpm scripts: `post-deploy`, `verify-hook`

## Test plan
- [x] `tsx scripts/verify-hook.ts` parses and exits with the expected "no addresses.json" error
- [x] `tsx scripts/post-deploy.ts` parses and exits with the expected "no broadcast" error
- [ ] Run end-to-end against an actual Base Sepolia broadcast (deferred until live deploy)