### PR TITLE
fix(keeper): forward chain to writeContract so submission lands

### DIFF
--- a/addresses.json
+++ b/addresses.json
@@ -1,9 +1,9 @@
 {
   "84532": {
-    "bellStrategy": "0xfa60db53c04ca4add6c0cd0df1e8b6ba97d769ce",
-    "chainlinkAdapter": "0x80466dd3dbe7a2e6910ea6522465adcb75fe2c35",
-    "protocolHook": "0xe450c5128a5e7d42250a870a7df044902cee85c0",
-    "vaultFactory": "0x589dfb3dade3c379d38654063d5d8e85e15e39e5",
+    "bellStrategy": "0x8621557ebc7cc5bbbb7254eca39fcc21fc9bd68c",
+    "chainlinkAdapter": "0x8ae80adfc0713c47e331418d1874ced8383a3ec1",
+    "protocolHook": "0x5f293d39afb11066b7018199865d973c240485c0",
+    "vaultFactory": "0xc7971d8e0856f7e287968257352a5588bbf6c64c",
     "poolManager": "0x05E73354cFDd6745C338b50BcFDfA3Aa6fA03408"
   }
 }

--- a/apps/keeper/src/index.ts
+++ b/apps/keeper/src/index.ts
@@ -80,6 +80,7 @@ async function main() {
       maxSubmitAttempts: 3,
       logger,
       metrics,
+      chain: baseSepolia,
     });
     logger.info({metrics: metrics.snapshot()}, "one-shot cycle complete");
     await flushSentry();
@@ -99,6 +100,7 @@ async function main() {
     intervalMs: config.POLL_INTERVAL_MS,
     logger,
     metrics,
+    chain: baseSepolia,
   });
 
   // Periodic metric snapshot — emits one structured log line per minute

--- a/apps/keeper/src/poll.ts
+++ b/apps/keeper/src/poll.ts
@@ -48,6 +48,9 @@ export interface PollDeps {
   /// this at startup and exposes a snapshot via /metrics. When omitted
   /// the loop runs metric-free — keeps unit tests trivial.
   metrics?: Metrics;
+  /// Chain object forwarded to writeContract during submission. Without
+  /// it viem v2 emits a tx with no chainId — see SubmitDeps.chain.
+  chain?: unknown;
 }
 
 /// One pass of the keeper poll loop.
@@ -153,6 +156,7 @@ async function evaluateVault(deps: EvaluateOne): Promise<VaultEvaluation> {
     maxFeePerGasCap: deps.maxFeePerGasCap,
     attemptTimeoutMs: deps.txAttemptTimeoutMs,
     maxAttempts: deps.maxSubmitAttempts,
+    chain: deps.chain,
   });
   if (submission.status === "confirmed") {
     logger.info(

--- a/apps/keeper/src/submit.ts
+++ b/apps/keeper/src/submit.ts
@@ -36,6 +36,12 @@ export interface SubmitDeps {
   attemptTimeoutMs: number;
   /// Maximum reprice retries before giving up.
   maxAttempts: number;
+  /// Chain object to pass to writeContract. Required for viem v2 — when
+  /// the wallet client is unwrapped into a structural slice (poll.ts),
+  /// the implicit chain on the original client is lost and viem sends a
+  /// transaction with no chainId, which the RPC rejects with a
+  /// JSON-RPC envelope error. Forwarding the chain explicitly fixes it.
+  chain?: unknown;
 }
 
 export type SubmitResult =
@@ -59,7 +65,7 @@ export type SubmitResult =
 ///
 /// Returns a typed verdict the caller can log + tally.
 export async function submitRebalance(deps: SubmitDeps): Promise<SubmitResult> {
-  const {client, account, vault, logger, maxFeePerGasCap, attemptTimeoutMs, maxAttempts} = deps;
+  const {client, account, vault, logger, maxFeePerGasCap, attemptTimeoutMs, maxAttempts, chain} = deps;
 
   // Pin the nonce up front so retries replace rather than queue.
   const nonce = await client.getTransactionCount({address: account, blockTag: "pending"});
@@ -86,6 +92,7 @@ export async function submitRebalance(deps: SubmitDeps): Promise<SubmitResult> {
         nonce,
         maxFeePerGas,
         maxPriorityFeePerGas,
+        chain,
       });
     } catch (err) {
       lastError = errMsg(err);

--- a/packages/shared/src/addresses.ts
+++ b/packages/shared/src/addresses.ts
@@ -27,10 +27,10 @@ const PLACEHOLDER: DeploymentAddresses = {
 
 // <<deployed-baseSepolia>>
 const BASESEPOLIA: DeploymentAddresses = {
-  vaultFactory: "0x589dfb3dade3c379d38654063d5d8e85e15e39e5",
-  protocolHook: "0xe450c5128a5e7d42250a870a7df044902cee85c0",
-  bellStrategy: "0xfa60db53c04ca4add6c0cd0df1e8b6ba97d769ce",
-  chainlinkAdapter: "0x80466dd3dbe7a2e6910ea6522465adcb75fe2c35",
+  vaultFactory: "0xc7971d8e0856f7e287968257352a5588bbf6c64c",
+  protocolHook: "0x5f293d39afb11066b7018199865d973c240485c0",
+  bellStrategy: "0x8621557ebc7cc5bbbb7254eca39fcc21fc9bd68c",
+  chainlinkAdapter: "0x8ae80adfc0713c47e331418d1874ced8383a3ec1",
   poolManager: "0x05E73354cFDd6745C338b50BcFDfA3Aa6fA03408",
 };
 // <</deployed-baseSepolia>>


### PR DESCRIPTION
## Summary

The structural client wrap in \`index.ts\` (where \`writeContract\` from the wallet client is assigned to a plain object) unmoors viem's \`writeContract\` from the chain it was created with. With chain context missing, the tx body has no \`chainId\` and Alchemy rejects the JSON-RPC envelope with:

\`\`\`
JSON is not a valid request object.
\`\`\`

First post-vault-redeploy keeper run hit this exactly: \`vault due\` → \`sim ok\` → \`submission failed\`.

Plumb \`chain\` through \`PollDeps\` → \`SubmitDeps\` → \`writeContract\` args, and pass \`baseSepolia\` from \`index.ts\`. Sim path is unaffected — it's a static \`eth_call\` that doesn't need a chainId.

## Test plan

- [x] \`pnpm --filter @prism/keeper typecheck\` clean
- [ ] First keeper-cron run after merge: \`submittableCount: 1, confirmedCount: 1\`