### PR TITLE
deploy(web): vercel.json for pnpm monorepo build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ Thumbs.db
 # Coverage
 coverage/
 lcov.info
+.vercel

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -6,3 +6,4 @@ out
 .env.*.local
 *.tsbuildinfo
 next-env.d.ts
+.vercel

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "cd ../.. && pnpm --filter @prism/web build",
+  "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
## Summary

- Adds \`apps/web/vercel.json\` so Vercel can build the Next.js app from the pnpm workspace root.
- buildCommand / installCommand \`cd ../..\` to the repo root so pnpm sees the \`@prism/shared\` workspace dep.
- outputDirectory is \`.next\` relative to \`apps/web\` (the Root Directory in Vercel project settings).
- Requires \"Include source files outside of the Root Directory\" enabled in the Vercel dashboard so \`packages/shared\` is uploaded into the build context.
- Adds \`.vercel\` to root and \`apps/web\` gitignores (created by \`vercel link\`).

## Test plan

- [x] Production deploy succeeded: https://prism-web-coral.vercel.app
- [x] \`/\`, \`/vaults\`, \`/vaults/0x5Ab391...E1FB\` all return 200
- [ ] Wallet connect via injected (MetaMask) — needs manual browser test
- [ ] WalletConnect modal — gated on \`NEXT_PUBLIC_WC_PROJECT_ID\` being set in Vercel env