### PR TITLE
fix(keeper): accept private key with or without 0x prefix

### DIFF
--- a/apps/keeper/src/config.ts
+++ b/apps/keeper/src/config.ts
@@ -4,7 +4,8 @@ const envSchema = z.object({
   BASE_SEPOLIA_RPC_URL: z.string().url(),
   KEEPER_PRIVATE_KEY: z
     .string()
-    .regex(/^0x[a-fA-F0-9]{64}$/, "KEEPER_PRIVATE_KEY must be 0x-prefixed 32-byte hex"),
+    .regex(/^(0x)?[a-fA-F0-9]{64}$/, "KEEPER_PRIVATE_KEY must be 32-byte hex (0x prefix optional)")
+    .transform((v) => (v.startsWith("0x") ? v : `0x${v}`)),
   VAULT_FACTORY_ADDRESS: z
     .string()
     .regex(/^0x[a-fA-F0-9]{40}$/, "VAULT_FACTORY_ADDRESS must be a 0x-prefixed address"),


### PR DESCRIPTION
## Summary

The first keeper-cron run on main failed because MetaMask exports private keys *without* the \`0x\` prefix, but \`config.ts\`'s zod schema required it:

\`\`\`
Error: Invalid keeper environment:
  - KEEPER_PRIVATE_KEY: KEEPER_PRIVATE_KEY must be 0x-prefixed 32-byte hex
\`\`\`

Update the schema to accept both forms and transform to the prefixed form before downstream consumers (\`privateKeyToAccount\`) see it. The 32-byte length + hex character set check is preserved.

## Test plan

- [x] \`pnpm --filter @prism/keeper typecheck\` clean
- [ ] keeper-cron run on main succeeds after merge