### PR TITLE
deploy(base-sepolia): redeploy with withdraw + rebalance bodies

### DIFF
--- a/addresses.json
+++ b/addresses.json
@@ -1,9 +1,9 @@
 {
   "84532": {
-    "bellStrategy": "0xfa60db53c04ca4add6c0cd0df1e8b6ba97d769ce",
-    "chainlinkAdapter": "0x80466dd3dbe7a2e6910ea6522465adcb75fe2c35",
-    "protocolHook": "0xe450c5128a5e7d42250a870a7df044902cee85c0",
-    "vaultFactory": "0x589dfb3dade3c379d38654063d5d8e85e15e39e5",
+    "bellStrategy": "0x8621557ebc7cc5bbbb7254eca39fcc21fc9bd68c",
+    "chainlinkAdapter": "0x8ae80adfc0713c47e331418d1874ced8383a3ec1",
+    "protocolHook": "0x5f293d39afb11066b7018199865d973c240485c0",
+    "vaultFactory": "0xc7971d8e0856f7e287968257352a5588bbf6c64c",
     "poolManager": "0x05E73354cFDd6745C338b50BcFDfA3Aa6fA03408"
   }
 }

--- a/packages/shared/src/addresses.ts
+++ b/packages/shared/src/addresses.ts
@@ -27,10 +27,10 @@ const PLACEHOLDER: DeploymentAddresses = {
 
 // <<deployed-baseSepolia>>
 const BASESEPOLIA: DeploymentAddresses = {
-  vaultFactory: "0x589dfb3dade3c379d38654063d5d8e85e15e39e5",
-  protocolHook: "0xe450c5128a5e7d42250a870a7df044902cee85c0",
-  bellStrategy: "0xfa60db53c04ca4add6c0cd0df1e8b6ba97d769ce",
-  chainlinkAdapter: "0x80466dd3dbe7a2e6910ea6522465adcb75fe2c35",
+  vaultFactory: "0xc7971d8e0856f7e287968257352a5588bbf6c64c",
+  protocolHook: "0x5f293d39afb11066b7018199865d973c240485c0",
+  bellStrategy: "0x8621557ebc7cc5bbbb7254eca39fcc21fc9bd68c",
+  chainlinkAdapter: "0x8ae80adfc0713c47e331418d1874ced8383a3ec1",
   poolManager: "0x05E73354cFDd6745C338b50BcFDfA3Aa6fA03408",
 };
 // <</deployed-baseSepolia>>


### PR DESCRIPTION
## Summary

PR #222 added \`_handleWithdraw\` and \`_handleRebalance\` bodies, but the on-chain stack still ran the prior bytecode where both reverted \`UnknownOp()\`. Customers who deposited could not withdraw, and the keeper sim-reverted every cycle.

Redeploys the full stack with the new bytecode and updates the dApp + keeper addresses to point at it. All five contracts verified on Basescan.

## New addresses

- BellStrategy:      \`0x8621557ebc7cc5bbbb7254eca39fcc21fc9bd68c\`
- ChainlinkAdapter:  \`0x8ae80adfc0713c47e331418d1874ced8383a3ec1\`
- ProtocolHook:      \`0x5f293d39afb11066b7018199865d973c240485c0\` (bits 0x05c0 ✓)
- VaultFactory:      \`0xc7971d8e0856f7e287968257352a5588bbf6c64c\`
- WETH/USDC Vault:   \`0x1c990b974dFcd07baD4aF9Df8cd0B3ED01070FD4\`

\`VAULT_FACTORY_ADDRESS\` repo secret already updated to the new factory; the next keeper-cron run will see the new vault.

## Test plan

- [x] All 5 contracts verified on Basescan
- [x] \`pnpm --filter @prism/web typecheck\` clean
- [x] \`pnpm --filter @prism/keeper typecheck\` clean
- [ ] Vercel preview deploys, /vaults page lists the new vault
- [ ] Manual deposit + **withdraw** + observe a keeper-driven rebalance after merge