### PR TITLE
deploy(base-sepolia): live addresses + Etherscan V2 verifier

### DIFF
--- a/addresses.json
+++ b/addresses.json
@@ -1,0 +1,9 @@
+{
+  "84532": {
+    "bellStrategy": "0x906071f25ddee5cda2825a529d570771229319fa",
+    "chainlinkAdapter": "0xed00475a2e74b0078b69e21b6b939506d0196e25",
+    "protocolHook": "0xfab41b25620607718e0baec2fd8aa6c3540005c0",
+    "vaultFactory": "0xb99722fdff599c69f37c5f0bcd766139aae15677",
+    "poolManager": "0x05E73354cFDd6745C338b50BcFDfA3Aa6fA03408"
+  }
+}

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -32,5 +32,9 @@ base_sepolia = "${BASE_SEPOLIA_RPC_URL}"
 base = "${BASE_RPC_URL}"
 
 [etherscan]
-base_sepolia = { key = "${BASESCAN_API_KEY}", url = "https://api-sepolia.basescan.org/api", chain = 84532 }
-base = { key = "${BASESCAN_API_KEY}", url = "https://api.basescan.org/api", chain = 8453 }
+# Etherscan V2 unified API (one endpoint, chainid query param). The
+# legacy basescan.org/api endpoints were deprecated in 2025 — see
+# https://docs.etherscan.io/v2-migration. The same API key works for
+# every chain Etherscan supports.
+base_sepolia = { key = "${BASESCAN_API_KEY}", url = "https://api.etherscan.io/v2/api?chainid=84532", chain = 84532 }
+base = { key = "${BASESCAN_API_KEY}", url = "https://api.etherscan.io/v2/api?chainid=8453", chain = 8453 }

--- a/packages/shared/src/addresses.ts
+++ b/packages/shared/src/addresses.ts
@@ -25,8 +25,18 @@ const PLACEHOLDER: DeploymentAddresses = {
   poolManager: ZERO,
 };
 
+// <<deployed-baseSepolia>>
+const BASESEPOLIA: DeploymentAddresses = {
+  vaultFactory: "0xb99722fdff599c69f37c5f0bcd766139aae15677",
+  protocolHook: "0xfab41b25620607718e0baec2fd8aa6c3540005c0",
+  bellStrategy: "0x906071f25ddee5cda2825a529d570771229319fa",
+  chainlinkAdapter: "0xed00475a2e74b0078b69e21b6b939506d0196e25",
+  poolManager: "0x05E73354cFDd6745C338b50BcFDfA3Aa6fA03408",
+};
+// <</deployed-baseSepolia>>
+
 export const ADDRESSES: Record<SupportedChainId, DeploymentAddresses | undefined> = {
-  [CHAIN_IDS.baseSepolia]: PLACEHOLDER,
+  [CHAIN_IDS.baseSepolia]: BASESEPOLIA,
   // Mainnet deployment is gated on M5 audit completion. See ADR-006.
   [CHAIN_IDS.base]: undefined,
 };


### PR DESCRIPTION
PRISM is now deployed and Basescan-verified on Base Sepolia (block 41109152, total cost 0.000024 ETH).

## Live addresses

| Contract | Address |
|---|---|
| BellStrategy | [\`0x906071f25ddee5cda2825a529d570771229319fa\`](https://sepolia.basescan.org/address/0x906071f25ddee5cda2825a529d570771229319fa#code) |
| ChainlinkAdapter | [\`0xed00475a2e74b0078b69e21b6b939506d0196e25\`](https://sepolia.basescan.org/address/0xed00475a2e74b0078b69e21b6b939506d0196e25#code) |
| ProtocolHook | [\`0xfab41b25620607718e0baec2fd8aa6c3540005c0\`](https://sepolia.basescan.org/address/0xfab41b25620607718e0baec2fd8aa6c3540005c0#code) (bits \`0x05c0\` ✓) |
| VaultFactory | [\`0xb99722fdff599c69f37c5f0bcd766139aae15677\`](https://sepolia.basescan.org/address/0xb99722fdff599c69f37c5f0bcd766139aae15677#code) |

Hook permission bits validated via \`pnpm verify-hook\` against deployed bytecode.

## Files changed

- **\`addresses.json\`** — operator-readable snapshot of the deploy
- **\`packages/shared/src/addresses.ts\`** — deployed block bracketed by \`<<deployed-baseSepolia>>\` sentinels; \`ADDRESSES\` map flipped from \`PLACEHOLDER\` to the live block
- **\`packages/contracts/foundry.toml\`** — switched \`[etherscan]\` URLs to Etherscan V2 unified API. Legacy \`basescan.org/api\` was deprecated in 2025; \`forge script ... --verify\` now works again.

## Test plan

- [x] All 4 contracts visible on Basescan with source code
- [x] \`pnpm verify-hook --chain base-sepolia\` reports \`OK: hook permissions match address bits\`
- [x] Frontend boots against the live addresses (no localhost RPC override)