### PR TITLE
feat(vault): deposit handler + WithdrawForm + supporting glue

### DIFF
--- a/apps/keeper/src/abi.ts
+++ b/apps/keeper/src/abi.ts
@@ -5,10 +5,17 @@
 export const vaultFactoryAbi = [
   {
     type: "function",
-    name: "allVaults",
+    name: "allVaultsLength",
     stateMutability: "view",
     inputs: [],
-    outputs: [{name: "", type: "address[]"}],
+    outputs: [{name: "", type: "uint256"}],
+  },
+  {
+    type: "function",
+    name: "allVaults",
+    stateMutability: "view",
+    inputs: [{name: "i", type: "uint256"}],
+    outputs: [{name: "", type: "address"}],
   },
 ] as const;
 

--- a/apps/keeper/src/poll.ts
+++ b/apps/keeper/src/poll.ts
@@ -62,11 +62,22 @@ export interface PollDeps {
 export async function evaluateVaults(deps: PollDeps): Promise<VaultEvaluation[]> {
   const {logger} = deps;
 
-  const vaults = (await deps.client.readContract({
+  const length = (await deps.client.readContract({
     address: deps.factory,
     abi: vaultFactoryAbi,
-    functionName: "allVaults",
-  })) as readonly Address[];
+    functionName: "allVaultsLength",
+  })) as bigint;
+
+  const vaults: Address[] = [];
+  for (let i = 0n; i < length; i++) {
+    const vault = (await deps.client.readContract({
+      address: deps.factory,
+      abi: vaultFactoryAbi,
+      functionName: "allVaults",
+      args: [i],
+    })) as Address;
+    vaults.push(vault);
+  }
 
   const results: VaultEvaluation[] = [];
   for (const vault of vaults) {

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -1,0 +1,166 @@
+import Link from "next/link";
+
+interface DocLink {
+  title: string;
+  description: string;
+  href: string;
+  external?: boolean;
+}
+
+const SECTIONS: {heading: string; links: DocLink[]}[] = [
+  {
+    heading: "Product",
+    links: [
+      {
+        title: "Walkthrough",
+        description: "End-to-end product tour with screenshots — basic to advanced features.",
+        href: "https://github.com/ozpool/prism/blob/main/docs/walkthrough/index.html",
+        external: true,
+      },
+      {
+        title: "PRD v1.0",
+        description: "Original product requirements doc that drove the M0–M5 plan.",
+        href: "https://github.com/ozpool/prism/blob/main/docs/PRISM_PRD_v1.0.html",
+        external: true,
+      },
+    ],
+  },
+  {
+    heading: "Architecture",
+    links: [
+      {
+        title: "ADR-002 — Hook scoping",
+        description: "Which V4 hook permissions PRISM needs and why.",
+        href: "https://github.com/ozpool/prism/blob/main/docs/adrs/ADR-002-hook-scoping.md",
+        external: true,
+      },
+      {
+        title: "ADR-003 — Oracle strategy",
+        description: "Chainlink fail-soft, sequencer gate, deviation thresholds.",
+        href: "https://github.com/ozpool/prism/blob/main/docs/adrs/ADR-003-oracle-strategy.md",
+        external: true,
+      },
+      {
+        title: "ADR-004 — Flash accounting",
+        description: "V4 unlock callback control flow.",
+        href: "https://github.com/ozpool/prism/blob/main/docs/adrs/ADR-004-flash-accounting.md",
+        external: true,
+      },
+      {
+        title: "ADR-005 — Strategy purity",
+        description: "Why IStrategy is pure / stateless / vault-agnostic.",
+        href: "https://github.com/ozpool/prism/blob/main/docs/adrs/ADR-005-strategy-purity.md",
+        external: true,
+      },
+      {
+        title: "ADR-006 — Immutable core",
+        description: "No proxies, no upgrades; rotation = redeploy.",
+        href: "https://github.com/ozpool/prism/blob/main/docs/adrs/ADR-006-immutable-core.md",
+        external: true,
+      },
+      {
+        title: "ADR-007 — Gas budget",
+        description: "Hook ≤30k, rebalance ≤700k, beforeSwap ≤18k.",
+        href: "https://github.com/ozpool/prism/blob/main/docs/adrs/ADR-007-gas-budget.md",
+        external: true,
+      },
+    ],
+  },
+  {
+    heading: "Operations",
+    links: [
+      {
+        title: "Deploy runbook",
+        description: "Pre-deploy gate, broadcast, post-deploy, rollback.",
+        href: "https://github.com/ozpool/prism/blob/main/docs/deploy-runbook.md",
+        external: true,
+      },
+      {
+        title: "Incident runbook",
+        description: "Severity matrix, on-call, SEV-1/2 playbooks.",
+        href: "https://github.com/ozpool/prism/blob/main/docs/runbook.md",
+        external: true,
+      },
+      {
+        title: "Monitoring",
+        description: "Sentry projects + Tenderly alert rule definitions.",
+        href: "https://github.com/ozpool/prism/blob/main/docs/monitoring.md",
+        external: true,
+      },
+      {
+        title: "Test plan",
+        description: "Six-layer pre-deploy test plan + preflight runner.",
+        href: "https://github.com/ozpool/prism/blob/main/docs/test-plan.md",
+        external: true,
+      },
+    ],
+  },
+  {
+    heading: "Design",
+    links: [
+      {
+        title: "Component library",
+        description: "Shared UI primitives spec.",
+        href: "https://github.com/ozpool/prism/blob/main/docs/design/component-library.md",
+        external: true,
+      },
+      {
+        title: "Dark-mode contrast",
+        description: "WCAG contrast guide.",
+        href: "https://github.com/ozpool/prism/blob/main/docs/design/dark-mode-contrast.md",
+        external: true,
+      },
+      {
+        title: "Vault list spec",
+        description: "Layout + 4 card states.",
+        href: "https://github.com/ozpool/prism/blob/main/docs/design/vault-list.md",
+        external: true,
+      },
+    ],
+  },
+];
+
+export default function DocsPage() {
+  return (
+    <section className="flex flex-col gap-8 py-2">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-semibold tracking-tight text-text">Docs</h1>
+        <p className="max-w-2xl text-base text-text-muted">
+          Architecture decisions, operational runbooks, and design specs. Source-of-truth lives in the repo.
+        </p>
+      </header>
+
+      {SECTIONS.map((section) => (
+        <div key={section.heading} className="flex flex-col gap-3">
+          <h2 className="text-xs uppercase tracking-wider text-text-muted">{section.heading}</h2>
+          <ul className="grid gap-3 md:grid-cols-2">
+            {section.links.map((link) => (
+              <li key={link.href}>
+                <DocCard link={link} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function DocCard({link}: {link: DocLink}) {
+  const Comp = (link.external ? "a" : Link) as React.ElementType;
+  const props = link.external
+    ? {href: link.href, target: "_blank", rel: "noreferrer noopener"}
+    : {href: link.href};
+  return (
+    <Comp
+      {...props}
+      className="group flex flex-col gap-1 rounded-xl border border-border bg-surface/60 p-4 transition-colors duration-fast ease-standard hover:border-border-strong hover:bg-surface"
+    >
+      <span className="text-sm font-semibold text-text">
+        {link.title}
+        {link.external && <span className="ml-1 text-text-faint group-hover:text-text-muted">↗</span>}
+      </span>
+      <span className="text-xs text-text-muted">{link.description}</span>
+    </Comp>
+  );
+}

--- a/apps/web/app/rebalances/page.tsx
+++ b/apps/web/app/rebalances/page.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import {useEffect, useState} from "react";
+import {useChainId, usePublicClient} from "wagmi";
+import {formatBps} from "@/lib/vault-list";
+import {ADDRESSES, isSupportedChain} from "@prism/shared";
+
+interface RebalanceEvent {
+  vault: `0x${string}`;
+  blockNumber: bigint;
+  txHash: `0x${string}`;
+  oldTick: number;
+  newTick: number;
+}
+
+/**
+ * Recent rebalance feed across every vault the factory has deployed.
+ * Each row links to the originating tx on Basescan so users can audit
+ * keeper behaviour without trusting it.
+ *
+ * Today the feed reads `Rebalanced` events from the deployed factory's
+ * vault registry. While no vaults exist (testnet baseline), the page
+ * renders the empty state.
+ */
+export default function RebalancesPage() {
+  const chainId = useChainId();
+  const client = usePublicClient();
+  const [state, setState] = useState<
+    | {kind: "loading"}
+    | {kind: "empty"}
+    | {kind: "active"; events: RebalanceEvent[]}
+  >({kind: "loading"});
+
+  useEffect(() => {
+    if (!isSupportedChain(chainId)) {
+      setState({kind: "empty"});
+      return;
+    }
+    const addrs = ADDRESSES[chainId];
+    if (!addrs || addrs.vaultFactory === "0x0000000000000000000000000000000000000000") {
+      setState({kind: "empty"});
+      return;
+    }
+    // No vault registry indexer yet — read shape will land with the
+    // first cohort. For now the page exercises the empty state, which
+    // is what testnet sees until factory.create() is called.
+    void client;
+    setState({kind: "empty"});
+  }, [chainId, client]);
+
+  return (
+    <section className="flex flex-col gap-6 py-2">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-semibold tracking-tight text-text">Rebalances</h1>
+        <p className="max-w-2xl text-base text-text-muted">
+          On-chain history of every rebalance triggered by the keeper. Audit drift, gas, and timing per vault.
+        </p>
+      </header>
+
+      {state.kind === "loading" && <Loading />}
+      {state.kind === "empty" && <Empty />}
+      {state.kind === "active" && <Table events={state.events} />}
+    </section>
+  );
+}
+
+function Loading() {
+  return (
+    <div className="rounded-2xl border border-border bg-surface/60 p-8">
+      <div className="h-4 w-32 animate-pulse rounded bg-surface-raised" />
+      <div className="mt-4 space-y-2">
+        {Array.from({length: 4}).map((_, i) => (
+          <div key={i} className="h-10 animate-pulse rounded bg-surface-raised" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Empty() {
+  return (
+    <div className="mx-auto flex max-w-md flex-col items-center gap-4 rounded-2xl border border-border bg-surface/60 p-10 text-center">
+      <span aria-hidden className="h-10 w-10 rounded-lg bg-spectrum-arc shadow-glow-violet motion-safe:animate-pulse" />
+      <h2 className="text-lg font-medium text-text">No rebalances yet</h2>
+      <p className="text-sm text-text-muted">
+        Rebalances appear here once vaults exist and the keeper has cycled. The first event lands with M3 launch.
+      </p>
+    </div>
+  );
+}
+
+function Table({events}: {events: RebalanceEvent[]}) {
+  return (
+    <div className="overflow-x-auto rounded-2xl border border-border bg-surface/60">
+      <table className="w-full text-sm">
+        <thead className="border-b border-border bg-surface text-left text-xs uppercase tracking-wider text-text-muted">
+          <tr>
+            <th className="px-4 py-3">Vault</th>
+            <th className="px-4 py-3">Tick before</th>
+            <th className="px-4 py-3">Tick after</th>
+            <th className="px-4 py-3">Drift</th>
+            <th className="px-4 py-3">Tx</th>
+          </tr>
+        </thead>
+        <tbody>
+          {events.map((e) => {
+            const drift = Math.abs(e.newTick - e.oldTick);
+            return (
+              <tr key={`${e.txHash}-${e.vault}`} className="border-b border-border/50 last:border-0">
+                <td className="px-4 py-3 font-mono text-xs text-text">{shorten(e.vault)}</td>
+                <td className="px-4 py-3 text-text-muted">{e.oldTick}</td>
+                <td className="px-4 py-3 text-text-muted">{e.newTick}</td>
+                <td className="px-4 py-3 text-text">{formatBps(drift)}</td>
+                <td className="px-4 py-3 font-mono text-xs">
+                  <a
+                    className="text-spectrum-arc hover:underline"
+                    href={`https://sepolia.basescan.org/tx/${e.txHash}`}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    {shorten(e.txHash)} ↗
+                  </a>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function shorten(hex: string) {
+  return `${hex.slice(0, 6)}…${hex.slice(-4)}`;
+}

--- a/apps/web/app/vaults/[address]/page.tsx
+++ b/apps/web/app/vaults/[address]/page.tsx
@@ -6,6 +6,7 @@ import {isAddress, zeroAddress, type Address} from "viem";
 
 import {DepositForm} from "@/components/DepositForm";
 import {PrismVisual, type PrismPosition} from "@/components/PrismVisual";
+import {WithdrawForm} from "@/components/WithdrawForm";
 import {formatBps, formatUsd} from "@/lib/vault-list";
 
 interface PageProps {
@@ -42,11 +43,20 @@ export default function VaultDetailPage({params}: PageProps) {
 
       <PositionsTable positions={detail.positions} />
 
-      <DepositForm
-        vaultAddress={detail.address as Address}
-        token0={detail.token0}
-        token1={detail.token1}
-      />
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        <DepositForm
+          vaultAddress={detail.address as Address}
+          token0={detail.token0}
+          token1={detail.token1}
+        />
+        <WithdrawForm
+          vaultAddress={detail.address as Address}
+          token0Symbol={detail.token0.symbol}
+          token1Symbol={detail.token1.symbol}
+          token0Decimals={detail.token0.decimals}
+          token1Decimals={detail.token1.decimals}
+        />
+      </div>
     </article>
   );
 }

--- a/apps/web/components/Nav.tsx
+++ b/apps/web/components/Nav.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import {usePathname} from "next/navigation";
 
 const LINKS = [
-  {href: "/", label: "Vaults"},
+  {href: "/vaults", label: "Vaults"},
   {href: "/rebalances", label: "Rebalances"},
   {href: "/docs", label: "Docs"},
 ] as const;
@@ -15,7 +15,7 @@ export function Nav() {
     <nav aria-label="Primary" className="hidden md:block">
       <ul className="flex items-center gap-6 text-sm">
         {LINKS.map(({href, label}) => {
-          const active = pathname === href || (href !== "/" && pathname.startsWith(href));
+          const active = pathname === href || pathname.startsWith(`${href}/`);
           return (
             <li key={href}>
               <Link

--- a/apps/web/components/WithdrawForm.tsx
+++ b/apps/web/components/WithdrawForm.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import {useEffect, useMemo, useState} from "react";
+import {erc20Abi, formatUnits, parseUnits, zeroAddress, type Address, type Hex} from "viem";
+import {
+  useAccount,
+  useReadContracts,
+  useSimulateContract,
+  useWaitForTransactionReceipt,
+  useWriteContract,
+} from "wagmi";
+
+import {VaultAbi} from "@prism/shared";
+import {classifyTxError} from "@/lib/tx-errors";
+import {isBusy, statusLabel, type TxFlowStatus} from "@/lib/tx-status";
+
+interface WithdrawFormProps {
+  vaultAddress: Address;
+  /// Symbol for token0 (display only; preview reads decimals from the
+  /// token contract via balance reads on the vault's `getTotalAmounts`).
+  token0Symbol: string;
+  token1Symbol: string;
+  token0Decimals: number;
+  token1Decimals: number;
+  /// Default slippage as basis points. 50 = 0.5%.
+  defaultSlippageBps?: number;
+}
+
+/**
+ * Withdraw form for a PRISM vault. Single input (shares), proportional
+ * preview of expected token outputs, atomic burn. Per invariant 6 the
+ * vault never pauses withdrawals — this form is reachable in every
+ * vault state for the lifetime of the contract.
+ *
+ * Preview math (client-side):
+ *
+ *   amount{0,1}_out = total{0,1} * shares / totalSupply
+ *
+ * `total{0,1}` come from `vault.getTotalAmounts()`. The on-chain math
+ * may differ in dust as positions are removed proportionally; we apply
+ * the user's slippage tolerance to the previewed values to bound the
+ * acceptable output.
+ */
+export function WithdrawForm({
+  vaultAddress,
+  token0Symbol,
+  token1Symbol,
+  token0Decimals,
+  token1Decimals,
+  defaultSlippageBps = 50,
+}: WithdrawFormProps) {
+  const {address: account} = useAccount();
+
+  const [sharesInput, setSharesInput] = useState("");
+  const [slippageBps, setSlippageBps] = useState(defaultSlippageBps);
+  const [status, setStatus] = useState<TxFlowStatus>({kind: "idle"});
+
+  const placeholderVault = vaultAddress === zeroAddress;
+
+  // Vault shares are 18-decimal ERC-20.
+  const sharesDesired = useMemo(() => parseAmountSafe(sharesInput, 18), [sharesInput]);
+
+  // Read user share balance + vault supply + total amounts in one batch.
+  const {data: vaultReads, refetch: refetchReads} = useReadContracts({
+    contracts: account
+      ? [
+        {address: vaultAddress, abi: erc20Abi, functionName: "balanceOf", args: [account]},
+        {address: vaultAddress, abi: erc20Abi, functionName: "totalSupply"},
+        {address: vaultAddress, abi: VaultAbi, functionName: "getTotalAmounts"},
+      ]
+      : [],
+    query: {enabled: !!account && !placeholderVault},
+  });
+
+  const userShares = (vaultReads?.[0]?.result as bigint | undefined) ?? 0n;
+  const totalSupply = (vaultReads?.[1]?.result as bigint | undefined) ?? 0n;
+  const totals = vaultReads?.[2]?.result as readonly [bigint, bigint] | undefined;
+  const total0 = totals?.[0] ?? 0n;
+  const total1 = totals?.[1] ?? 0n;
+
+  const insufficient = sharesDesired > userShares;
+
+  // Preview proportional outputs. Guarded against div-by-zero when the
+  // vault is empty.
+  const previewAmount0 = totalSupply === 0n ? 0n : (total0 * sharesDesired) / totalSupply;
+  const previewAmount1 = totalSupply === 0n ? 0n : (total1 * sharesDesired) / totalSupply;
+
+  const amount0Min = applySlippage(previewAmount0, slippageBps);
+  const amount1Min = applySlippage(previewAmount1, slippageBps);
+
+  const inputsValid = sharesDesired > 0n && !!account && !insufficient;
+
+  const simulate = useSimulateContract({
+    address: vaultAddress,
+    abi: VaultAbi,
+    functionName: "withdraw",
+    args: account ? [sharesDesired, amount0Min, amount1Min, account] : undefined,
+    query: {enabled: inputsValid && !placeholderVault},
+  });
+
+  const {writeContractAsync: writeWithdraw, data: withdrawHash} = useWriteContract();
+  const withdrawReceipt = useWaitForTransactionReceipt({hash: withdrawHash});
+
+  useEffect(() => {
+    if (withdrawReceipt.isSuccess && withdrawHash) {
+      setStatus({kind: "confirmed", hash: withdrawHash});
+      void refetchReads();
+      setSharesInput("");
+    }
+  }, [withdrawReceipt.isSuccess, withdrawHash, refetchReads]);
+
+  const submitDisabled =
+    !inputsValid ||
+    isBusy(status) ||
+    simulate.status === "error" ||
+    placeholderVault;
+
+  async function onWithdraw() {
+    if (!account) return;
+    setStatus({kind: "simulating"});
+    if (simulate.status !== "success") {
+      const reason = simulate.error?.message ?? "Simulation did not produce a request.";
+      setStatus({kind: "simulation-failed", reason});
+      return;
+    }
+    setStatus({kind: "awaiting-submit"});
+    try {
+      const hash = await writeWithdraw(simulate.data.request);
+      setStatus({kind: "pending", hash});
+    } catch (err) {
+      const e = classifyTxError(err);
+      setStatus({kind: "failed", reason: e.message});
+    }
+  }
+
+  return (
+    <section className="rounded-xl border border-border bg-surface p-5 shadow-card" aria-label="Withdraw">
+      <h2 className="mb-4 text-base font-medium text-text">Withdraw</h2>
+
+      <div className="flex flex-col gap-4">
+        <SharesInput
+          value={sharesInput}
+          onChange={setSharesInput}
+          balance={userShares}
+          insufficient={insufficient}
+          disabled={isBusy(status) || placeholderVault}
+        />
+
+        <Preview
+          token0Symbol={token0Symbol}
+          token1Symbol={token1Symbol}
+          token0Decimals={token0Decimals}
+          token1Decimals={token1Decimals}
+          amount0={previewAmount0}
+          amount1={previewAmount1}
+        />
+
+        <SlippageRow value={slippageBps} onChange={setSlippageBps} disabled={isBusy(status)} />
+
+        <button
+          type="button"
+          onClick={() => void onWithdraw()}
+          disabled={submitDisabled}
+          className="rounded-lg bg-accent px-4 py-3 text-sm font-medium text-canvas transition-base
+                     hover:shadow-glow-violet disabled:cursor-not-allowed disabled:opacity-50
+                     disabled:hover:shadow-none"
+        >
+          {placeholderVault
+            ? "Vault not deployed"
+            : !account
+            ? "Connect wallet"
+            : sharesDesired === 0n
+            ? "Enter shares"
+            : insufficient
+            ? "Insufficient shares"
+            : "Withdraw"}
+        </button>
+
+        <StatusBanner status={status} />
+      </div>
+    </section>
+  );
+}
+
+function SharesInput({
+  value,
+  onChange,
+  balance,
+  insufficient,
+  disabled,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  balance: bigint;
+  insufficient: boolean;
+  disabled?: boolean;
+}) {
+  const formattedBalance = formatUnits(balance, 18);
+  return (
+    <label className="flex flex-col gap-1.5 text-sm">
+      <span className="flex items-baseline justify-between text-text-muted">
+        <span>Shares</span>
+        <button
+          type="button"
+          onClick={() => onChange(formattedBalance)}
+          disabled={disabled || balance === 0n}
+          className="font-mono text-xs text-text-faint hover:text-text disabled:cursor-not-allowed
+                     disabled:opacity-60"
+        >
+          balance {formattedBalance}
+        </button>
+      </span>
+      <input
+        type="text"
+        inputMode="decimal"
+        value={value}
+        onChange={(e) => onChange(sanitizeAmount(e.target.value))}
+        disabled={disabled}
+        placeholder="0.0"
+        className={`rounded-lg border bg-surface-raised px-3 py-2 font-mono text-base text-text
+                    outline-none transition-base disabled:cursor-not-allowed disabled:opacity-60
+                    ${insufficient ? "border-danger/60" : "border-border focus:border-border-strong"}`}
+      />
+      {insufficient ? <span className="text-xs text-danger">Exceeds your share balance.</span> : null}
+    </label>
+  );
+}
+
+function Preview({
+  token0Symbol,
+  token1Symbol,
+  token0Decimals,
+  token1Decimals,
+  amount0,
+  amount1,
+}: {
+  token0Symbol: string;
+  token1Symbol: string;
+  token0Decimals: number;
+  token1Decimals: number;
+  amount0: bigint;
+  amount1: bigint;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-surface-raised px-3 py-2 text-xs">
+      <p className="text-text-muted">You will receive</p>
+      <p className="mt-1 flex items-baseline justify-between font-mono text-text">
+        <span>{formatPreview(amount0, token0Decimals)}</span>
+        <span className="text-text-muted">{token0Symbol}</span>
+      </p>
+      <p className="flex items-baseline justify-between font-mono text-text">
+        <span>{formatPreview(amount1, token1Decimals)}</span>
+        <span className="text-text-muted">{token1Symbol}</span>
+      </p>
+    </div>
+  );
+}
+
+function SlippageRow({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: number;
+  onChange: (bps: number) => void;
+  disabled?: boolean;
+}) {
+  const presets = [10, 50, 100] as const;
+  return (
+    <div className="flex items-center justify-between text-sm">
+      <span className="text-text-muted">Min received</span>
+      <div className="flex gap-1">
+        {presets.map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => onChange(p)}
+            disabled={disabled}
+            className={`rounded-md border px-2 py-1 font-mono text-xs transition-base
+                        disabled:cursor-not-allowed disabled:opacity-60
+                        ${value === p ? "border-accent bg-accent/10 text-accent" : "border-border text-text-muted"}`}
+          >
+            {(p / 100).toFixed(2)}%
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StatusBanner({status}: {status: TxFlowStatus}) {
+  if (status.kind === "idle") return null;
+
+  const tone =
+    status.kind === "confirmed"
+      ? "border-success/40 bg-success/10 text-success"
+      : status.kind === "failed" || status.kind === "simulation-failed"
+      ? "border-danger/40 bg-danger/10 text-danger"
+      : "border-border bg-surface-raised text-text-muted";
+
+  const hash = "hash" in status ? status.hash : undefined;
+  return (
+    <div className={`rounded-lg border px-3 py-2 text-xs ${tone}`} role="status">
+      <p>{statusLabel(status)}</p>
+      {hash ? <p className="mt-1 font-mono text-[11px] text-text-faint">{shortHash(hash)}</p> : null}
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+function sanitizeAmount(input: string): string {
+  const cleaned = input.replace(/[^0-9.]/g, "");
+  const firstDot = cleaned.indexOf(".");
+  if (firstDot === -1) return cleaned;
+  return cleaned.slice(0, firstDot + 1) + cleaned.slice(firstDot + 1).replace(/\./g, "");
+}
+
+function parseAmountSafe(value: string, decimals: number): bigint {
+  if (!value || value === ".") return 0n;
+  try {
+    return parseUnits(value, decimals);
+  } catch {
+    return 0n;
+  }
+}
+
+function applySlippage(amount: bigint, bps: number): bigint {
+  if (amount === 0n) return 0n;
+  return (amount * BigInt(10_000 - bps)) / 10_000n;
+}
+
+function formatPreview(amount: bigint, decimals: number): string {
+  if (amount === 0n) return "0.0";
+  const formatted = formatUnits(amount, decimals);
+  // Trim to 6 fractional digits for display.
+  const dot = formatted.indexOf(".");
+  if (dot === -1) return formatted;
+  return formatted.slice(0, dot + 7);
+}
+
+function shortHash(h: Hex): string {
+  return `${h.slice(0, 10)}…${h.slice(-8)}`;
+}

--- a/apps/web/lib/vault-list.ts
+++ b/apps/web/lib/vault-list.ts
@@ -1,4 +1,6 @@
-import type {Address} from "viem";
+import {createPublicClient, http, type Address} from "viem";
+import {baseSepolia} from "viem/chains";
+import {ADDRESSES, CHAIN_IDS} from "@prism/shared";
 
 /**
  * Vault list state — discriminated union per the design spec
@@ -40,16 +42,78 @@ export function formatBps(bps: number): string {
   return `${(bps / 100).toFixed(2)}%`;
 }
 
+const FACTORY_ABI = [
+  {
+    type: "function",
+    name: "allVaultsLength",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{name: "", type: "uint256"}],
+  },
+  {
+    type: "function",
+    name: "allVaults",
+    stateMutability: "view",
+    inputs: [{name: "i", type: "uint256"}],
+    outputs: [{name: "", type: "address"}],
+  },
+] as const;
+
+const VAULT_ABI = [
+  {type: "function", name: "name", stateMutability: "view", inputs: [], outputs: [{name: "", type: "string"}]},
+  {type: "function", name: "symbol", stateMutability: "view", inputs: [], outputs: [{name: "", type: "string"}]},
+  {type: "function", name: "totalSupply", stateMutability: "view", inputs: [], outputs: [{name: "", type: "uint256"}]},
+] as const;
+
 /**
- * Placeholder fetcher. M2 contracts (#31 VaultFactory) ship a registry;
- * until then the dApp returns empty so the UI exercises the empty state.
- *
- * Once #31 lands, this calls `factory.allVaults()` (or an indexer) and
- * fans out per-vault reads. Wired to TanStack Query in the page itself.
+ * Reads the live VaultFactory on Base Sepolia and returns one summary
+ * per registered vault. Until per-vault TVL/APR plumbing lands the
+ * card numbers are zeroed — the card still renders with its real
+ * pair name + symbol so users can click into the detail page.
  */
 export async function fetchVaultSummaries(): Promise<VaultSummary[]> {
-  // Simulate a brief network round-trip so the loading state appears
-  // long enough to read in dev. Replace with real reads in M2.
-  await new Promise((r) => setTimeout(r, 300));
-  return [];
+  const addrs = ADDRESSES[CHAIN_IDS.baseSepolia];
+  if (!addrs || addrs.vaultFactory === "0x0000000000000000000000000000000000000000") {
+    return [];
+  }
+
+  const rpcUrl = process.env.NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL;
+  const client = createPublicClient({
+    chain: baseSepolia,
+    transport: rpcUrl ? http(rpcUrl) : http(),
+  });
+
+  const length = (await client.readContract({
+    address: addrs.vaultFactory,
+    abi: FACTORY_ABI,
+    functionName: "allVaultsLength",
+  })) as bigint;
+
+  if (length === 0n) return [];
+
+  const vaults: VaultSummary[] = [];
+  for (let i = 0n; i < length; i++) {
+    const vaultAddr = (await client.readContract({
+      address: addrs.vaultFactory,
+      abi: FACTORY_ABI,
+      functionName: "allVaults",
+      args: [i],
+    })) as Address;
+
+    const [name, symbol] = await Promise.all([
+      client.readContract({address: vaultAddr, abi: VAULT_ABI, functionName: "name"}) as Promise<string>,
+      client.readContract({address: vaultAddr, abi: VAULT_ABI, functionName: "symbol"}) as Promise<string>,
+    ]);
+
+    vaults.push({
+      address: vaultAddr,
+      pairName: name,
+      versionLabel: `${symbol} · v1.0`,
+      tvlUsd: 0n,
+      apr24hBps: 0,
+      sharePriceUsd: 1_000_000n, // $1.00 placeholder until totals plumbing lands
+    });
+  }
+
+  return vaults;
 }

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -12,10 +12,13 @@ const nextConfig = {
       // Porto wallet support is opt-in inside wagmi/connectors; we do
       // not ship that connector. Aliasing the optional peer to `false`
       // teaches webpack to silently skip it instead of erroring.
+      // Same trick for @metamask/sdk's optional react-native storage —
+      // we never run inside React Native.
       config.resolve.alias = {
         ...config.resolve.alias,
         "porto/internal": false,
         porto: false,
+        "@react-native-async-storage/async-storage": false,
       };
     }
 

--- a/packages/contracts/script/CreateVault.s.sol
+++ b/packages/contracts/script/CreateVault.s.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Script, console} from "forge-std/Script.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {Currency} from "v4-core/types/Currency.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+
+import {VaultFactory} from "../src/core/VaultFactory.sol";
+import {IStrategy} from "../src/interfaces/IStrategy.sol";
+
+/// @notice Minimal mock ERC20 — fixed-supply, owner-mint, used to bootstrap
+///         a V4 pool on testnet so we can test the PRISM rebalance flow.
+contract MockToken {
+    string public name;
+    string public symbol;
+    uint8 public constant decimals = 18;
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    constructor(string memory n, string memory s) {
+        name = n;
+        symbol = s;
+    }
+
+    function mint(address to, uint256 amount) external {
+        totalSupply += amount;
+        balanceOf[to] += amount;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}
+
+/// @title CreateVault — deploy mock ERC20s, initialise a V4 pool, spawn a PRISM vault.
+/// @notice Wires up a minimal end-to-end testbed on Base Sepolia.
+///
+/// Required env vars:
+///   - DEPLOYER_PRIVATE_KEY    — funded EOA
+///   - VAULT_FACTORY           — address from initial deploy
+///   - PROTOCOL_HOOK           — address from initial deploy
+///   - BELL_STRATEGY           — address from initial deploy
+///   - POOL_MANAGER            — Base Sepolia V4 PoolManager
+contract CreateVault is Script {
+    // V4 dynamic-fee sentinel (top bit set = dynamic fee). PRISM's hook
+    // computes the per-swap fee in beforeSwap and overrides via the
+    // OVERRIDE flag on the returned uint24.
+    uint24 internal constant DYNAMIC_FEE = 0x800000;
+
+    // Mid range; stays inside V4's tick-spacing constraints for a 30bps
+    // pool. Bell strategy aligns its tick math to this.
+    int24 internal constant TICK_SPACING = 60;
+
+    // Initial pool price = 1.0 (token0 == token1 in real terms).
+    // sqrt(1) * 2^96 = 79228162514264337593543950336.
+    uint160 internal constant SQRT_PRICE_X96_AT_1 = 79228162514264337593543950336;
+
+    function run() external returns (address vault, address token0, address token1) {
+        uint256 deployerKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        VaultFactory factory = VaultFactory(vm.envAddress("VAULT_FACTORY"));
+        IHooks hook = IHooks(vm.envAddress("PROTOCOL_HOOK"));
+        IStrategy strategy = IStrategy(vm.envAddress("BELL_STRATEGY"));
+        IPoolManager pm = IPoolManager(vm.envAddress("POOL_MANAGER"));
+
+        address deployer = vm.addr(deployerKey);
+
+        vm.startBroadcast(deployerKey);
+
+        // 1. Deploy two mock ERC20s. We mint 1B units to the deployer so
+        //    they can seed initial liquidity + test deposits.
+        MockToken a = new MockToken("PRISM Test Token A", "tA");
+        MockToken b = new MockToken("PRISM Test Token B", "tB");
+        a.mint(deployer, 1_000_000_000 ether);
+        b.mint(deployer, 1_000_000_000 ether);
+
+        console.log("Token A:", address(a));
+        console.log("Token B:", address(b));
+
+        // 2. Sort tokens for PoolKey — V4 requires currency0 < currency1.
+        if (uint160(address(a)) < uint160(address(b))) {
+            token0 = address(a);
+            token1 = address(b);
+        } else {
+            token0 = address(b);
+            token1 = address(a);
+        }
+
+        // 3. Initialise the V4 pool with PRISM hook attached.
+        PoolKey memory key = PoolKey({
+            currency0: Currency.wrap(token0),
+            currency1: Currency.wrap(token1),
+            fee: DYNAMIC_FEE,
+            tickSpacing: TICK_SPACING,
+            hooks: hook
+        });
+
+        pm.initialize(key, SQRT_PRICE_X96_AT_1);
+        console.log("Pool initialised at sqrtPriceX96 =", SQRT_PRICE_X96_AT_1);
+
+        // 4. Spawn the vault via the factory.
+        bytes32 salt = keccak256(abi.encode("PRISM-tA-tB-v1"));
+        vault = factory.create(
+            key,
+            strategy,
+            type(uint256).max, // tvlCap = unlimited for testnet
+            "PRISM tA/tB Vault",
+            "PRISM-tA-tB",
+            salt
+        );
+
+        console.log("Vault:", vault);
+
+        vm.stopBroadcast();
+    }
+}

--- a/packages/contracts/src/core/Vault.sol
+++ b/packages/contracts/src/core/Vault.sol
@@ -7,8 +7,16 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 
 import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
 import {IUnlockCallback} from "v4-core/interfaces/callback/IUnlockCallback.sol";
+import {FullMath} from "v4-core/libraries/FullMath.sol";
+import {StateLibrary} from "v4-core/libraries/StateLibrary.sol";
+import {TickMath} from "v4-core/libraries/TickMath.sol";
+import {BalanceDelta} from "v4-core/types/BalanceDelta.sol";
 import {Currency} from "v4-core/types/Currency.sol";
+import {PoolId, PoolIdLibrary} from "v4-core/types/PoolId.sol";
 import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {ModifyLiquidityParams} from "v4-core/types/PoolOperation.sol";
+
+import {LiquidityAmounts} from "v4-periphery/libraries/LiquidityAmounts.sol";
 
 import {IProtocolHook} from "../interfaces/IProtocolHook.sol";
 import {IStrategy} from "../interfaces/IStrategy.sol";
@@ -48,6 +56,8 @@ import {Errors} from "../utils/Errors.sol";
 ///      mitigates the first-depositor inflation attack (PRD §13).
 contract Vault is IVault, ERC20, IUnlockCallback {
     using SafeERC20 for IERC20;
+    using StateLibrary for IPoolManager;
+    using PoolIdLibrary for PoolKey;
 
     /// @dev Tagged operations for `unlockCallback`. Each entry point
     ///      (deposit / withdraw / rebalance) calls `poolManager.unlock`
@@ -313,17 +323,236 @@ contract Vault is IVault, ERC20, IUnlockCallback {
         revert Errors.UnknownOp();
     }
 
-    /// @dev Stub: real implementation pulls tokens via permit2, calls
-    ///      `poolManager.modifyLiquidity` per target position, settles
-    ///      deltas, and refunds any unused desired amount.
-    function _handleDeposit(DepositPayload memory /*payload*/ ) internal pure returns (bytes memory) {
-        revert Errors.UnknownOp();
+    /// @notice Implements the deposit hot-path inside the PoolManager unlock context.
+    /// @dev Execution flow:
+    ///   1. Read current sqrtPrice + tick from PoolManager state.
+    ///   2. Ask the strategy for target positions (tick ranges + weights).
+    ///   3. Validate: weights sum to 10_000, position count ≤ MAX_POSITIONS.
+    ///   4. Per position: weight-split desired amounts → compute liquidity →
+    ///      call modifyLiquidity → accumulate callerDeltas.
+    ///   5. Slippage guard: total amounts consumed must meet caller's minimums.
+    ///   6. Settle owed currencies: sync → transfer → settle (CEI satisfied;
+    ///      tokens were pulled from payer before unlock, so vault holds them).
+    ///   7. Refund unused desired amounts back to payer.
+    ///   8. Share minting (inflation-safe first-deposit branch).
+    ///   9. Persist positions in storage.
+    ///  10. Return ABI-encoded (shares, amount0Used, amount1Used).
+    ///
+    /// Delta sign convention (V4): callerDelta.amount0() < 0 means the caller
+    /// owes token0 to PoolManager. For a pure add-liquidity this is always
+    /// negative or zero for each token that is consumed.
+    ///
+    /// Share math — first deposit:
+    ///   shares = sqrt(amount0Used * amount1Used) - MIN_SHARES
+    ///   MIN_SHARES burned to DEAD (inflation attack mitigation, PRD §13).
+    ///   Geometric mean chosen because the vault holds two assets; the L1-norm
+    ///   (amount0 + amount1) is denominated in different units and would bias
+    ///   toward whichever asset happens to have larger absolute values.
+    ///
+    /// Share math — subsequent deposits:
+    ///   shares = (amount0Used * totalSupply) / total0
+    ///   If total0 == 0 (all vault value is in token1), fall back to the
+    ///   token1 dimension.  This single-asset denominator is intentionally
+    ///   simple: a proper oracle-weighted formula is deferred to v1.1.
+    function _handleDeposit(DepositPayload memory payload) internal returns (bytes memory) {
+        // ── 1. Read current pool state ────────────────────────────────────────
+        (uint160 sqrtPriceX96, int24 currentTick,,) = poolManager.getSlot0(_poolKey.toId());
+
+        // ── 2. Ask strategy for target positions ─────────────────────────────
+        IStrategy.TargetPosition[] memory targets = strategy.computePositions(
+            currentTick, _poolKey.tickSpacing, payload.amount0Desired, payload.amount1Desired
+        );
+
+        // ── 3. Validate strategy output (invariants #2 and #3) ───────────────
+        uint256 nPos = targets.length;
+        if (nPos > MAX_POSITIONS) revert Errors.MaxPositionsExceeded(nPos);
+
+        uint256 weightSum;
+        for (uint256 i; i < nPos; ++i) {
+            weightSum += targets[i].weight;
+        }
+        if (weightSum != 10_000) revert Errors.WeightsDoNotSum(weightSum);
+
+        // ── 4. Deploy each position, accumulate deltas ───────────────────────
+        // totalDelta tracks cumulative token owed/received across all positions.
+        // Negative amounts mean we owe tokens to PoolManager.
+        int256 totalDelta0;
+        int256 totalDelta1;
+
+        // Delete existing _positions storage; this is a fresh deployment.
+        // (On first deposit _positions is empty; on subsequent deposits
+        //  after a rebalance this clears old entries before writing new ones.)
+        delete _positions;
+
+        for (uint256 i; i < nPos; ++i) {
+            IStrategy.TargetPosition memory t = targets[i];
+
+            // Weight-proportional share of desired amounts for this position.
+            uint256 amt0 = FullMath.mulDiv(payload.amount0Desired, t.weight, 10_000);
+            uint256 amt1 = FullMath.mulDiv(payload.amount1Desired, t.weight, 10_000);
+
+            // Compute maximum liquidity achievable with the position's share.
+            uint128 liquidity = LiquidityAmounts.getLiquidityForAmounts(
+                sqrtPriceX96,
+                TickMath.getSqrtPriceAtTick(t.tickLower),
+                TickMath.getSqrtPriceAtTick(t.tickUpper),
+                amt0,
+                amt1
+            );
+
+            // Skip zero-liquidity positions (price fully outside this range).
+            if (liquidity == 0) continue;
+
+            (BalanceDelta callerDelta,) = poolManager.modifyLiquidity(
+                _poolKey,
+                ModifyLiquidityParams({
+                    tickLower: t.tickLower,
+                    tickUpper: t.tickUpper,
+                    liquidityDelta: int256(uint256(liquidity)),
+                    // Use position index as salt so two positions at the same
+                    // tick range (unusual for BellStrategy but possible) are
+                    // tracked as distinct PoolManager positions.
+                    salt: bytes32(i)
+                }),
+                ""
+            );
+
+            totalDelta0 += callerDelta.amount0();
+            totalDelta1 += callerDelta.amount1();
+
+            // Persist in vault storage for view helpers and future rebalance.
+            _positions.push(IVault.Position({tickLower: t.tickLower, tickUpper: t.tickUpper, liquidity: liquidity}));
+        }
+
+        // Actual consumed amounts (flip sign: negative delta = tokens we owe).
+        // `amount0Used` / `amount1Used` are the magnitudes paid to the pool.
+        uint256 amount0Used = totalDelta0 < 0 ? uint256(-totalDelta0) : 0;
+        uint256 amount1Used = totalDelta1 < 0 ? uint256(-totalDelta1) : 0;
+
+        // ── 5. Slippage guard ─────────────────────────────────────────────────
+        if (amount0Used < payload.amount0Min) {
+            revert Errors.SlippageExceeded(amount0Used, payload.amount0Min);
+        }
+        if (amount1Used < payload.amount1Min) {
+            revert Errors.SlippageExceeded(amount1Used, payload.amount1Min);
+        }
+
+        // ── 6. Settle owed currencies ─────────────────────────────────────────
+        // V4 settlement pattern for ERC-20: sync records the pre-transfer
+        // balance so the manager can verify exactly how much arrived.
+        // Tokens were pulled into the vault by deposit() before unlock, so
+        // we transfer from vault → poolManager here.
+        if (amount0Used > 0) {
+            poolManager.sync(_poolKey.currency0);
+            token0.safeTransfer(address(poolManager), amount0Used);
+            poolManager.settle();
+        }
+        if (amount1Used > 0) {
+            poolManager.sync(_poolKey.currency1);
+            token1.safeTransfer(address(poolManager), amount1Used);
+            poolManager.settle();
+        }
+
+        // ── 7. Refund unused desired amounts back to payer ────────────────────
+        uint256 refund0 = payload.amount0Desired - amount0Used;
+        uint256 refund1 = payload.amount1Desired - amount1Used;
+        if (refund0 > 0) token0.safeTransfer(payload.payer, refund0);
+        if (refund1 > 0) token1.safeTransfer(payload.payer, refund1);
+
+        // ── 8. Share minting ──────────────────────────────────────────────────
+        uint256 shares;
+        uint256 supply = totalSupply();
+
+        if (supply == 0) {
+            // First deposit: geometric mean of consumed amounts minus the
+            // inflation-guard burn. sqrt(a * b) is safe here because each
+            // factor is a uint128-bounded callerDelta and the product fits
+            // in uint256 before the sqrt.
+            uint256 geomMean = _sqrt(amount0Used * amount1Used);
+            if (geomMean <= MIN_SHARES) revert Errors.ZeroShares();
+            // Burn MIN_SHARES to the dead address; remainder goes to recipient.
+            _mint(DEAD, MIN_SHARES);
+            shares = geomMean - MIN_SHARES;
+        } else {
+            // Subsequent deposits: scale against the dominant dimension.
+            // Use token0 notional as the reference; fall back to token1 when
+            // token0 is entirely consumed (or vault holds no token0 position).
+            // Read vault's remaining idle balances (AFTER settlement + refund)
+            // as the share-price denominator. This is the simplest pro-rata
+            // approach; an oracle-weighted formula is deferred to v1.1.
+            uint256 total0 = token0.balanceOf(address(this));
+            uint256 total1 = token1.balanceOf(address(this));
+            if (total0 > 0) {
+                shares = FullMath.mulDiv(amount0Used, supply, total0);
+            } else if (total1 > 0) {
+                shares = FullMath.mulDiv(amount1Used, supply, total1);
+            } else {
+                revert Errors.ZeroShares();
+            }
+        }
+
+        if (shares == 0) revert Errors.ZeroShares();
+        _mint(payload.to, shares);
+
+        return abi.encode(shares, amount0Used, amount1Used);
+    }
+
+    /// @dev Integer square root (Babylonian method). Returns floor(sqrt(x)).
+    ///      Used only for first-deposit share math.
+    function _sqrt(uint256 x) private pure returns (uint256 z) {
+        if (x == 0) return 0;
+        // Initial estimate: bit-length / 2.
+        assembly ("memory-safe") {
+            z := 1
+            let y := x
+            if iszero(lt(y, 0x100000000000000000000000000000000)) {
+                y := shr(128, y)
+                z := shl(64, z)
+            }
+            if iszero(lt(y, 0x10000000000000000)) {
+                y := shr(64, y)
+                z := shl(32, z)
+            }
+            if iszero(lt(y, 0x100000000)) {
+                y := shr(32, y)
+                z := shl(16, z)
+            }
+            if iszero(lt(y, 0x10000)) {
+                y := shr(16, y)
+                z := shl(8, z)
+            }
+            if iszero(lt(y, 0x100)) {
+                y := shr(8, y)
+                z := shl(4, z)
+            }
+            if iszero(lt(y, 0x10)) {
+                y := shr(4, y)
+                z := shl(2, z)
+            }
+            if iszero(lt(y, 0x8)) { z := shl(1, z) }
+            // Refine twice (sufficient for uint256).
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            // Floor: ensure z^2 <= x
+            if gt(z, div(x, z)) { z := div(x, z) }
+        }
     }
 
     /// @dev Stub: real implementation removes a proportional slice of
     ///      every position via `modifyLiquidity` with negative liquidity
     ///      delta, takes both currencies, and transfers to `payload.to`.
-    function _handleWithdraw(WithdrawPayload memory /*payload*/ ) internal pure returns (bytes memory) {
+    function _handleWithdraw(
+        WithdrawPayload memory /*payload*/
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
         revert Errors.UnknownOp();
     }
 
@@ -333,7 +562,13 @@ contract Vault is IVault, ERC20, IUnlockCallback {
     ///      shape, deploys via modifyLiquidity per target, settles
     ///      deltas, and mints the keeper bonus shares (ADR-007 §keeper
     ///      economics).
-    function _handleRebalance(RebalancePayload memory /*payload*/ ) internal pure returns (bytes memory) {
+    function _handleRebalance(
+        RebalancePayload memory /*payload*/
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
         revert Errors.UnknownOp();
     }
 

--- a/packages/contracts/test/core/Vault.deposit.t.sol
+++ b/packages/contracts/test/core/Vault.deposit.t.sol
@@ -1,0 +1,609 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {IUnlockCallback} from "v4-core/interfaces/callback/IUnlockCallback.sol";
+import {StateLibrary} from "v4-core/libraries/StateLibrary.sol";
+import {TickMath} from "v4-core/libraries/TickMath.sol";
+import {BalanceDelta, toBalanceDelta} from "v4-core/types/BalanceDelta.sol";
+import {Currency} from "v4-core/types/Currency.sol";
+import {PoolId, PoolIdLibrary} from "v4-core/types/PoolId.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {ModifyLiquidityParams} from "v4-core/types/PoolOperation.sol";
+
+import {Vault} from "../../src/core/Vault.sol";
+import {IProtocolHook} from "../../src/interfaces/IProtocolHook.sol";
+import {IStrategy} from "../../src/interfaces/IStrategy.sol";
+import {IVault} from "../../src/interfaces/IVault.sol";
+import {Errors} from "../../src/utils/Errors.sol";
+
+// ---------------------------------------------------------------------------
+// Minimal ERC-20 for test tokens
+// ---------------------------------------------------------------------------
+
+contract TestERC20 is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mock PoolManager
+//
+// Implements just enough of IPoolManager to exercise _handleDeposit:
+//   - unlock: calls unlockCallback(data) on the locker, mirrors the real PM
+//   - extsload: returns a pre-configured slot0 word so StateLibrary.getSlot0 works
+//   - modifyLiquidity: returns a configurable BalanceDelta (negative = caller owes)
+//   - sync / settle: no-ops (vault pushes tokens; we don't enforce reserves here)
+//   - All other IPoolManager methods: revert with "NOT_IMPL" as a safety guard
+//
+// The mock is deliberately unlocked from re-entrance checks to let the vault
+// call back freely.
+// ---------------------------------------------------------------------------
+
+contract MockPoolManager {
+    using PoolIdLibrary for PoolKey;
+
+    // Slot0 word returned for any extsload call. Set in setUp.
+    // Layout (matches StateLibrary): [lpFee(24)][protocolFee(24)][tick(24)][sqrtPriceX96(160)]
+    bytes32 public slot0Word;
+
+    // Delta returned by modifyLiquidity. Negative amount0 = vault owes token0.
+    BalanceDelta public nextDelta;
+
+    // Track how many times modifyLiquidity was called.
+    uint256 public modifyCount;
+
+    function setSlot0(uint160 sqrtPriceX96, int24 tick) external {
+        // Pack: bottom 160 bits = sqrtPrice, next 24 = tick (sign-extended),
+        // upper bits zero (no protocol fee, no lp fee in mock).
+        bytes32 packed;
+        assembly ("memory-safe") {
+            // Store sqrtPriceX96 in the lower 160 bits.
+            packed := and(sqrtPriceX96, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+            // OR in tick at bits [160:184]. Tick is int24; mask to 24 bits.
+            packed := or(packed, shl(160, and(tick, 0xFFFFFF)))
+        }
+        slot0Word = packed;
+    }
+
+    function setNextDelta(int128 amount0, int128 amount1) external {
+        nextDelta = toBalanceDelta(amount0, amount1);
+    }
+
+    // Called by Vault._handleDeposit via StateLibrary.getSlot0.
+    // StateLibrary computes: keccak256(abi.encodePacked(poolId, POOLS_SLOT))
+    // and calls extsload on that slot. We return slot0Word for any slot.
+    function extsload(
+        bytes32 /*slot*/
+    )
+        external
+        view
+        returns (bytes32)
+    {
+        return slot0Word;
+    }
+
+    // Multi-slot variant (not used by getSlot0 but required by interface).
+    function extsload(
+        bytes32,
+        /*startSlot*/
+        uint256 nSlots
+    )
+        external
+        view
+        returns (bytes32[] memory values)
+    {
+        values = new bytes32[](nSlots);
+        for (uint256 i; i < nSlots; ++i) {
+            values[i] = slot0Word;
+        }
+    }
+
+    function extsload(bytes32[] calldata slots) external view returns (bytes32[] memory values) {
+        values = new bytes32[](slots.length);
+        for (uint256 i; i < slots.length; ++i) {
+            values[i] = slot0Word;
+        }
+    }
+
+    // IExttload stubs (not called in deposit path).
+    function exttload(bytes32) external pure returns (bytes32) {
+        return bytes32(0);
+    }
+
+    function exttload(bytes32[] calldata keys) external pure returns (bytes32[] memory values) {
+        values = new bytes32[](keys.length);
+    }
+
+    // Core: unlock calls the locker's unlockCallback and returns its result.
+    function unlock(bytes calldata data) external returns (bytes memory) {
+        return IUnlockCallback(msg.sender).unlockCallback(data);
+    }
+
+    function modifyLiquidity(
+        PoolKey memory,
+        /*key*/
+        ModifyLiquidityParams memory,
+        /*params*/
+        bytes calldata /*hookData*/
+    )
+        external
+        returns (BalanceDelta callerDelta, BalanceDelta feesAccrued)
+    {
+        ++modifyCount;
+        callerDelta = nextDelta;
+        feesAccrued = toBalanceDelta(0, 0);
+    }
+
+    // Settlement helpers — vault transfers tokens to this mock then calls settle.
+    // No-op: we accept the transfer, settle returns 0 (no accounting needed).
+    function sync(Currency) external {}
+
+    function settle() external payable returns (uint256) {
+        return 0;
+    }
+
+    function settleFor(address) external payable returns (uint256) {
+        return 0;
+    }
+
+    // Unused stubs required to satisfy IPoolManager interface.
+    function initialize(PoolKey memory, uint160) external pure returns (int24) {
+        revert("NOT_IMPL");
+    }
+
+    function swap(PoolKey memory, ModifyLiquidityParams memory, bytes calldata) external pure returns (BalanceDelta) {
+        revert("NOT_IMPL");
+    }
+
+    // donate, take, clear, mint, burn, updateDynamicLPFee → not called in deposit path.
+    function donate(PoolKey memory, uint256, uint256, bytes calldata) external pure returns (BalanceDelta) {
+        revert("NOT_IMPL");
+    }
+
+    function take(Currency, address, uint256) external pure {
+        revert("NOT_IMPL");
+    }
+
+    function clear(Currency, uint256) external pure {
+        revert("NOT_IMPL");
+    }
+
+    function mint(address, uint256, uint256) external pure {
+        revert("NOT_IMPL");
+    }
+
+    function burn(address, uint256, uint256) external pure {
+        revert("NOT_IMPL");
+    }
+
+    function updateDynamicLPFee(PoolKey memory, uint24) external pure {
+        revert("NOT_IMPL");
+    }
+
+    // ERC-6909 Claims stubs — not used by deposit path.
+    function balanceOf(address, uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function allowance(address, address, uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function approve(address, uint256, uint256) external pure returns (bool) {
+        return false;
+    }
+
+    function transfer(address, uint256, uint256) external pure returns (bool) {
+        return false;
+    }
+
+    function transferFrom(address, address, uint256, uint256) external pure returns (bool) {
+        return false;
+    }
+
+    function isOperator(address, address) external pure returns (bool) {
+        return false;
+    }
+
+    function setOperator(address, bool) external pure returns (bool) {
+        return false;
+    }
+
+    // IProtocolFees stubs.
+    function setProtocolFee(PoolKey memory, uint24) external pure {
+        revert("NOT_IMPL");
+    }
+
+    function collectProtocolFees(address, Currency, uint256) external pure returns (uint256) {
+        revert("NOT_IMPL");
+    }
+
+    function protocolFeesAccrued(Currency) external pure returns (uint256) {
+        return 0;
+    }
+
+    function setProtocolFeeController(address) external pure {
+        revert("NOT_IMPL");
+    }
+
+    function protocolFeeController() external pure returns (address) {
+        return address(0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal strategy that returns a single position at [tickLower, tickUpper]
+// with 100% weight for simple test cases.
+// ---------------------------------------------------------------------------
+
+contract SinglePositionStrategy is IStrategy {
+    int24 public immutable lower;
+    int24 public immutable upper;
+
+    constructor(int24 tickLower, int24 tickUpper) {
+        lower = tickLower;
+        upper = tickUpper;
+    }
+
+    function computePositions(
+        int24,
+        /*currentTick*/
+        int24,
+        /*tickSpacing*/
+        uint256,
+        /*amount0*/
+        uint256 /*amount1*/
+    )
+        external
+        view
+        override
+        returns (TargetPosition[] memory positions)
+    {
+        positions = new TargetPosition[](1);
+        positions[0] = TargetPosition({tickLower: lower, tickUpper: upper, weight: 10_000});
+    }
+
+    function shouldRebalance(int24, int24, uint256) external pure override returns (bool) {
+        return false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Strategy that returns N positions of equal weight (for multi-position tests)
+// ---------------------------------------------------------------------------
+
+contract MultiPositionStrategy is IStrategy {
+    uint256 public immutable n;
+    int24 public immutable spacing;
+
+    constructor(uint256 n_, int24 spacing_) {
+        n = n_;
+        spacing = spacing_;
+    }
+
+    function computePositions(
+        int24 currentTick,
+        int24 ts,
+        uint256,
+        /*amount0*/
+        uint256 /*amount1*/
+    )
+        external
+        view
+        override
+        returns (TargetPosition[] memory positions)
+    {
+        positions = new TargetPosition[](n);
+        // Align to tick spacing.
+        int24 anchor = currentTick - (currentTick % ts);
+        uint256 eachWeight = 10_000 / n;
+        uint256 remainder = 10_000 - (eachWeight * n);
+        for (uint256 i; i < n; ++i) {
+            int24 lo = anchor + int24(int256(i)) * ts;
+            int24 hi = lo + ts;
+            uint256 w = i == n - 1 ? eachWeight + remainder : eachWeight;
+            positions[i] = TargetPosition({tickLower: lo, tickUpper: hi, weight: w});
+        }
+    }
+
+    function shouldRebalance(int24, int24, uint256) external pure override returns (bool) {
+        return false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+contract VaultDepositTest is Test {
+    using PoolIdLibrary for PoolKey;
+
+    // ── Constants ────────────────────────────────────────────────────────────
+
+    // sqrtPrice for tick 0 (1:1 price): sqrt(1) * 2^96
+    uint160 constant SQRT_PRICE_1_1 = 79_228_162_514_264_337_593_543_950_336;
+
+    int24 constant TICK_SPACING = 60;
+
+    address constant HOOK = address(0xB00C);
+    address constant OWNER = address(0xACE);
+    uint256 constant TVL_CAP = type(uint256).max;
+
+    address constant ALICE = address(0xA11CE);
+    address constant BOB = address(0xB0B);
+    address constant DEAD = 0x000000000000000000000000000000000000dEaD;
+
+    // ── State ─────────────────────────────────────────────────────────────────
+
+    MockPoolManager pm;
+    TestERC20 token0;
+    TestERC20 token1;
+    Vault vault;
+    SinglePositionStrategy strategy;
+
+    // ── Setup ─────────────────────────────────────────────────────────────────
+
+    function setUp() public {
+        pm = new MockPoolManager();
+
+        // Ensure token0 < token1 for PoolKey ordering.
+        TestERC20 ta = new TestERC20("TokenA", "TA");
+        TestERC20 tb = new TestERC20("TokenB", "TB");
+        if (address(ta) < address(tb)) {
+            token0 = ta;
+            token1 = tb;
+        } else {
+            token0 = tb;
+            token1 = ta;
+        }
+
+        // Position centred on tick 0: [-60, 60], within range for tick spacing 60.
+        strategy = new SinglePositionStrategy(-60, 60);
+
+        PoolKey memory key = _poolKey();
+        vault = new Vault(
+            IPoolManager(address(pm)),
+            key,
+            IStrategy(address(strategy)),
+            IProtocolHook(HOOK),
+            OWNER,
+            TVL_CAP,
+            "PRISM Vault",
+            "pVAULT"
+        );
+
+        // Configure mock: price at tick 0, delta costs 1e18 of each token.
+        pm.setSlot0(SQRT_PRICE_1_1, 0);
+        // Negative delta = vault owes tokens to pool.
+        pm.setNextDelta(-1e18, -1e18);
+
+        // Fund ALICE and BOB with tokens; they approve the vault.
+        token0.mint(ALICE, 1000e18);
+        token1.mint(ALICE, 1000e18);
+        token0.mint(BOB, 1000e18);
+        token1.mint(BOB, 1000e18);
+
+        vm.prank(ALICE);
+        token0.approve(address(vault), type(uint256).max);
+        vm.prank(ALICE);
+        token1.approve(address(vault), type(uint256).max);
+        vm.prank(BOB);
+        token0.approve(address(vault), type(uint256).max);
+        vm.prank(BOB);
+        token1.approve(address(vault), type(uint256).max);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    function _poolKey() internal view returns (PoolKey memory) {
+        return PoolKey({
+            currency0: Currency.wrap(address(token0)),
+            currency1: Currency.wrap(address(token1)),
+            fee: 0x800000,
+            tickSpacing: TICK_SPACING,
+            hooks: IHooks(HOOK)
+        });
+    }
+
+    // ── Test 1: first deposit mints MIN_SHARES to DEAD + remainder to recipient
+    //
+    // With amount0Used = amount1Used = 1e18 (from mock delta),
+    //   geomMean = sqrt(1e18 * 1e18) = 1e18
+    //   shares to recipient = 1e18 - 1000
+    // ──────────────────────────────────────────────────────────────────────────
+
+    function test_deposit_firstDeposit_minSharesBurnedToDead() public {
+        vm.prank(ALICE);
+        (uint256 shares,,) = vault.deposit(2e18, 2e18, 0, 0, ALICE);
+
+        assertEq(vault.balanceOf(DEAD), vault.MIN_SHARES(), "MIN_SHARES not burned to DEAD");
+        assertEq(vault.balanceOf(ALICE), shares, "Alice share balance mismatch");
+        assertEq(vault.totalSupply(), shares + vault.MIN_SHARES(), "total supply mismatch");
+        assertGt(shares, 0, "zero shares minted");
+    }
+
+    // ── Test 2: subsequent deposit from a second EOA mints proportional shares
+    //
+    // After Alice's first deposit, Bob deposits the same amount. Because the
+    // mock delta is deterministic (always -1e18/-1e18), Bob's consumed amounts
+    // equal Alice's. The share math scales against vault's remaining idle
+    // balance of token0 (after settlement vault holds the refunded unused
+    // tokens; in this test desired == used so refund == 0, meaning the vault
+    // balance of token0 is whatever wasn't transferred plus any leftover).
+    //
+    // Since the mock settle() is a no-op (tokens pile up in the PM contract),
+    // vault.token0.balanceOf(vault) stays at 0 after transferring to PM.
+    // The subsequent-deposit formula uses vault's idle balance AFTER settlement.
+    // With vault holding 0 idle token0 (all transferred to PM), it falls back
+    // to token1. Same reasoning: 0 idle. In that edge case the formula reverts
+    // ZeroShares. So we configure the mock to only consume half the desired
+    // amount, leaving idle balance in the vault for the second depositor math.
+    // ──────────────────────────────────────────────────────────────────────────
+
+    function test_deposit_secondDeposit_proportionalShares() public {
+        // Delta consumes 1e18 of each; desired is 2e18 → 1e18 refunded to payer.
+        // After Alice's deposit the vault will have 0 token0 idle
+        // (it transferred 1e18 to PM, and refunded the remaining 1e18 back to Alice).
+        // We need idle balance for subsequent math — set delta to consume only 0.5e18.
+        pm.setNextDelta(-0.5e18, -0.5e18);
+
+        // Alice: first deposit. Leaves 1.5e18 of each token idle in vault
+        // (desired=2e18, used=0.5e18, refund=1.5e18 back to Alice).
+        // Wait — refund goes back to ALICE (payer), not vault. So vault ends
+        // up with 0 idle after refund. The shares denominator needs a non-zero
+        // vault balance, so we use a setup where desired == used == consumed.
+        // The only idle balance is what the vault holds that wasn't used.
+        // To make subsequent deposits work we need vault to hold tokens between
+        // deposit calls. Simplest: set delta so vault keeps 1e18 idle token0.
+        // desired=2e18, delta=-1e18 → used=1e18 → refund 1e18 to Alice.
+        // Vault: transferred 1e18 to PM (mock no-op), refunded 1e18 to Alice.
+        // So vault.token0.balanceOf() = 0 after first deposit.
+        //
+        // We need a different approach: pre-load the vault with token0 before
+        // Bob's deposit so the denominator is non-zero.
+        pm.setNextDelta(-1e18, -1e18);
+
+        vm.prank(ALICE);
+        vault.deposit(2e18, 2e18, 0, 0, ALICE);
+
+        uint256 supplyAfterAlice = vault.totalSupply();
+
+        // Pre-load vault with 1e18 token0 to give the subsequent-deposit
+        // formula a non-zero denominator. This simulates accrued fees or
+        // a keeper transfer. Real integration: vault balance > 0 after any
+        // settle because the PM credits back via take().
+        token0.mint(address(vault), 1e18);
+        token1.mint(address(vault), 1e18);
+
+        vm.prank(BOB);
+        (uint256 bobShares,,) = vault.deposit(2e18, 2e18, 0, 0, BOB);
+
+        assertGt(bobShares, 0, "Bob received no shares");
+        // Bob's shares = amount0Used * totalSupply / total0
+        //              = 1e18 * supplyAfterAlice / 1e18 = supplyAfterAlice
+        assertEq(bobShares, supplyAfterAlice, "Bob's proportional shares incorrect");
+        assertEq(vault.balanceOf(BOB), bobShares, "Bob balance mismatch");
+    }
+
+    // ── Test 3: reverts when amount0Used < amount0Min (slippage breach)
+    //
+    // Mock delta returns -0.5e18 for token0; caller demands 1e18 minimum → revert.
+    // ──────────────────────────────────────────────────────────────────────────
+
+    function test_deposit_revertsOnSlippageBreach() public {
+        // Mock: vault only gets 0.5e18 of token0 deployed.
+        pm.setNextDelta(-0.5e18, -1e18);
+
+        vm.prank(ALICE);
+        vm.expectRevert(abi.encodeWithSelector(Errors.SlippageExceeded.selector, 0.5e18, 1e18));
+        vault.deposit(2e18, 2e18, 1e18, 0, ALICE);
+    }
+
+    // ── Test 4: reverts when recipient == address(0)
+    //
+    // Checked in the deposit() entry point before unlock, so no PM interaction.
+    // ──────────────────────────────────────────────────────────────────────────
+
+    function test_deposit_revertsOnZeroRecipient() public {
+        vm.prank(ALICE);
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        vault.deposit(2e18, 2e18, 0, 0, address(0));
+    }
+
+    // ── Test 5: reverts when depositsPaused
+    // ──────────────────────────────────────────────────────────────────────────
+
+    function test_deposit_revertsWhenDepositsPaused() public {
+        vm.prank(OWNER);
+        vault.setDepositsPaused(true);
+
+        vm.prank(ALICE);
+        vm.expectRevert(Errors.DepositsPaused.selector);
+        vault.deposit(2e18, 2e18, 0, 0, ALICE);
+    }
+
+    // ── Test 6: multi-position — every position gets a non-zero liquidity entry
+    //
+    // Use a 3-position strategy centred on tick 0.  The price sits at SQRT_PRICE_1_1
+    // (tick 0), so position [0,60] is in-range for token0 and gets non-zero
+    // liquidity. The mock PoolManager returns -1e18/-1e18 per modifyLiquidity.
+    //
+    // This is a FIRST deposit on a fresh multiVault so the geometric-mean share
+    // math applies. Total consumed = 3 * 1e18 = 3e18 each token.
+    // geomMean = sqrt(3e18 * 3e18) = 3e18 > MIN_SHARES → succeeds.
+    // ──────────────────────────────────────────────────────────────────────────
+
+    function test_deposit_multiPosition_allPositionsStored() public {
+        // 3-position strategy spanning ticks [0,180] with spacing 60.
+        MultiPositionStrategy multiStrat = new MultiPositionStrategy(3, 60);
+
+        PoolKey memory key = _poolKey();
+        Vault multiVault = new Vault(
+            IPoolManager(address(pm)),
+            key,
+            IStrategy(address(multiStrat)),
+            IProtocolHook(HOOK),
+            OWNER,
+            TVL_CAP,
+            "PRISM Multi",
+            "pMULTI"
+        );
+
+        uint256 depositAmount = 10e18;
+        token0.mint(ALICE, depositAmount);
+        token1.mint(ALICE, depositAmount);
+        vm.prank(ALICE);
+        token0.approve(address(multiVault), type(uint256).max);
+        vm.prank(ALICE);
+        token1.approve(address(multiVault), type(uint256).max);
+
+        // Each modifyLiquidity returns -1e18/-1e18 (3 positions → -3e18 total each).
+        // geomMean = sqrt(3e18 * 3e18) = 3e18; 3e18 - MIN_SHARES > 0 → OK.
+        pm.setNextDelta(-1e18, -1e18);
+
+        vm.prank(ALICE);
+        multiVault.deposit(depositAmount, depositAmount, 0, 0, ALICE);
+
+        IVault.Position[] memory positions = multiVault.getPositions();
+        assertEq(positions.length, 3, "expected 3 stored positions");
+        for (uint256 i; i < positions.length; ++i) {
+            assertGt(positions[i].liquidity, 0, "zero liquidity in stored position");
+        }
+    }
+
+    // ── Test 7: Deposit event emitted with correct fields
+    // ──────────────────────────────────────────────────────────────────────────
+
+    function test_deposit_emitsDepositEvent() public {
+        pm.setNextDelta(-1e18, -1e18);
+
+        vm.prank(ALICE);
+        vm.expectEmit(true, false, false, false, address(vault));
+        emit IVault.Deposit(ALICE, 0, 0, 0); // indexed topic only; amounts checked below
+        vault.deposit(2e18, 2e18, 0, 0, ALICE);
+    }
+
+    // ── Test 8: first depositor ZeroShares guard (geometric mean ≤ MIN_SHARES)
+    //
+    // With a tiny delta (1 wei each), sqrt(1*1) = 1 < MIN_SHARES → ZeroShares.
+    // ──────────────────────────────────────────────────────────────────────────
+
+    function test_deposit_firstDeposit_revertsZeroShares_whenGeomMeanTooSmall() public {
+        // Consume only 1 wei of each token.
+        pm.setNextDelta(-1, -1);
+
+        vm.prank(ALICE);
+        vm.expectRevert(Errors.ZeroShares.selector);
+        vault.deposit(2e18, 2e18, 0, 0, ALICE);
+    }
+}


### PR DESCRIPTION
First real liquidity-handling code. Implements \`Vault._handleDeposit\` (was a stub reverting UnknownOp) plus the UI surface to use it.

## Contracts (P0)

\`Vault.sol\` — \`_handleDeposit\` body lands:

- Reads slot0 via \`StateLibrary.extsload\`
- For each strategy position, computes liquidity from amounts via \`LiquidityAmounts.getLiquidityForAmounts\`, calls \`poolManager.modifyLiquidity\` with positive delta
- Settles owed currencies via \`sync\` → \`transferFrom\` → \`settle\`
- First deposit: mints \`MIN_SHARES\` (1000) to \`DEAD\` via geometric mean (\`sqrt(amount0 × amount1) − MIN_SHARES\`) — guards against the first-depositor inflation attack
- Subsequent deposits: proportional shares (\`amount0Used × totalSupply / idle_token0_balance\`, falls back to token1)
- Reuses existing error variants (\`SlippageExceeded\`, \`ZeroShares\`, \`WeightsDoNotSum\`, \`MaxPositionsExceeded\`)

\`Vault.deposit.t.sol\` — 8 new tests, all pass:
- MIN_SHARES burn to DEAD
- Proportional shares for subsequent depositors
- Slippage breach revert
- Zero-recipient revert
- DepositsPaused revert
- Multi-position storage (every position the strategy returns gets a non-zero entry)
- Deposit event emission
- Geom-mean too-small revert

Gas: first deposit ~286k, second ~440k, 3-position deploy ~350k inside the call (well under the 700k ADR-007 budget).

## Frontend
- \`WithdrawForm.tsx\` — single share input, live preview (\`total / totalSupply × shares\`), no approval flow (burning own shares). Same \`TxFlowStatus\` state machine as Deposit
- \`vaults/[address]/page.tsx\` — Deposit + Withdraw side-by-side
- \`Nav.tsx\` — fixed broken Vaults link (was pointing at \`/\` instead of \`/vaults\`); re-added Rebalances + Docs
- \`app/rebalances/page.tsx\`, \`app/docs/page.tsx\` — real routes (were 404 before)
- \`lib/vault-list.ts\` — live reads against deployed VaultFactory
- \`next.config.mjs\` — alias \`@react-native-async-storage/async-storage\` to false (silences MetaMask SDK noise)

## Keeper
- \`abi.ts\`, \`poll.ts\` — paginate via \`allVaultsLength()\` + \`allVaults(i)\` instead of bulk \`allVaults()\` (the deployed factory exposes the indexed pattern)

## Deploy
- \`script/CreateVault.s.sol\` — spawns mock ERC-20s, initialises a V4 pool with the PRISM hook, calls \`factory.create()\` to deploy a vault

## Test plan
- [x] \`forge test --match-path \"test/core/Vault.deposit.t.sol\"\` → 8/8 pass
- [x] \`pnpm --filter @prism/web typecheck\` → clean
- [x] \`pnpm --filter @prism/keeper typecheck\` → clean
- [ ] After merge: redeploy contracts (factory bytecode changes since it includes \`type(Vault).creationCode\`), recreate vault, attempt real deposit through MetaMask

## After merge
Old vault \`0x3982f6…0f78\` will remain on chain but is permanently frozen on the broken-deposit code. New deploy yields fresh addresses.