### PR TITLE
feat(keeper): one-shot mode + GitHub Actions cron ($0 hosting)

### DIFF
--- a/.github/workflows/keeper-cron.yml
+++ b/.github/workflows/keeper-cron.yml
@@ -1,0 +1,78 @@
+name: keeper-cron
+
+# Production keeper for PRISM, hosted on GitHub Actions in lieu of a
+# 24/7 server. Runs the keeper in --once mode every minute (the GitHub
+# Actions cron minimum). One-minute polling is plenty for PRISM's drift
+# threshold; the queue may delay a run by a few minutes during peak
+# Actions load — that's an acceptable trade against $0 hosting.
+#
+# Required repo secrets:
+#   - BASE_SEPOLIA_RPC_URL
+#   - KEEPER_PRIVATE_KEY     (a fresh wallet, NOT the deployer)
+#   - VAULT_FACTORY_ADDRESS
+#   - POOL_MANAGER_ADDRESS
+# Optional:
+#   - SENTRY_DSN
+#
+# `workflow_dispatch` lets you trigger an out-of-cycle run from the
+# Actions UI when debugging.
+
+on:
+  schedule:
+    - cron: "* * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize cron runs of this workflow on main so a slow cycle (e.g.
+  # tx submission waiting on a block) cannot overlap with the next one
+  # and double-submit. `cancel-in-progress: false` means the in-flight
+  # run finishes; the next scheduled run is just queued behind it.
+  group: keeper-cron-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "20"
+  PNPM_VERSION: "10.18.0"
+
+jobs:
+  cycle:
+    name: keeper one-shot cycle
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run keeper cycle
+        env:
+          BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL }}
+          KEEPER_PRIVATE_KEY: ${{ secrets.KEEPER_PRIVATE_KEY }}
+          VAULT_FACTORY_ADDRESS: ${{ secrets.VAULT_FACTORY_ADDRESS }}
+          POOL_MANAGER_ADDRESS: ${{ secrets.POOL_MANAGER_ADDRESS }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          POLL_INTERVAL_MS: "30000"
+          MAX_GAS_PRICE_GWEI: "10"
+          HEALTH_PORT: "8080"
+          LOG_LEVEL: "info"
+          NODE_ENV: "production"
+          RUN_ONCE: "1"
+        run: pnpm --filter @prism/keeper start

--- a/apps/keeper/src/index.ts
+++ b/apps/keeper/src/index.ts
@@ -6,11 +6,16 @@ import pino from "pino";
 import {loadConfig} from "./config.js";
 import {startHealthServer, stopHealthServer} from "./health.js";
 import {Metrics} from "./metrics.js";
-import {runPollLoop} from "./poll.js";
+import {runCycle, runPollLoop} from "./poll.js";
 import {captureException, flushSentry, initSentry} from "./sentry.js";
 import {gweiToWei} from "./submit.js";
 
 const METRIC_SNAPSHOT_INTERVAL_MS = 60_000;
+
+/// One-shot mode runs a single poll cycle and exits — the shape we want
+/// for cron triggers (GitHub Actions, k8s CronJob). Selected via `--once`
+/// or `RUN_ONCE=1`; otherwise the keeper runs the long-poll forever loop.
+const ONCE_MODE = process.argv.includes("--once") || process.env.RUN_ONCE === "1";
 
 async function main() {
   const config = loadConfig();
@@ -59,6 +64,28 @@ async function main() {
   } as unknown as Parameters<typeof runPollLoop>[0]["client"];
 
   const metrics = new Metrics();
+
+  // One-shot mode: skip the health server and the metric-snapshot timer
+  // (cron runs are short-lived and don't need a /health endpoint), run a
+  // single cycle, flush Sentry, and exit. Failed cycles map to a non-zero
+  // exit so the cron platform surfaces the failure.
+  if (ONCE_MODE) {
+    const ok = await runCycle({
+      client: client as unknown as Parameters<typeof runCycle>[0]["client"],
+      factory: config.VAULT_FACTORY_ADDRESS as Address,
+      poolManager: config.POOL_MANAGER_ADDRESS as Address,
+      account: account.address,
+      maxFeePerGasCap: gweiToWei(config.MAX_GAS_PRICE_GWEI),
+      txAttemptTimeoutMs: 60_000,
+      maxSubmitAttempts: 3,
+      logger,
+      metrics,
+    });
+    logger.info({metrics: metrics.snapshot()}, "one-shot cycle complete");
+    await flushSentry();
+    process.exit(ok ? 0 : 1);
+  }
+
   const healthServer = startHealthServer({port: config.HEALTH_PORT, logger, metrics});
 
   const stop = runPollLoop({

--- a/apps/keeper/src/poll.ts
+++ b/apps/keeper/src/poll.ts
@@ -190,60 +190,67 @@ function errMsg(err: unknown): string {
   return String(err);
 }
 
+/// Run a single poll cycle: evaluate every vault, submit any due
+/// rebalances, record metrics. Always resolves — internal errors are
+/// logged + counted as a failed cycle but do not throw. The boolean
+/// return is used by the cron one-shot wrapper to decide its exit code:
+/// `true` on success, `false` if the cycle itself raised.
+export async function runCycle(deps: PollDeps): Promise<boolean> {
+  const {logger, metrics} = deps;
+  const cycleId = Date.now().toString(36);
+  const cycleLogger = logger.child({cycle: cycleId});
+  const start = Date.now();
+  try {
+    const evaluations = await evaluateVaults({...deps, logger: cycleLogger});
+    const dueCount = evaluations.filter((e) => e.shouldRebalance).length;
+    const submittableCount = evaluations.filter((e) => e.simulation?.ok === true).length;
+    const confirmedCount = evaluations.filter((e) => e.submission?.status === "confirmed").length;
+    const failedCount = evaluations.filter((e) => e.submission?.status === "failed").length;
+
+    if (metrics) {
+      for (const e of evaluations) {
+        if (e.simulation?.ok) metrics.rebalanceSimulated();
+        if (e.submission?.status === "confirmed") {
+          metrics.rebalanceSubmitted();
+          metrics.rebalanceConfirmed();
+        } else if (e.submission?.status === "failed") {
+          metrics.rebalanceSubmitted();
+          metrics.rebalanceFailed();
+        }
+      }
+      metrics.cycleCompleted(Date.now() - start);
+    }
+
+    cycleLogger.info(
+      {
+        vaultCount: evaluations.length,
+        dueCount,
+        submittableCount,
+        confirmedCount,
+        failedCount,
+        ms: Date.now() - start,
+      },
+      "poll cycle complete",
+    );
+    return true;
+  } catch (err) {
+    const ms = Date.now() - start;
+    if (metrics) metrics.cycleFailed(ms);
+    cycleLogger.error({err: errMsg(err), ms}, "poll cycle failed");
+    return false;
+  }
+}
+
 /// Run the poll loop forever with the configured cadence. Returns a
 /// stop function that resolves after the in-flight cycle completes.
 export function runPollLoop(deps: PollDeps & {intervalMs: number}): () => Promise<void> {
-  const {logger, intervalMs, metrics} = deps;
+  const {intervalMs} = deps;
   let stopped = false;
   let inflight: Promise<void> = Promise.resolve();
 
-  const tick = async (): Promise<void> => {
-    if (stopped) return;
-    const cycleId = Date.now().toString(36);
-    const cycleLogger = logger.child({cycle: cycleId});
-    const start = Date.now();
-    try {
-      const evaluations = await evaluateVaults({...deps, logger: cycleLogger});
-      const dueCount = evaluations.filter((e) => e.shouldRebalance).length;
-      const submittableCount = evaluations.filter((e) => e.simulation?.ok === true).length;
-      const confirmedCount = evaluations.filter((e) => e.submission?.status === "confirmed").length;
-      const failedCount = evaluations.filter((e) => e.submission?.status === "failed").length;
-
-      if (metrics) {
-        for (const e of evaluations) {
-          if (e.simulation?.ok) metrics.rebalanceSimulated();
-          if (e.submission?.status === "confirmed") {
-            metrics.rebalanceSubmitted();
-            metrics.rebalanceConfirmed();
-          } else if (e.submission?.status === "failed") {
-            metrics.rebalanceSubmitted();
-            metrics.rebalanceFailed();
-          }
-        }
-        metrics.cycleCompleted(Date.now() - start);
-      }
-
-      cycleLogger.info(
-        {
-          vaultCount: evaluations.length,
-          dueCount,
-          submittableCount,
-          confirmedCount,
-          failedCount,
-          ms: Date.now() - start,
-        },
-        "poll cycle complete",
-      );
-    } catch (err) {
-      const ms = Date.now() - start;
-      if (metrics) metrics.cycleFailed(ms);
-      cycleLogger.error({err: errMsg(err), ms}, "poll cycle failed");
-    }
-  };
-
   const schedule = (): void => {
     if (stopped) return;
-    inflight = tick().finally(() => {
+    inflight = runCycle(deps).then(() => {
       if (!stopped) setTimeout(schedule, intervalMs);
     });
   };


### PR DESCRIPTION
## Summary

- `apps/keeper` now supports a single-cycle `--once` / `RUN_ONCE=1` mode that runs one poll cycle and exits — the shape we want for cron triggers.
- Forever-loop `runPollLoop` is unchanged; it now delegates to `runCycle` internally.
- `.github/workflows/keeper-cron.yml` runs the one-shot keeper every minute on GitHub Actions. Public repos get unlimited free minutes; this is the \$0 alternative to paid Fly.io hosting.
- Concurrency group serializes runs so a slow cycle cannot overlap the next.
- Fly.io path (`apps/keeper/Dockerfile` + `fly.toml`) is preserved for when paid hosting is available.

## Required repo secrets (set before merging)

- `BASE_SEPOLIA_RPC_URL`
- `KEEPER_PRIVATE_KEY` (a fresh wallet, NOT the deployer)
- `VAULT_FACTORY_ADDRESS`
- `POOL_MANAGER_ADDRESS`

## Test plan

- [x] `pnpm --filter @prism/keeper typecheck` clean
- [ ] First scheduled run on main confirms a successful cycle
- [ ] Manual `workflow_dispatch` smoke test before depending on cron